### PR TITLE
style: improve character sheet and level up dialog

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -64,3 +64,11 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .bar .fill { background:#000; height:100%; width:100%; }
 #battle-log { border:1px solid #000; height:150px; overflow-y:auto; margin-top:8px; padding:4px; }
 #battle-dialog .dialog-buttons { text-align:right; margin-top:8px; }
+
+.stats-table { border-collapse:collapse; margin-bottom:8px; }
+.stats-table th, .stats-table td { border:1px solid #000; padding:4px; }
+.stats-table .section td { font-weight:bold; text-align:center; }
+
+#levelup-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
+#levelup-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
+#levelup-dialog .dialog-buttons { margin-top:8px; text-align:right; }


### PR DESCRIPTION
## Summary
- Layout character sheet using tables for clearer stats and sections
- Replace inline level up form with dialog box that previews derived stat changes
- Add shared table and dialog styles for pixel retro UI

## Testing
- `node --check ui/main.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7b12422d48320afe9ce85cd24c45d