### PR TITLE
Show resource values inside battle bars

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -64,8 +64,39 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #battle-dialog .combatant { flex:1; border:1px solid #000; padding:12px; }
 #battle-dialog .combatant .name { font-weight:bold; text-align:center; margin-bottom:8px; }
 #battle-dialog .bars { display:flex; flex-direction:column; gap:6px; }
-.bar { border:1px solid #000; height:12px; }
-.bar .fill { background:#000; height:100%; width:100%; }
+.bar {
+  position:relative;
+  border:1px solid #000;
+  height:12px;
+  background:#fff;
+  overflow:hidden;
+}
+.bar .fill {
+  position:absolute;
+  left:0;
+  top:0;
+  bottom:0;
+  background:#000;
+  width:100%;
+}
+.bar .label {
+  position:absolute;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:10px;
+  font-weight:bold;
+  color:#fff;
+  pointer-events:none;
+}
+.bar .label .value {
+  pointer-events:none;
+  white-space:nowrap;
+}
 #battle-log { border:1px solid #000; height:220px; overflow-y:auto; padding:8px; display:flex; flex-direction:column; gap:8px; margin-top:16px; }
 #battle-log .log-message { max-width:75%; padding:6px 8px; border:1px solid #000; }
 #battle-log .log-message.you { align-self:flex-start; background:#000; color:#fff; border-color:#000; }


### PR DESCRIPTION
## Summary
- overlay HP/MP/SP values directly on battle resource bars
- update bar management logic to keep labels readable by switching text color based on fill coverage
- style combat resource bars so the new labels sit centered above the fills

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68c910cc618c8320ae7afdbb356abcb4