### PR TITLE
Use turn-based stun durations

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -21,7 +21,7 @@
     "scaling": ["strength"],
     "effects": [
       { "type": "PhysicalDamage", "value": 15 },
-      { "type": "Stun", "duration": 2 }
+      { "type": "Stun", "turns": 1 }
     ]
   },
   {
@@ -58,7 +58,7 @@
     "scaling": ["intellect"],
     "effects": [
       { "type": "MagicDamage", "value": 8 },
-      { "type": "Stun", "duration": 1 }
+      { "type": "Stun", "turns": 1 }
     ]
   },
   {

--- a/ui/main.js
+++ b/ui/main.js
@@ -26,7 +26,7 @@ function abilityTooltip(ability) {
     if (e.type === 'MagicDamage') return `Magic Damage ${e.value}`;
     if (e.type === 'Heal') return `Heal ${e.value}`;
     if (e.type === 'BuffDamagePct') return `+${Math.round(e.amount * 100)}% Damage for ${e.duration}s`;
-    if (e.type === 'Stun') return `Stun ${e.duration}s`;
+    if (e.type === 'Stun') return `Stun ${e.turns} turn${e.turns > 1 ? 's' : ''}`;
     if (e.type === 'Poison') return `Poison ${e.damage} dmg/${e.interval}s for ${e.duration}s`;
     return e.type;
   }).join('<br/>');


### PR DESCRIPTION
## Summary
- Represent stun effects using turns instead of seconds
- Update Heavy Strike and Ice Spike abilities with turn-based stun
- Display stun durations as turn counts in the UI tooltip

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4f3e0b0048320a49c91c0da041e52