### PR TITLE
Refine rotation ability layout into physical and magical grids

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -43,9 +43,11 @@
       <div id="rotation" class="tab-pane">
         <div id="rotation-container">
           <div class="lists">
-            <div>
-              <h3>Abilities</h3>
-              <ul id="ability-pool"></ul>
+            <div class="pool">
+              <h3>Physical Abilities</h3>
+              <div id="physical-abilities" class="ability-grid"></div>
+              <h3>Magical Abilities</h3>
+              <div id="magical-abilities" class="ability-grid"></div>
             </div>
             <div>
               <h3>Rotation</h3>

--- a/ui/main.js
+++ b/ui/main.js
@@ -181,16 +181,23 @@ async function initRotation() {
 }
 
 function renderAbilityPool() {
-  const pool = document.getElementById('ability-pool');
-  pool.innerHTML = '';
+  const phys = document.getElementById('physical-abilities');
+  const mag = document.getElementById('magical-abilities');
+  phys.innerHTML = '';
+  mag.innerHTML = '';
   abilityCatalog.forEach(ab => {
-    const li = document.createElement('li');
-    li.textContent = ab.name;
-    li.dataset.id = ab.id;
-    li.draggable = true;
-    li.addEventListener('dragstart', handleDragStart);
-    attachTooltip(li, () => abilityTooltip(ab));
-    pool.appendChild(li);
+    const card = document.createElement('div');
+    card.textContent = ab.name;
+    card.className = 'ability-card';
+    card.dataset.id = ab.id;
+    card.draggable = true;
+    card.addEventListener('dragstart', handleDragStart);
+    attachTooltip(card, () => abilityTooltip(ab));
+    if (ab.school === 'physical') {
+      phys.appendChild(card);
+    } else if (ab.school === 'magical') {
+      mag.appendChild(card);
+    }
   });
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -16,7 +16,10 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #character-list li .info { white-space:pre; margin-right:8px; }
 
 #rotation-container { margin-top:8px; }
-#rotation-container .lists { display:flex; gap:16px; }
+#rotation-container .lists { display:flex; gap:32px; align-items:flex-start; }
+#rotation-container .pool { flex:1; }
+#rotation-container .ability-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(100px,1fr)); gap:8px; margin-bottom:16px; }
+#rotation-container .ability-card { border:1px solid #000; padding:8px; text-align:center; cursor:move; }
 #rotation-container ul { list-style:none; padding:0; margin:0; border:1px solid #000; min-width:150px; min-height:200px; }
 #rotation-container li { border-bottom:1px solid #000; padding:4px; cursor:move; }
 #rotation-container li:last-child { border-bottom:none; }


### PR DESCRIPTION
## Summary
- Display physical and magical abilities in separate card grids on the rotation page
- Add retro-styled grid and card CSS for ability pool while keeping rotation list ordering
- Adjust rotation JS to populate new grids and maintain drag-and-drop behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68c4f51363948320b121a2016c5eb1d2