### PR TITLE
Fix persistent login by normalizing player names

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ app.get("/", (req, res) => {
 });
 
 app.post("/register", async (req, res) => {
-  const { name } = req.body;
+  const name = req.body.name && req.body.name.trim();
   if (!name) {
     return res.status(400).json({ error: "name required" });
   }
@@ -29,13 +29,17 @@ app.post("/register", async (req, res) => {
     const result = await registerPlayer(name);
     res.json(result);
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: "registration failed" });
+    if (err.message === "name taken") {
+      res.status(409).json({ error: "name taken" });
+    } else {
+      console.error(err);
+      res.status(500).json({ error: "registration failed" });
+    }
   }
 });
 
 app.post("/login", async (req, res) => {
-  const { name } = req.body;
+  const name = req.body.name && req.body.name.trim();
   if (!name) {
     return res.status(400).json({ error: "name required" });
   }

--- a/systems/playerService.js
+++ b/systems/playerService.js
@@ -29,6 +29,10 @@ function rollBasicType() {
 
 async function registerPlayer(name) {
   const players = await readJSON(PLAYERS_FILE);
+  const exists = players.some(p => p.name.toLowerCase() === name.toLowerCase());
+  if (exists) {
+    throw new Error('name taken');
+  }
   const playerId = players.length + 1;
   const player = new Player({ id: playerId, name, gold: 0, items: [], characterId: null });
   players.push(player);
@@ -38,7 +42,7 @@ async function registerPlayer(name) {
 
 async function loginPlayer(name) {
   const players = await readJSON(PLAYERS_FILE);
-  const player = players.find(p => p.name === name);
+  const player = players.find(p => p.name.toLowerCase() === name.toLowerCase());
   if (!player) {
     throw new Error('player not found');
   }

--- a/ui/main.js
+++ b/ui/main.js
@@ -21,7 +21,14 @@ async function postJSON(url, data) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
-  if (!res.ok) throw new Error('request failed');
+  if (!res.ok) {
+    let message = 'request failed';
+    try {
+      const err = await res.json();
+      if (err && err.error) message = err.error;
+    } catch {}
+    throw new Error(message);
+  }
   return res.json();
 }
 
@@ -55,8 +62,8 @@ document.getElementById('login-btn').addEventListener('click', async () => {
     authDiv.classList.add('hidden');
     charSelectDiv.classList.remove('hidden');
     authError.classList.add('hidden');
-  } catch {
-    authError.textContent = 'Login failed';
+  } catch (err) {
+    authError.textContent = err.message;
     authError.classList.remove('hidden');
   }
 });
@@ -73,8 +80,8 @@ document.getElementById('register-btn').addEventListener('click', async () => {
     authDiv.classList.add('hidden');
     charSelectDiv.classList.remove('hidden');
     authError.classList.add('hidden');
-  } catch {
-    authError.textContent = 'Registration failed';
+  } catch (err) {
+    authError.textContent = err.message;
     authError.classList.remove('hidden');
   }
 });


### PR DESCRIPTION
## Summary
- Prevent registering duplicate player names
- Handle player lookup case-insensitively for logins
- Surface server error messages in UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node index.js & sleep 1; pkill node`

------
https://chatgpt.com/codex/tasks/task_e_68c4e84e3cf483209082b3a0075301ae