### PR TITLE
Improve basic attack logging when abilities unavailable

### DIFF
--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -56,6 +56,27 @@ async function runCombat(charA, charB, abilityMap, onUpdate) {
         log.push(`${actor.character.name} uses ${action.ability.name}`);
         action.ability.effects.forEach(e => applyEffect(actor, target, e, now, log));
       } else {
+        const basicLabel = actor.character.basicType === 'melee' ? 'melee' : 'magic';
+        let message;
+        if (action.reason === 'cooldown' && action.ability) {
+          const remaining =
+            typeof action.remainingCooldown === 'number'
+              ? Math.max(0, action.remainingCooldown)
+              : null;
+          const remainingText =
+            remaining !== null ? ` (${remaining.toFixed(1)}s remaining)` : '';
+          message = `${action.ability.name} is on cooldown${remainingText}, so ${actor.character.name} performs a ${basicLabel} basic attack.`;
+        } else if (action.reason === 'resource' && action.ability) {
+          const available = typeof action.available === 'number' ? action.available : 0;
+          message = `${actor.character.name} lacks ${action.resourceType} (${available}/${action.required}) for ${action.ability.name} and performs a ${basicLabel} basic attack.`;
+        } else if (action.reason === 'missingAbility') {
+          message = `${actor.character.name} cannot use unknown ability ${action.abilityId} and performs a ${basicLabel} basic attack.`;
+        } else if (action.reason === 'noRotation') {
+          message = `${actor.character.name} has no rotation ready and performs a ${basicLabel} basic attack.`;
+        }
+
+        log.push(message || `${actor.character.name} performs a ${basicLabel} basic attack.`);
+
         const effect =
           actor.character.basicType === 'melee'
             ? { type: 'PhysicalDamage', value: 0 }

--- a/systems/rotationEngine.js
+++ b/systems/rotationEngine.js
@@ -1,21 +1,51 @@
 function getAction(combatant, now, abilityMap) {
   if (!combatant.character.rotation || combatant.character.rotation.length === 0) {
-    return { type: 'basic' };
+    return { type: 'basic', reason: 'noRotation' };
   }
+
   const abilityId = combatant.character.rotation[combatant.rotationIndex];
   const ability = abilityMap.get(abilityId);
-  if (
-    ability &&
-    (!combatant.cooldowns[abilityId] || combatant.cooldowns[abilityId] <= now) &&
-    combatant[ability.costType] >= ability.costValue
-  ) {
+
+  if (!ability) {
+    return { type: 'basic', reason: 'missingAbility', abilityId };
+  }
+
+  const cooldownReady =
+    !combatant.cooldowns[abilityId] || combatant.cooldowns[abilityId] <= now;
+  const availableResource =
+    typeof combatant[ability.costType] === 'number'
+      ? combatant[ability.costType]
+      : 0;
+  const hasResource = availableResource >= ability.costValue;
+
+  if (cooldownReady && hasResource) {
     combatant[ability.costType] -= ability.costValue;
     combatant.cooldowns[abilityId] = now + ability.cooldown;
     combatant.rotationIndex =
       (combatant.rotationIndex + 1) % combatant.character.rotation.length;
     return { type: 'ability', ability };
   }
-  return { type: 'basic' };
+
+  if (!cooldownReady) {
+    const remaining = combatant.cooldowns[abilityId] - now;
+    return {
+      type: 'basic',
+      reason: 'cooldown',
+      ability,
+      abilityId,
+      remainingCooldown: remaining > 0 ? remaining : 0,
+    };
+  }
+
+  return {
+    type: 'basic',
+    reason: 'resource',
+    ability,
+    abilityId,
+    resourceType: ability.costType,
+    required: ability.costValue,
+    available: availableResource,
+  };
 }
 
 module.exports = { getAction };


### PR DESCRIPTION
## Summary
- add detailed fallback information from the rotation engine when an ability cannot be used
- log why basic attacks are triggered and which type of basic attack is performed in the combat engine

## Testing
- node -e "require('./systems/rotationEngine'); require('./systems/combatEngine');"

------
https://chatgpt.com/codex/tasks/task_e_68c89001f9d483208255bcd79d552c4d