### PR TITLE
Add ability removal area for rotation editor

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -52,6 +52,7 @@
             <div>
               <h3>Rotation</h3>
               <ul id="rotation-list" class="drop-zone"></ul>
+              <div id="rotation-delete" class="drop-zone delete-zone">Drop here to remove</div>
             </div>
           </div>
           <button id="save-rotation">Save Rotation</button>

--- a/ui/main.js
+++ b/ui/main.js
@@ -177,6 +177,9 @@ async function initRotation() {
   const list = document.getElementById('rotation-list');
   list.addEventListener('dragover', handleDragOverList);
   list.addEventListener('drop', handleDrop);
+  const del = document.getElementById('rotation-delete');
+  del.addEventListener('dragover', e => e.preventDefault());
+  del.addEventListener('drop', handleDropRemove);
   document.getElementById('save-rotation').addEventListener('click', saveRotation);
 }
 
@@ -271,6 +274,15 @@ function handleDrop(e) {
   }
   rotation.splice(insertIndex, 0, data.id);
   renderRotationList();
+}
+
+function handleDropRemove(e) {
+  e.preventDefault();
+  const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+  if (data.from === 'rotation') {
+    rotation.splice(data.index, 1);
+    renderRotationList();
+  }
 }
 
 function saveRotation() {

--- a/ui/style.css
+++ b/ui/style.css
@@ -37,6 +37,15 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #rotation-container li:last-child { border-bottom:none; }
 #rotation-error { margin-top:8px; }
 
+#rotation-delete {
+  border:1px dashed #000;
+  padding:8px;
+  min-height:40px;
+  margin-top:8px;
+  text-align:center;
+  color:#a00;
+}
+
 #name-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
 #name-dialog .dialog-box { border:1px solid #000; padding:8px; }
 #name-dialog input { width:200px; margin-top:4px; }


### PR DESCRIPTION
## Summary
- Add a delete drop zone under the rotation list to remove abilities by dragging
- Style delete zone with dashed border and warning color
- Handle drop events to remove abilities from rotation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c516907d1c83209ce580392d708169