### PR TITLE
Add basic auth and character selection flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 const express = require("express");
 const path = require("path");
-const { registerPlayer } = require("./systems/playerRegistration");
+const {
+  registerPlayer,
+  loginPlayer,
+  createCharacter,
+  getPlayerCharacters,
+} = require("./systems/playerService");
 const app = express();
 
 app.use(express.json());
@@ -24,6 +29,42 @@ app.post("/register", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "registration failed" });
+  }
+});
+
+app.post("/login", async (req, res) => {
+  const { name } = req.body;
+  if (!name) {
+    return res.status(400).json({ error: "name required" });
+  }
+  try {
+    const result = await loginPlayer(name);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(404).json({ error: "login failed" });
+  }
+});
+
+app.get("/players/:playerId/characters", async (req, res) => {
+  const playerId = parseInt(req.params.playerId, 10);
+  try {
+    const characters = await getPlayerCharacters(playerId);
+    res.json(characters);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "failed to load characters" });
+  }
+});
+
+app.post("/players/:playerId/characters", async (req, res) => {
+  const playerId = parseInt(req.params.playerId, 10);
+  try {
+    const character = await createCharacter(playerId);
+    res.json(character);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "character creation failed" });
   }
 });
 

--- a/systems/playerService.js
+++ b/systems/playerService.js
@@ -29,13 +29,31 @@ function rollBasicType() {
 
 async function registerPlayer(name) {
   const players = await readJSON(PLAYERS_FILE);
-  const characters = await readJSON(CHARACTERS_FILE);
-
   const playerId = players.length + 1;
+  const player = new Player({ id: playerId, name, gold: 0, items: [], characterId: null });
+  players.push(player);
+  await writeJSON(PLAYERS_FILE, players);
+  return { player };
+}
+
+async function loginPlayer(name) {
+  const players = await readJSON(PLAYERS_FILE);
+  const player = players.find(p => p.name === name);
+  if (!player) {
+    throw new Error('player not found');
+  }
+  const characters = await getPlayerCharacters(player.id);
+  return { player, characters };
+}
+
+async function getPlayerCharacters(playerId) {
+  const characters = await readJSON(CHARACTERS_FILE);
+  return characters.filter(c => c.playerId === playerId);
+}
+
+async function createCharacter(playerId) {
+  const characters = await readJSON(CHARACTERS_FILE);
   const characterId = characters.length + 1;
-
-  const player = new Player({ id: playerId, name, gold: 0, items: [], characterId });
-
   const character = new Character({
     id: characterId,
     playerId,
@@ -51,14 +69,9 @@ async function registerPlayer(name) {
       hands: null,
     },
   });
-
-  players.push(player);
   characters.push(character);
-
-  await writeJSON(PLAYERS_FILE, players);
   await writeJSON(CHARACTERS_FILE, characters);
-
-  return { player, character };
+  return character;
 }
 
-module.exports = { registerPlayer };
+module.exports = { registerPlayer, loginPlayer, createCharacter, getPlayerCharacters };

--- a/ui/index.html
+++ b/ui/index.html
@@ -6,20 +6,33 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <nav id="tabs">
-    <button data-tab="shop">Shop</button>
-    <button data-tab="character">Character</button>
-    <button data-tab="inventory">Inventory</button>
-    <button data-tab="battle">Battle</button>
-    <button data-tab="rotation">Rotation</button>
-  </nav>
-  <section id="content">
-    <div id="shop" class="tab-pane">Shop content</div>
-    <div id="character" class="tab-pane hidden">Character content</div>
-    <div id="inventory" class="tab-pane hidden">Inventory content</div>
-    <div id="battle" class="tab-pane hidden">Battle content</div>
-    <div id="rotation" class="tab-pane hidden">Rotation content</div>
-  </section>
+  <div id="auth">
+    <input id="player-name" placeholder="Name" />
+    <button id="login-btn">Login</button>
+    <button id="register-btn">Register</button>
+    <div id="auth-error" class="hidden"></div>
+  </div>
+  <div id="character-select" class="hidden">
+    <h2>Select Character</h2>
+    <ul id="character-list"></ul>
+    <button id="create-character">Create Character</button>
+  </div>
+  <div id="game" class="hidden">
+    <nav id="tabs">
+      <button data-tab="shop">Shop</button>
+      <button data-tab="character">Character</button>
+      <button data-tab="inventory">Inventory</button>
+      <button data-tab="battle">Battle</button>
+      <button data-tab="rotation">Rotation</button>
+    </nav>
+    <section id="content">
+      <div id="shop" class="tab-pane">Shop content</div>
+      <div id="character" class="tab-pane hidden">Character content</div>
+      <div id="inventory" class="tab-pane hidden">Inventory content</div>
+      <div id="battle" class="tab-pane hidden">Battle content</div>
+      <div id="rotation" class="tab-pane hidden">Rotation content</div>
+    </section>
+  </div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,9 +1,97 @@
-document.querySelectorAll('#tabs button').forEach(btn => {
-  btn.addEventListener('click', () => {
-    const target = btn.getAttribute('data-tab');
-    document.querySelectorAll('.tab-pane').forEach(pane => {
-      pane.classList.toggle('active', pane.id === target);
+let currentPlayer = null;
+let characters = [];
+
+const authDiv = document.getElementById('auth');
+const charSelectDiv = document.getElementById('character-select');
+const gameDiv = document.getElementById('game');
+const nameInput = document.getElementById('player-name');
+const authError = document.getElementById('auth-error');
+
+async function postJSON(url, data) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) throw new Error('request failed');
+  return res.json();
+}
+
+function renderCharacters() {
+  const list = document.getElementById('character-list');
+  list.innerHTML = '';
+  characters.forEach(c => {
+    const li = document.createElement('li');
+    li.textContent = `Character ${c.id} (${c.basicType})`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Select';
+    btn.addEventListener('click', () => enterGame(c));
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('login-btn').addEventListener('click', async () => {
+  const name = nameInput.value.trim();
+  if (!name) return;
+  try {
+    const data = await postJSON('/login', { name });
+    currentPlayer = data.player;
+    characters = data.characters;
+    renderCharacters();
+    authDiv.classList.add('hidden');
+    charSelectDiv.classList.remove('hidden');
+    authError.classList.add('hidden');
+  } catch {
+    authError.textContent = 'Login failed';
+    authError.classList.remove('hidden');
+  }
+});
+
+document.getElementById('register-btn').addEventListener('click', async () => {
+  const name = nameInput.value.trim();
+  if (!name) return;
+  try {
+    await postJSON('/register', { name });
+    const data = await postJSON('/login', { name });
+    currentPlayer = data.player;
+    characters = data.characters;
+    renderCharacters();
+    authDiv.classList.add('hidden');
+    charSelectDiv.classList.remove('hidden');
+    authError.classList.add('hidden');
+  } catch {
+    authError.textContent = 'Registration failed';
+    authError.classList.remove('hidden');
+  }
+});
+
+document.getElementById('create-character').addEventListener('click', async () => {
+  try {
+    const res = await fetch(`/players/${currentPlayer.id}/characters`, { method: 'POST' });
+    if (!res.ok) throw new Error('create failed');
+    const character = await res.json();
+    characters.push(character);
+    renderCharacters();
+  } catch {
+    console.error('character creation failed');
+  }
+});
+
+function enterGame(character) {
+  charSelectDiv.classList.add('hidden');
+  gameDiv.classList.remove('hidden');
+  initTabs();
+}
+
+function initTabs() {
+  document.querySelectorAll('#tabs button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.getAttribute('data-tab');
+      document.querySelectorAll('.tab-pane').forEach(pane => {
+        pane.classList.toggle('active', pane.id === target);
+      });
     });
   });
-});
-document.querySelector('#tabs button').click();
+  document.querySelector('#tabs button').click();
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,8 +1,13 @@
 * { box-sizing: border-box; }
 body { margin:0; background:#fff; color:#000; font-family:'Courier New', monospace; }
+button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor:pointer; font-family:'Courier New', monospace; }
 #tabs { display:flex; border-bottom:1px solid #000; }
-#tabs button { flex:1; background:#fff; color:#000; border:1px solid #000; border-bottom:none; padding:8px; cursor:pointer; font-family:'Courier New', monospace; }
+#tabs button { flex:1; border-bottom:none; }
 #content { border:1px solid #000; padding:8px; }
 .tab-pane { display:none; }
 .tab-pane.active { display:block; }
 .hidden { display:none; }
+#auth, #character-select { border:1px solid #000; padding:8px; max-width:300px; margin:20px auto; }
+#auth input { width:100%; margin-bottom:8px; }
+#character-list { list-style:none; padding:0; }
+#character-list li { margin-bottom:4px; }


### PR DESCRIPTION
## Summary
- add JSON-backed player service with register, login, and character creation helpers
- expose REST endpoints for auth and character management
- build frontend flow prompting login/registration and character selection before game tabs

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js` *(prints "Server running on port 3000" then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ca5e3d788320b5847e4335bf1361