### PR TITLE
Remove AI behavior perks from challenge opponents

### DIFF
--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -36,7 +36,6 @@ function createCombatant(character, equipmentMap) {
     stunnedUntil: 0,
     onHitEffects: derived.onHitEffects || [],
     basicAttackEffectType: derived.basicAttackEffectType,
-    behavior: character && character.behavior ? { ...character.behavior } : null,
   };
 }
 
@@ -151,10 +150,6 @@ async function runCombat(charA, charB, abilityMap, equipmentMap, onUpdateOrOptio
           } basic attack.`;
         } else if (action.reason === 'noRotation') {
           message = `${actor.character.name} has no rotation ready and performs a ${
-            effectType === 'PhysicalDamage' ? 'melee' : 'magic'
-          } basic attack.`;
-        } else if (action.reason === 'behavior' && action.ability) {
-          message = `${actor.character.name} holds ${action.ability.name} for a better moment and performs a ${
             effectType === 'PhysicalDamage' ? 'melee' : 'magic'
           } basic attack.`;
         }

--- a/systems/rotationEngine.js
+++ b/systems/rotationEngine.js
@@ -10,19 +10,6 @@ function getAction(combatant, now, abilityMap) {
     return { type: 'basic', reason: 'missingAbility', abilityId };
   }
 
-  const behavior = combatant.behavior || (combatant.character && combatant.character.behavior) || null;
-  if (behavior && ability.effects && ability.effects.some(e => e && e.type === 'Heal')) {
-    const threshold = typeof behavior.healThreshold === 'number' ? behavior.healThreshold : null;
-    const maxHealth = combatant.derived && typeof combatant.derived.health === 'number' ? combatant.derived.health : 0;
-    if (threshold !== null && maxHealth > 0) {
-      const clamped = Math.min(Math.max(threshold, 0), 1);
-      const ratio = combatant.health / maxHealth;
-      if (ratio > clamped) {
-        return { type: 'basic', reason: 'behavior', ability, abilityId };
-      }
-    }
-  }
-
   const cooldownReady =
     !combatant.cooldowns[abilityId] || combatant.cooldowns[abilityId] <= now;
   const availableResource =

--- a/ui/main.js
+++ b/ui/main.js
@@ -978,13 +978,6 @@ function renderOpponentPreview(opponent) {
   derivedTable.appendChild(derivedRow4);
   container.appendChild(derivedTable);
 
-  if (opponent.behavior && typeof opponent.behavior.healThreshold === 'number') {
-    const behaviorDiv = document.createElement('div');
-    behaviorDiv.className = 'opponent-behavior';
-    behaviorDiv.textContent = `Heals below ${Math.round(opponent.behavior.healThreshold * 100)}% health`;
-    container.appendChild(behaviorDiv);
-  }
-
   const equipmentSection = document.createElement('div');
   equipmentSection.className = 'equipment-section';
   const equipmentTitle = document.createElement('div');

--- a/ui/style.css
+++ b/ui/style.css
@@ -150,7 +150,6 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .opponent-name { font-weight:bold; text-transform:uppercase; }
 .opponent-meta { font-size:12px; }
 .opponent-metrics { border:1px dashed #000; padding:4px; text-align:center; }
-.opponent-behavior { border:1px solid #000; padding:4px; text-align:center; }
 .equipment-section, .rotation-section { display:flex; flex-direction:column; gap:4px; }
 .equipment-section .section-title, .rotation-section .section-title { font-weight:bold; text-transform:uppercase; border-bottom:1px solid #000; padding-bottom:2px; }
 .equipment-list { display:grid; grid-template-columns:repeat(auto-fit, minmax(140px,1fr)); gap:4px; }


### PR DESCRIPTION
## Summary
- remove the behavioral heal threshold from challenge opponent genomes and previews
- simplify the combat and rotation engines so they no longer read optional behavior data
- update the UI to stop rendering the opponent behavior callout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9a724d2488320b63b1a7ce6fb1715