### PR TITLE
Adjust challenge population scaling and hide meta indicators

### DIFF
--- a/systems/challengeGA.js
+++ b/systems/challengeGA.js
@@ -110,7 +110,8 @@ function shuffle(list) {
 
 function populationSizeForRound(round) {
   const baseRound = typeof round === 'number' && round > 0 ? round : 1;
-  const target = MIN_POPULATION_SIZE + (baseRound - 1) * POPULATION_STEP;
+  const increments = Math.floor((baseRound - 1) / 3);
+  const target = MIN_POPULATION_SIZE + increments * POPULATION_STEP;
   return Math.max(MIN_POPULATION_SIZE, Math.min(MAX_POPULATION_SIZE, target));
 }
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -922,16 +922,6 @@ function renderOpponentPreview(opponent) {
   header.appendChild(metaEl);
   container.appendChild(header);
 
-  if (opponent.metrics) {
-    const metrics = document.createElement('div');
-    metrics.className = 'opponent-metrics';
-    const dmg = Math.round(opponent.metrics.damageToPlayer || 0);
-    const duration = opponent.metrics.duration != null ? opponent.metrics.duration.toFixed(1) : '0.0';
-    const resultText = opponent.metrics.win ? 'Victory' : 'Defeat';
-    metrics.textContent = `Simulation: ${resultText} (${dmg} dmg over ${duration}s)`;
-    container.appendChild(metrics);
-  }
-
   const attributesTable = document.createElement('table');
   attributesTable.className = 'stats-table';
   const attrHeader = document.createElement('tr');
@@ -1095,25 +1085,6 @@ async function renderChallengePanel(statusOverride) {
     next.className = 'challenge-next';
     next.textContent = `Next Reward: +${status.nextRewards.xpGain} XP, +${status.nextRewards.goldGain} GP`;
     panel.appendChild(next);
-  }
-
-  if (status.lastOutcome) {
-    const last = document.createElement('div');
-    last.className = 'challenge-last';
-    const resultText = status.lastOutcome === 'win' ? 'Victory' : 'Defeat';
-    const rewardText = status.lastReward
-      ? ` (${status.lastReward.xp || 0} XP, ${status.lastReward.gold || 0} GP)`
-      : '';
-    last.textContent = `Last Result: ${resultText}${rewardText}`;
-    panel.appendChild(last);
-    if (status.lastMetrics) {
-      const metrics = document.createElement('div');
-      metrics.className = 'challenge-metrics';
-      const dmg = status.lastMetrics.damageToPlayer != null ? status.lastMetrics.damageToPlayer : 0;
-      const duration = status.lastMetrics.duration != null ? status.lastMetrics.duration.toFixed(1) : '0.0';
-      metrics.textContent = `Previous foe dealt ${dmg} damage over ${duration}s`;
-      panel.appendChild(metrics);
-    }
   }
 
   const messageDiv = document.createElement('div');

--- a/ui/style.css
+++ b/ui/style.css
@@ -141,7 +141,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .simple-list li { border:1px solid #000; padding:4px 6px; background:#fff; }
 .challenge-panel { border:1px solid #000; padding:12px; display:flex; flex-direction:column; gap:12px; background:#fff; }
 .challenge-round { font-weight:bold; text-transform:uppercase; text-align:center; font-size:18px; }
-.challenge-reward, .challenge-next, .challenge-last, .challenge-metrics { border:1px solid #000; padding:6px; background:#fff; }
+.challenge-reward, .challenge-next { border:1px solid #000; padding:6px; background:#fff; }
 .challenge-actions { display:flex; justify-content:center; gap:8px; }
 .challenge-message { align-self:center; }
 .challenge-empty { border:1px dashed #000; padding:8px; text-align:center; }
@@ -149,7 +149,6 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .opponent-header { display:flex; justify-content:space-between; align-items:flex-end; border-bottom:1px solid #000; padding-bottom:4px; }
 .opponent-name { font-weight:bold; text-transform:uppercase; }
 .opponent-meta { font-size:12px; }
-.opponent-metrics { border:1px dashed #000; padding:4px; text-align:center; }
 .equipment-section, .rotation-section { display:flex; flex-direction:column; gap:4px; }
 .equipment-section .section-title, .rotation-section .section-title { font-weight:bold; text-transform:uppercase; border-bottom:1px solid #000; padding-bottom:2px; }
 .equipment-list { display:grid; grid-template-columns:repeat(auto-fit, minmax(140px,1fr)); gap:4px; }


### PR DESCRIPTION
## Summary
- hide challenge meta panels in the UI by removing the simulation preview and last result sections
- relax the challenge generator by only increasing the population size every three rounds
- clean up the unused challenge styles after removing the panels

## Testing
- npm run start *(fails: MongoDB connection unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b09ea5748320b10072c7a0de16ef