### PR TITLE
feat: add ability tooltip

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -58,6 +58,7 @@
       </div>
     </section>
   </div>
+  <script src="tooltip.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -5,6 +5,35 @@ let abilityCatalog = [];
 let rotation = [];
 let rotationInitialized = false;
 
+function abilityTooltip(ability) {
+  const container = document.createElement('div');
+  container.className = 'tooltip-grid';
+  const add = (label, value) => {
+    const l = document.createElement('div');
+    l.className = 'label';
+    l.textContent = label;
+    container.appendChild(l);
+    const v = document.createElement('div');
+    v.innerHTML = value;
+    container.appendChild(v);
+  };
+  add('School', ability.school);
+  add('Cost', `${ability.costValue} ${ability.costType}`);
+  add('Cooldown', `${ability.cooldown}s`);
+  add('Scaling', ability.scaling.length ? ability.scaling.join(', ') : 'None');
+  const effectLines = ability.effects.map(e => {
+    if (e.type === 'PhysicalDamage') return `Physical Damage ${e.value}`;
+    if (e.type === 'MagicDamage') return `Magic Damage ${e.value}`;
+    if (e.type === 'Heal') return `Heal ${e.value}`;
+    if (e.type === 'BuffDamagePct') return `+${Math.round(e.amount * 100)}% Damage for ${e.duration}s`;
+    if (e.type === 'Stun') return `Stun ${e.duration}s`;
+    if (e.type === 'Poison') return `Poison ${e.damage} dmg/${e.interval}s for ${e.duration}s`;
+    return e.type;
+  }).join('<br/>');
+  add('Effects', effectLines);
+  return container;
+}
+
 const authDiv = document.getElementById('auth');
 const charSelectDiv = document.getElementById('character-select');
 const gameDiv = document.getElementById('game');
@@ -160,6 +189,7 @@ function renderAbilityPool() {
     li.dataset.id = ab.id;
     li.draggable = true;
     li.addEventListener('dragstart', handleDragStart);
+    attachTooltip(li, () => abilityTooltip(ab));
     pool.appendChild(li);
   });
 }
@@ -182,6 +212,7 @@ function renderRotationList() {
         renderRotationList();
       }
     });
+    attachTooltip(li, () => abilityTooltip(ability));
     list.appendChild(li);
   });
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -26,3 +26,8 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #name-dialog .dialog-box { border:1px solid #000; padding:8px; }
 #name-dialog input { width:200px; margin-top:4px; }
 #name-dialog .dialog-buttons { margin-top:8px; text-align:right; }
+
+.tooltip { position:absolute; background:#fff; border:1px solid #000; padding:4px; pointer-events:none; z-index:1000; }
+.tooltip.hidden { display:none; }
+.tooltip-grid { display:grid; grid-template-columns:auto auto; gap:2px 8px; }
+.tooltip-grid .label { font-weight:bold; text-align:right; }

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -1,0 +1,28 @@
+(function(){
+  let tooltip;
+  function ensureTooltip(){
+    if (tooltip) return tooltip;
+    tooltip = document.createElement('div');
+    tooltip.className = 'tooltip hidden';
+    document.body.appendChild(tooltip);
+    return tooltip;
+  }
+  window.attachTooltip = function(element, contentFn){
+    const tip = ensureTooltip();
+    element.addEventListener('mouseenter', e => {
+      const content = contentFn();
+      tip.innerHTML = '';
+      tip.appendChild(content);
+      tip.classList.remove('hidden');
+      position(e);
+    });
+    element.addEventListener('mousemove', position);
+    element.addEventListener('mouseleave', () => {
+      tip.classList.add('hidden');
+    });
+    function position(e){
+      tip.style.left = e.pageX + 10 + 'px';
+      tip.style.top = e.pageY + 10 + 'px';
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- add reusable tooltip component for hover details
- show ability stats and effects in organized grid
- style tooltip to match black-and-white pixel theme

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c4ebef677c8320881147b7e4ec2d9b