### PR TITLE
Make rotation list scrollable and improve drag and drop

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -175,7 +175,7 @@ async function initRotation() {
   renderAbilityPool();
   renderRotationList();
   const list = document.getElementById('rotation-list');
-  list.addEventListener('dragover', e => e.preventDefault());
+  list.addEventListener('dragover', handleDragOverList);
   list.addEventListener('drop', handleDrop);
   document.getElementById('save-rotation').addEventListener('click', saveRotation);
 }
@@ -203,6 +203,8 @@ function renderAbilityPool() {
 
 function renderRotationList() {
   const list = document.getElementById('rotation-list');
+  const atBottom = list.scrollTop + list.clientHeight >= list.scrollHeight;
+  const prevScroll = list.scrollTop;
   list.innerHTML = '';
   rotation.forEach(id => {
     const ability = abilityCatalog.find(a => a.id === id);
@@ -222,10 +224,23 @@ function renderRotationList() {
     attachTooltip(li, () => abilityTooltip(ability));
     list.appendChild(li);
   });
+  list.scrollTop = atBottom ? list.scrollHeight : prevScroll;
 }
 
 function handleDragStart(e) {
   e.dataTransfer.setData('text/plain', e.target.dataset.id);
+}
+
+function handleDragOverList(e) {
+  e.preventDefault();
+  const list = e.currentTarget;
+  const rect = list.getBoundingClientRect();
+  const margin = 20;
+  if (e.clientY < rect.top + margin) {
+    list.scrollTop -= 10;
+  } else if (e.clientY > rect.bottom - margin) {
+    list.scrollTop += 10;
+  }
 }
 
 function handleDrop(e) {
@@ -236,7 +251,9 @@ function handleDrop(e) {
   const target = e.target.closest('li');
   let insertIndex = children.length;
   if (target) {
-    insertIndex = children.indexOf(target);
+    const rect = target.getBoundingClientRect();
+    const after = (e.clientY - rect.top) > rect.height / 2;
+    insertIndex = children.indexOf(target) + (after ? 1 : 0);
   }
   const existing = rotation.indexOf(id);
   if (existing >= 0) {

--- a/ui/style.css
+++ b/ui/style.css
@@ -32,7 +32,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 #rotation-container .ability-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(100px,1fr)); gap:8px; margin-bottom:16px; }
 #rotation-container .ability-card { border:1px solid #000; padding:8px; text-align:center; cursor:move; }
-#rotation-container ul { list-style:none; padding:0; margin:0; border:1px solid #000; min-width:150px; min-height:200px; }
+#rotation-container ul { list-style:none; padding:0 0 8px; margin:0; border:1px solid #000; min-width:150px; min-height:200px; max-height:300px; overflow-y:auto; }
 #rotation-container li { border-bottom:1px solid #000; padding:4px; cursor:move; }
 #rotation-container li:last-child { border-bottom:none; }
 #rotation-error { margin-top:8px; }


### PR DESCRIPTION
## Summary
- Limit rotation list height and enable vertical scrolling
- Preserve scroll position and auto-scroll when dragging new abilities
- Allow dropping below items to insert later in rotation

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `npm start` (Server running on port 3000)

------
https://chatgpt.com/codex/tasks/task_e_68c500d229ac83208974346eb4fb302f