### PR TITLE
style: improve character sheet and level up dialog

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -6,8 +6,10 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #content { border:1px solid #000; padding:8px; }
 .tab-pane { display:none; }
 .tab-pane.active { display:block; }
+.tab-pane#character.active { display:flex; flex-direction:column; align-items:center; }
 .hidden { display:none !important; }
 #auth, #character-select { border:1px solid #000; padding:8px; margin:20px auto; }
+#game { max-width:800px; margin:20px auto; }
 #auth { max-width:300px; }
 #character-select { max-width:600px; }
 #auth input { width:100%; margin-bottom:8px; }
@@ -64,3 +66,11 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .bar .fill { background:#000; height:100%; width:100%; }
 #battle-log { border:1px solid #000; height:150px; overflow-y:auto; margin-top:8px; padding:4px; }
 #battle-dialog .dialog-buttons { text-align:right; margin-top:8px; }
+
+.stats-table { border-collapse:collapse; margin-bottom:8px; }
+.stats-table th, .stats-table td { border:1px solid #000; padding:4px; }
+.stats-table .section td { font-weight:bold; text-align:center; }
+
+#levelup-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
+#levelup-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
+#levelup-dialog .dialog-buttons { margin-top:8px; text-align:right; }


### PR DESCRIPTION
## Summary
- Layout character sheet using tables for clearer stats and sections
- Replace inline level up form with dialog box that previews derived stat changes
- Add shared table and dialog styles for pixel retro UI
- Center gameplay layout to avoid left-aligned empty space

## Testing
- `node --check ui/main.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7b12422d48320afe9ce85cd24c45d