### PR TITLE
Add battle rewards and character leveling

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const {
   getPlayerCharacters,
 } = require("./systems/playerService");
 const { getAbilities } = require("./systems/abilityService");
-const { updateRotation } = require("./systems/characterService");
+const { updateRotation, levelUp } = require("./systems/characterService");
 const { queueMatch } = require("./systems/matchmaking");
 const app = express();
 
@@ -94,6 +94,18 @@ app.put("/characters/:characterId/rotation", async (req, res) => {
   const { rotation } = req.body;
   try {
     const character = await updateRotation(characterId, rotation);
+    res.json(character);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post("/characters/:characterId/levelup", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { allocations } = req.body || {};
+  try {
+    const character = await levelUp(characterId, allocations || {});
     res.json(character);
   } catch (err) {
     console.error(err);

--- a/systems/characterService.js
+++ b/systems/characterService.js
@@ -5,6 +5,12 @@ const { getAbilities } = require('./abilityService');
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const CHARACTERS_FILE = path.join(DATA_DIR, 'characters.json');
 
+const STATS = ['strength', 'stamina', 'agility', 'intellect', 'wisdom'];
+
+function xpForNextLevel(level) {
+  return level * 100;
+}
+
 async function updateRotation(characterId, rotation) {
   if (!Array.isArray(rotation) || rotation.length < 3) {
     throw new Error('rotation must have at least 3 abilities');
@@ -24,4 +30,35 @@ async function updateRotation(characterId, rotation) {
   return characters[idx];
 }
 
-module.exports = { updateRotation };
+async function levelUp(characterId, allocations) {
+  const characters = await readJSON(CHARACTERS_FILE);
+  const idx = characters.findIndex(c => c.id === characterId);
+  if (idx === -1) {
+    throw new Error('character not found');
+  }
+  const character = characters[idx];
+  const needed = xpForNextLevel(character.level || 1);
+  if ((character.xp || 0) < needed) {
+    throw new Error('not enough xp');
+  }
+  let spent = 0;
+  STATS.forEach(stat => {
+    const v = allocations && allocations[stat] ? allocations[stat] : 0;
+    if (v < 0) throw new Error('invalid allocation');
+    spent += v;
+  });
+  if (spent !== 2) {
+    throw new Error('must allocate exactly 2 points');
+  }
+  STATS.forEach(stat => {
+    const add = allocations[stat] || 0;
+    character.attributes[stat] = (character.attributes[stat] || 0) + add;
+  });
+  character.level = (character.level || 1) + 1;
+  character.xp = (character.xp || 0) - needed;
+  characters[idx] = character;
+  await writeJSON(CHARACTERS_FILE, characters);
+  return character;
+}
+
+module.exports = { updateRotation, levelUp, xpForNextLevel };


### PR DESCRIPTION
## Summary
- Grant gold and experience after matchmaking battles, updating player and character records
- Expose a level-up endpoint that lets players allocate 2 attribute points when enough XP is earned
- Add character tab UI showing stats, rewards, and a level-up form with derived stat recalculation

## Testing
- ⚠️ `npm test` *(missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7a88b07cc832085632b93ff8cd054