### PR TITLE
Add matchmaking battle mode with real-time combat engine

### DIFF
--- a/domain/battleState.js
+++ b/domain/battleState.js
@@ -1,0 +1,8 @@
+class BattleState {
+  constructor({ combatants = [] } = {}) {
+    this.combatants = combatants;
+    this.log = [];
+  }
+}
+
+module.exports = BattleState;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {
 } = require("./systems/playerService");
 const { getAbilities } = require("./systems/abilityService");
 const { updateRotation } = require("./systems/characterService");
+const { queueMatch } = require("./systems/matchmaking");
 const app = express();
 
 app.use(express.json());
@@ -94,6 +95,17 @@ app.put("/characters/:characterId/rotation", async (req, res) => {
   try {
     const character = await updateRotation(characterId, rotation);
     res.json(character);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post("/matchmaking/queue", async (req, res) => {
+  const { characterId } = req.body;
+  try {
+    const result = await queueMatch(characterId);
+    res.json(result);
   } catch (err) {
     console.error(err);
     res.status(400).json({ error: err.message });

--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -1,0 +1,63 @@
+const { compute } = require('./derivedStats');
+const { getAction } = require('./rotationEngine');
+const { applyEffect, tick } = require('./effectsEngine');
+
+function createCombatant(character) {
+  const derived = compute(character);
+  return {
+    character,
+    derived,
+    health: derived.health,
+    mana: derived.mana,
+    stamina: derived.stamina,
+    rotationIndex: 0,
+    cooldowns: {},
+    damageBuff: 0,
+    buffs: [],
+    dots: [],
+    stunnedUntil: 0,
+  };
+}
+
+async function runCombat(charA, charB, abilityMap) {
+  const a = createCombatant(charA);
+  const b = createCombatant(charB);
+  const nextTimes = [0, 0];
+  const combatants = [a, b];
+  const log = [];
+  let now = 0;
+  while (a.health > 0 && b.health > 0) {
+    const idx = nextTimes[0] <= nextTimes[1] ? 0 : 1;
+    const actor = combatants[idx];
+    const target = combatants[1 - idx];
+    now = nextTimes[idx];
+    tick(actor, now, log);
+    tick(target, now, log);
+    if (actor.stunnedUntil > now) {
+      log.push(`${actor.character.name} is stunned and misses the turn`);
+    } else {
+      const action = getAction(actor, now, abilityMap);
+      if (action.type === 'ability') {
+        log.push(`${actor.character.name} uses ${action.ability.name}`);
+        action.ability.effects.forEach(e => applyEffect(actor, target, e, now, log));
+      } else {
+        const effect =
+          actor.character.basicType === 'melee'
+            ? { type: 'PhysicalDamage', value: 0 }
+            : { type: 'MagicDamage', value: 0 };
+        applyEffect(actor, target, effect, now, log);
+      }
+    }
+    nextTimes[idx] += actor.derived.attackIntervalSeconds;
+    const next = Math.min(nextTimes[0], nextTimes[1]);
+    const wait = Math.max(0, next - now);
+    if (a.health > 0 && b.health > 0) {
+      // wait in real time until the next scheduled action
+      await new Promise(res => setTimeout(res, wait * 1000));
+    }
+  }
+  const winner = a.health > 0 ? a : b;
+  return { winnerId: winner.character.id, log };
+}
+
+module.exports = { runCombat };

--- a/systems/derivedStats.js
+++ b/systems/derivedStats.js
@@ -1,0 +1,30 @@
+const A = 3;
+const K = 0.1;
+
+function attackInterval(agi) {
+  return 2.0 + A * Math.exp(-K * agi);
+}
+
+function compute(character) {
+  const attr = character.attributes || {};
+  const strength = attr.strength || 0;
+  const stamina = attr.stamina || 0;
+  const agility = attr.agility || 0;
+  const intellect = attr.intellect || 0;
+  const wisdom = attr.wisdom || 0;
+
+  return {
+    minMeleeAttack: strength * 2,
+    maxMeleeAttack: strength * 2 + 4,
+    minMagicAttack: intellect * 2,
+    maxMagicAttack: intellect * 2 + 4,
+    attackIntervalSeconds: attackInterval(agility),
+    health: 100 + stamina * 10,
+    mana: 50 + wisdom * 8,
+    stamina: 50 + stamina * 8,
+    meleeResist: 0,
+    magicResist: 0,
+  };
+}
+
+module.exports = { compute };

--- a/systems/effectsEngine.js
+++ b/systems/effectsEngine.js
@@ -1,0 +1,78 @@
+function randBetween(min, max) {
+  return Math.floor(min + Math.random() * (max - min + 1));
+}
+
+function applyDamage(source, target, amount, type, log) {
+  const resist = type === 'physical' ? target.derived.meleeResist : target.derived.magicResist;
+  let dmg = amount * (1 + source.damageBuff);
+  dmg = Math.max(1, Math.round(dmg * (1 - resist)));
+  target.health -= dmg;
+  log.push(`${source.character.name} hits ${target.character.name} for ${dmg} ${type}`);
+}
+
+function applyEffect(source, target, effect, now, log) {
+  switch (effect.type) {
+    case 'PhysicalDamage': {
+      const base = effect.value + randBetween(source.derived.minMeleeAttack, source.derived.maxMeleeAttack);
+      applyDamage(source, target, base, 'physical', log);
+      break;
+    }
+    case 'MagicDamage': {
+      const base = effect.value + randBetween(source.derived.minMagicAttack, source.derived.maxMagicAttack);
+      applyDamage(source, target, base, 'magical', log);
+      break;
+    }
+    case 'Heal': {
+      const amount = effect.value;
+      const before = source.health;
+      source.health = Math.min(source.health + amount, source.derived.health);
+      log.push(`${source.character.name} heals ${source.health - before}`);
+      break;
+    }
+    case 'BuffDamagePct': {
+      source.damageBuff += effect.amount;
+      source.buffs.push({ amount: effect.amount, expires: now + effect.duration });
+      log.push(`${source.character.name} gains +${Math.round(effect.amount * 100)}% damage`);
+      break;
+    }
+    case 'Stun': {
+      target.stunnedUntil = Math.max(target.stunnedUntil, now + effect.duration);
+      log.push(`${target.character.name} is stunned`);
+      break;
+    }
+    case 'Poison': {
+      target.dots.push({
+        damage: effect.damage,
+        interval: effect.interval,
+        nextTick: now + effect.interval,
+        expires: now + effect.duration,
+      });
+      log.push(`${target.character.name} is poisoned`);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function tick(combatant, now, log) {
+  combatant.buffs = combatant.buffs.filter(b => {
+    if (now >= b.expires) {
+      combatant.damageBuff -= b.amount;
+      log.push(`${combatant.character.name}'s buff fades`);
+      return false;
+    }
+    return true;
+  });
+  combatant.dots = combatant.dots.filter(d => {
+    while (now >= d.nextTick && now < d.expires) {
+      const dmg = Math.max(1, Math.round(d.damage * (1 - combatant.derived.meleeResist)));
+      combatant.health -= dmg;
+      log.push(`${combatant.character.name} takes ${dmg} poison damage`);
+      d.nextTick += d.interval;
+    }
+    return now < d.expires;
+  });
+}
+
+module.exports = { applyEffect, tick };

--- a/systems/matchmaking.js
+++ b/systems/matchmaking.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const { readJSON } = require('../store/jsonStore');
+const { getAbilities } = require('./abilityService');
+const { runCombat } = require('./combatEngine');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const CHARACTERS_FILE = path.join(DATA_DIR, 'characters.json');
+
+const queue = [];
+
+async function loadCharacter(id) {
+  const characters = await readJSON(CHARACTERS_FILE);
+  return characters.find(c => c.id === id);
+}
+
+async function queueMatch(characterId) {
+  const character = await loadCharacter(characterId);
+  if (!character) throw new Error('character not found');
+  if (!character.rotation || character.rotation.length < 3) {
+    throw new Error('character rotation invalid');
+  }
+  const abilities = await getAbilities();
+  const abilityMap = new Map(abilities.map(a => [a.id, a]));
+  return new Promise(resolve => {
+    queue.push({ character, resolve });
+    if (queue.length >= 2) {
+      const a = queue.shift();
+      const b = queue.shift();
+      runCombat(a.character, b.character, abilityMap).then(result => {
+        a.resolve({ you: a.character.id, winnerId: result.winnerId, log: result.log });
+        b.resolve({ you: b.character.id, winnerId: result.winnerId, log: result.log });
+      });
+    }
+  });
+}
+
+module.exports = { queueMatch };

--- a/systems/rotationEngine.js
+++ b/systems/rotationEngine.js
@@ -1,0 +1,21 @@
+function getAction(combatant, now, abilityMap) {
+  if (!combatant.character.rotation || combatant.character.rotation.length === 0) {
+    return { type: 'basic' };
+  }
+  const abilityId = combatant.character.rotation[combatant.rotationIndex];
+  const ability = abilityMap.get(abilityId);
+  if (
+    ability &&
+    (!combatant.cooldowns[abilityId] || combatant.cooldowns[abilityId] <= now) &&
+    combatant[ability.costType] >= ability.costValue
+  ) {
+    combatant[ability.costType] -= ability.costValue;
+    combatant.cooldowns[abilityId] = now + ability.cooldown;
+    combatant.rotationIndex =
+      (combatant.rotationIndex + 1) % combatant.character.rotation.length;
+    return { type: 'ability', ability };
+  }
+  return { type: 'basic' };
+}
+
+module.exports = { getAction };

--- a/ui/index.html
+++ b/ui/index.html
@@ -39,7 +39,14 @@
       <div id="shop" class="tab-pane active">Shop content</div>
       <div id="character" class="tab-pane">Character content</div>
       <div id="inventory" class="tab-pane">Inventory content</div>
-      <div id="battle" class="tab-pane">Battle content</div>
+      <div id="battle" class="tab-pane">
+        <div id="battle-modes">
+          <button data-mode="matchmaking">Matchmaking</button>
+          <button data-mode="challenge">Challenge</button>
+          <button data-mode="adventure">Adventure</button>
+        </div>
+        <div id="battle-area"></div>
+      </div>
       <div id="rotation" class="tab-pane">
         <div id="rotation-container">
           <div class="lists">

--- a/ui/main.js
+++ b/ui/main.js
@@ -310,3 +310,37 @@ function saveRotation() {
     errorDiv.classList.remove('hidden');
   });
 }
+
+// Battle modes
+const battleArea = document.getElementById('battle-area');
+document.querySelectorAll('#battle-modes button').forEach(btn => {
+  btn.addEventListener('click', () => selectMode(btn.dataset.mode));
+});
+
+function selectMode(mode) {
+  if (mode === 'matchmaking') {
+    battleArea.innerHTML = '<button id="queue-match">Queue for Match</button><div id="battle-log"></div>';
+    document.getElementById('queue-match').addEventListener('click', () => {
+      const logDiv = document.getElementById('battle-log');
+      logDiv.textContent = 'Waiting for opponent...';
+      fetch('/matchmaking/queue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ characterId: currentCharacter.id })
+      }).then(res => {
+        if (!res.ok) throw new Error('queue failed');
+        return res.json();
+      }).then(result => {
+        const { winnerId, log } = result;
+        logDiv.innerHTML = log.map(l => `<div>${l}</div>`).join('');
+        const outcome = document.createElement('div');
+        outcome.textContent = winnerId === currentCharacter.id ? 'You won!' : 'You lost!';
+        logDiv.appendChild(outcome);
+      }).catch(err => {
+        logDiv.textContent = err.message;
+      });
+    });
+  } else {
+    battleArea.textContent = 'Mode not implemented';
+  }
+}


### PR DESCRIPTION
## Summary
- Implement modular combat engine with real-time delays so fighters act on independent attack intervals
- Add matchmaking system and server endpoint to queue characters and run battles
- Provide battle UI with three game modes and working matchmaking queue

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c63df0604c8320b08de46e185469ad