### PR TITLE
Revamp battle dialog layout

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -58,14 +58,20 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .tooltip-grid { display:grid; grid-template-columns:auto auto; gap:2px 8px; }
 .tooltip-grid .label { font-weight:bold; text-align:right; }
 
-#battle-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
-#battle-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
-#battle-dialog .combatant { margin-bottom:8px; }
-#battle-dialog .name { font-weight:bold; margin-bottom:2px; }
-.bar { border:1px solid #000; height:10px; margin-bottom:4px; }
+#battle-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; padding:16px; z-index:1000; }
+#battle-dialog .dialog-box { border:1px solid #000; padding:16px; width:100%; max-width:800px; background:#fff; display:flex; flex-direction:column; }
+#battle-dialog .combatants-row { display:flex; gap:16px; margin-bottom:16px; }
+#battle-dialog .combatant { flex:1; border:1px solid #000; padding:12px; }
+#battle-dialog .combatant .name { font-weight:bold; text-align:center; margin-bottom:8px; }
+#battle-dialog .bars { display:flex; flex-direction:column; gap:6px; }
+.bar { border:1px solid #000; height:12px; }
 .bar .fill { background:#000; height:100%; width:100%; }
-#battle-log { border:1px solid #000; height:150px; overflow-y:auto; margin-top:8px; padding:4px; }
-#battle-dialog .dialog-buttons { text-align:right; margin-top:8px; }
+#battle-log { border:1px solid #000; height:220px; overflow-y:auto; padding:8px; display:flex; flex-direction:column; gap:8px; margin-top:16px; }
+#battle-log .log-message { max-width:75%; padding:6px 8px; border:1px solid #000; }
+#battle-log .log-message.you { align-self:flex-start; background:#000; color:#fff; border-color:#000; }
+#battle-log .log-message.opponent { align-self:flex-end; background:#fff; color:#000; border-color:#000; text-align:right; }
+#battle-log .log-message.neutral { align-self:center; background:#fff; color:#000; border-style:dashed; text-align:center; }
+#battle-dialog .dialog-buttons { text-align:right; margin-top:16px; }
 
 .stats-table { border-collapse:collapse; margin-bottom:8px; }
 .stats-table th, .stats-table td { border:1px solid #000; padding:4px; }


### PR DESCRIPTION
## Summary
- enlarge the battle dialog to match the main interface footprint and place combatants side by side with the player on the left
- restyle the battle log as a black-and-white chat stream with orientation-aware bubbles driven by a new log classification helper

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68c8a0e846ac8320818f1b479e3cb02c