### PR TITLE
Implement real-time battle streaming

### DIFF
--- a/systems/matchmaking.js
+++ b/systems/matchmaking.js
@@ -13,7 +13,7 @@ async function loadCharacter(id) {
   return characters.find(c => c.id === id);
 }
 
-async function queueMatch(characterId) {
+async function queueMatch(characterId, send) {
   const character = await loadCharacter(characterId);
   if (!character) throw new Error('character not found');
   if (!character.rotation || character.rotation.length < 3) {
@@ -22,14 +22,32 @@ async function queueMatch(characterId) {
   const abilities = await getAbilities();
   const abilityMap = new Map(abilities.map(a => [a.id, a]));
   return new Promise(resolve => {
-    queue.push({ character, resolve });
+    queue.push({ character, send, resolve });
     if (queue.length >= 2) {
       const a = queue.shift();
       const b = queue.shift();
-      runCombat(a.character, b.character, abilityMap).then(result => {
-        a.resolve({ you: a.character.id, winnerId: result.winnerId, log: result.log });
-        b.resolve({ you: b.character.id, winnerId: result.winnerId, log: result.log });
-      });
+      runCombat(a.character, b.character, abilityMap, event => {
+        if (event.type === 'start') {
+          a.send({ type: 'start', you: event.a, opponent: event.b });
+          b.send({ type: 'start', you: event.b, opponent: event.a });
+        } else if (event.type === 'update') {
+          a.send({ type: 'update', you: event.a, opponent: event.b, log: event.log });
+          b.send({ type: 'update', you: event.b, opponent: event.a, log: event.log });
+        }
+      })
+        .then(result => {
+          a.send({ type: 'end', winnerId: result.winnerId });
+          b.send({ type: 'end', winnerId: result.winnerId });
+          a.resolve();
+          b.resolve();
+        })
+        .catch(err => {
+          const error = { type: 'error', message: err.message };
+          a.send(error);
+          b.send(error);
+          a.resolve();
+          b.resolve();
+        });
     }
   });
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -55,3 +55,12 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .tooltip.hidden { display:none; }
 .tooltip-grid { display:grid; grid-template-columns:auto auto; gap:2px 8px; }
 .tooltip-grid .label { font-weight:bold; text-align:right; }
+
+#battle-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
+#battle-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
+#battle-dialog .combatant { margin-bottom:8px; }
+#battle-dialog .name { font-weight:bold; margin-bottom:2px; }
+.bar { border:1px solid #000; height:10px; margin-bottom:4px; }
+.bar .fill { background:#000; height:100%; width:100%; }
+#battle-log { border:1px solid #000; height:150px; overflow-y:auto; margin-top:8px; padding:4px; }
+#battle-dialog .dialog-buttons { text-align:right; margin-top:8px; }


### PR DESCRIPTION
## Summary
- stream combat updates over server-sent events to drive real-time battle UI
- add battle dialog with health/mana/stamina bars that update as actions occur
- rework matchmaking to pair players and broadcast combat states

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68c7a57fc3f08320ab807392308c9b57