### PR TITLE
Add nonlinear combat chance stats

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -10,7 +10,8 @@
       "damageType": "physical",
       "baseDamage": { "min": 4, "max": 8 },
       "scaling": { "strength": "D" },
-      "attributeBonuses": { "strength": 1 }
+      "attributeBonuses": { "strength": 1, "agility": 1 },
+      "chanceBonuses": { "hitChance": 2 }
     },
     {
       "id": "weapon_militia_spear",
@@ -22,7 +23,8 @@
       "damageType": "physical",
       "baseDamage": { "min": 5, "max": 9 },
       "scaling": { "strength": "E", "agility": "D" },
-      "attributeBonuses": { "agility": 1 }
+      "attributeBonuses": { "agility": 1, "intellect": 1 },
+      "chanceBonuses": { "hitChance": 3, "critChance": 1 }
     },
     {
       "id": "weapon_apprentice_wand",
@@ -34,8 +36,9 @@
       "damageType": "magical",
       "baseDamage": { "min": 3, "max": 7 },
       "scaling": { "intellect": "D", "wisdom": "E" },
-      "attributeBonuses": { "intellect": 1 },
-      "resourceBonuses": { "mana": 10 }
+      "attributeBonuses": { "intellect": 1, "wisdom": 1 },
+      "resourceBonuses": { "mana": 10 },
+      "chanceBonuses": { "hitChance": 4, "dodgeChance": 1 }
     },
     {
       "id": "weapon_soldiers_longsword",
@@ -47,7 +50,8 @@
       "damageType": "physical",
       "baseDamage": { "min": 8, "max": 14 },
       "scaling": { "strength": "C" },
-      "attributeBonuses": { "strength": 2, "stamina": 1 }
+      "attributeBonuses": { "strength": 2, "stamina": 1 },
+      "chanceBonuses": { "critChance": 3, "blockChance": 2, "hitChance": 2 }
     },
     {
       "id": "weapon_hunter_twin_daggers",
@@ -59,7 +63,8 @@
       "damageType": "physical",
       "baseDamage": { "min": 6, "max": 10 },
       "scaling": { "agility": "B" },
-      "attributeBonuses": { "agility": 2 },
+      "attributeBonuses": { "agility": 2, "strength": 1 },
+      "chanceBonuses": { "critChance": 5, "hitChance": 3, "dodgeChance": 2 },
       "onHitEffects": [
         {
           "trigger": "basic",
@@ -78,8 +83,9 @@
       "damageType": "physical",
       "baseDamage": { "min": 12, "max": 20 },
       "scaling": { "strength": "B", "stamina": "D" },
-      "attributeBonuses": { "strength": 3 },
+      "attributeBonuses": { "strength": 3, "stamina": 2 },
       "resourceBonuses": { "stamina": 10 },
+      "chanceBonuses": { "critChance": 6, "blockChance": 4, "hitChance": 2 },
       "onHitEffects": [
         {
           "trigger": "basic",
@@ -100,6 +106,7 @@
       "scaling": { "intellect": "B", "wisdom": "C" },
       "attributeBonuses": { "intellect": 3, "wisdom": 1 },
       "resourceBonuses": { "mana": 20 },
+      "chanceBonuses": { "hitChance": 6, "critChance": 2, "dodgeChance": 1 },
       "onHitEffects": [
         {
           "trigger": "ability",
@@ -119,7 +126,8 @@
       "damageType": "physical",
       "baseDamage": { "min": 9, "max": 16 },
       "scaling": { "agility": "A", "strength": "D" },
-      "attributeBonuses": { "agility": 4 },
+      "attributeBonuses": { "agility": 4, "strength": 1 },
+      "chanceBonuses": { "critChance": 8, "hitChance": 5, "dodgeChance": 4 },
       "onHitEffects": [
         {
           "trigger": "basic",
@@ -140,6 +148,7 @@
       "scaling": { "intellect": "A", "wisdom": "B" },
       "attributeBonuses": { "wisdom": 3, "intellect": 2 },
       "resourceBonuses": { "mana": 30 },
+      "chanceBonuses": { "hitChance": 7, "critChance": 3, "dodgeChance": 2 },
       "onHitEffects": [
         {
           "trigger": "ability",
@@ -161,6 +170,7 @@
       "scaling": { "strength": "S", "stamina": "B" },
       "attributeBonuses": { "strength": 5, "stamina": 3 },
       "resourceBonuses": { "stamina": 15 },
+      "chanceBonuses": { "critChance": 9, "blockChance": 6, "hitChance": 5 },
       "onHitEffects": [
         {
           "trigger": "basic",
@@ -185,7 +195,8 @@
       "cost": 40,
       "attributeBonuses": { "intellect": 1, "wisdom": 1 },
       "resourceBonuses": { "mana": 10 },
-      "resistances": { "magic": 0.03 }
+      "resistances": { "magic": 0.03 },
+      "chanceBonuses": { "hitChance": 2, "dodgeChance": 1 }
     },
     {
       "id": "armor_iron_visor",
@@ -196,7 +207,8 @@
       "cost": 95,
       "attributeBonuses": { "stamina": 2 },
       "resourceBonuses": { "health": 20 },
-      "resistances": { "melee": 0.06 }
+      "resistances": { "melee": 0.06 },
+      "chanceBonuses": { "blockChance": 3 }
     },
     {
       "id": "armor_travelers_vest",
@@ -207,7 +219,8 @@
       "cost": 40,
       "attributeBonuses": { "agility": 1 },
       "resourceBonuses": { "stamina": 5 },
-      "resistances": { "melee": 0.04, "magic": 0.01 }
+      "resistances": { "melee": 0.04, "magic": 0.01 },
+      "chanceBonuses": { "hitChance": 2, "dodgeChance": 1 }
     },
     {
       "id": "armor_guardian_cuirass",
@@ -218,7 +231,8 @@
       "cost": 220,
       "attributeBonuses": { "stamina": 3, "strength": 1 },
       "resourceBonuses": { "health": 60 },
-      "resistances": { "melee": 0.1, "magic": 0.03 }
+      "resistances": { "melee": 0.1, "magic": 0.03 },
+      "chanceBonuses": { "blockChance": 4, "critChance": 2 }
     },
     {
       "id": "armor_scout_trousers",
@@ -229,7 +243,8 @@
       "cost": 38,
       "attributeBonuses": { "agility": 2 },
       "resourceBonuses": { "stamina": 8 },
-      "resistances": { "melee": 0.03 }
+      "resistances": { "melee": 0.03 },
+      "chanceBonuses": { "dodgeChance": 3, "hitChance": 2 }
     },
     {
       "id": "armor_mystic_legwraps",
@@ -240,7 +255,8 @@
       "cost": 120,
       "attributeBonuses": { "intellect": 2 },
       "resourceBonuses": { "mana": 20 },
-      "resistances": { "magic": 0.06 }
+      "resistances": { "magic": 0.06 },
+      "chanceBonuses": { "hitChance": 3, "dodgeChance": 2 }
     },
     {
       "id": "armor_leather_boots",
@@ -252,7 +268,8 @@
       "attributeBonuses": { "agility": 1 },
       "resourceBonuses": { "stamina": 5 },
       "resistances": { "melee": 0.02 },
-      "attackIntervalModifier": -0.1
+      "attackIntervalModifier": -0.1,
+      "chanceBonuses": { "dodgeChance": 2, "hitChance": 1 }
     },
     {
       "id": "armor_tempest_greaves",
@@ -265,6 +282,7 @@
       "resourceBonuses": { "stamina": 12 },
       "resistances": { "melee": 0.05, "magic": 0.02 },
       "attackIntervalModifier": -0.2,
+      "chanceBonuses": { "dodgeChance": 5, "hitChance": 3, "blockChance": 2 },
       "onHitEffects": [
         {
           "trigger": "basic",
@@ -282,7 +300,8 @@
       "cost": 30,
       "attributeBonuses": { "strength": 1 },
       "resourceBonuses": { "stamina": 5 },
-      "resistances": { "melee": 0.01 }
+      "resistances": { "melee": 0.01 },
+      "chanceBonuses": { "critChance": 2, "hitChance": 1 }
     },
     {
       "id": "armor_venomweave_grips",
@@ -294,6 +313,7 @@
       "attributeBonuses": { "agility": 2, "intellect": 1 },
       "resourceBonuses": { "stamina": 6 },
       "resistances": { "magic": 0.04 },
+      "chanceBonuses": { "critChance": 4, "hitChance": 3, "dodgeChance": 2 },
       "onHitEffects": [
         {
           "trigger": "basic",

--- a/domain/item.js
+++ b/domain/item.js
@@ -14,6 +14,7 @@ class Item {
     resistances = {},
     onHitEffects = [],
     attackIntervalModifier = 0,
+    chanceBonuses = {},
   }) {
     this.id = id;
     this.name = name;
@@ -29,6 +30,7 @@ class Item {
     this.resistances = resistances;
     this.onHitEffects = onHitEffects;
     this.attackIntervalModifier = attackIntervalModifier;
+    this.chanceBonuses = chanceBonuses;
   }
 }
 

--- a/systems/effectsEngine.js
+++ b/systems/effectsEngine.js
@@ -4,34 +4,134 @@ function randBetween(min, max) {
   return Math.floor(min + Math.random() * (max - min + 1));
 }
 
-function applyDamage(source, target, amount, type, log) {
-  const resist = type === 'physical' ? target.derived.meleeResist : target.derived.magicResist;
-  let dmg = amount * (1 + source.damageBuff);
-  dmg = Math.max(1, Math.round(dmg * (1 - resist)));
-  target.health -= dmg;
-  pushLog(log, `${source.character.name} hits ${target.character.name} for ${dmg} ${type}`, {
+const CRIT_MULTIPLIER = 1.75;
+const BLOCK_DAMAGE_MULTIPLIER = 0.4;
+const MIN_HIT_CHANCE = 0.05;
+const MAX_HIT_CHANCE = 1;
+
+function clampProbability(value, min = 0, max = 1) {
+  if (!Number.isFinite(value)) return min;
+  const clamped = Math.min(Math.max(value, min), max);
+  return clamped;
+}
+
+function chanceRoll(probability) {
+  return Math.random() < probability;
+}
+
+function getDamageType(source, effectType) {
+  if (effectType === 'MagicDamage') return 'magical';
+  if (effectType === 'PhysicalDamage') return 'physical';
+  if (source && source.derived && source.derived.weaponDamageType) {
+    return source.derived.weaponDamageType;
+  }
+  if (source && source.basicAttackEffectType === 'MagicDamage') return 'magical';
+  if (source && source.character && source.character.basicType === 'magic') return 'magical';
+  return 'physical';
+}
+
+function resolveAttack(source, target, type, log, existingResolution) {
+  if (existingResolution && typeof existingResolution === 'object') {
+    return {
+      hit: !!existingResolution.hit,
+      outcome: existingResolution.outcome || (existingResolution.hit ? 'hit' : 'miss'),
+      damageType: existingResolution.damageType || type,
+      hitChance: existingResolution.hitChance,
+      dodgeChance: existingResolution.dodgeChance,
+    };
+  }
+
+  const hitChance = clampProbability((source.derived.hitChance || 0) / 100, MIN_HIT_CHANCE, MAX_HIT_CHANCE);
+  const dodgeChance = clampProbability((target.derived.dodgeChance || 0) / 100);
+
+  if (Math.random() > hitChance) {
+    pushLog(log, `${source.character.name}'s attack misses ${target.character.name}`, {
+      sourceId: source.character.id,
+      targetId: target.character.id,
+      kind: 'miss',
+      damageType: type,
+    });
+    return { hit: false, outcome: 'miss', damageType: type, hitChance, dodgeChance };
+  }
+
+  if (chanceRoll(dodgeChance)) {
+    pushLog(log, `${target.character.name} dodges ${source.character.name}'s attack`, {
+      sourceId: target.character.id,
+      targetId: source.character.id,
+      kind: 'dodge',
+      damageType: type,
+    });
+    return { hit: false, outcome: 'dodge', damageType: type, hitChance, dodgeChance };
+  }
+
+  return { hit: true, outcome: 'hit', damageType: type, hitChance, dodgeChance };
+}
+
+function applyDamage(source, target, amount, type, log, context = {}) {
+  const resolution = resolveAttack(source, target, type, log, context.resolution);
+  const resolvedType = resolution.damageType || type;
+  if (!resolution.hit) {
+    return { hit: false, amount: 0, damageType: resolvedType, resolution };
+  }
+
+  const critChance = clampProbability((source.derived.critChance || 0) / 100);
+  const blockChance = clampProbability((target.derived.blockChance || 0) / 100);
+  const crit = chanceRoll(critChance);
+  const blocked = chanceRoll(blockChance);
+
+  const damageBuff = Number.isFinite(source.damageBuff) ? source.damageBuff : 0;
+  let dmg = amount;
+  if (crit) {
+    dmg *= CRIT_MULTIPLIER;
+  }
+  dmg *= 1 + damageBuff;
+  if (blocked) {
+    dmg *= BLOCK_DAMAGE_MULTIPLIER;
+  }
+
+  const resist = resolvedType === 'physical' ? target.derived.meleeResist : target.derived.magicResist;
+  const finalDamage = Math.max(1, Math.round(dmg * (1 - resist)));
+  target.health -= finalDamage;
+
+  let message;
+  if (crit && blocked) {
+    message = `${source.character.name} critically hits ${target.character.name} for ${finalDamage} ${resolvedType} (blocked)`;
+  } else if (crit) {
+    message = `${source.character.name} critically hits ${target.character.name} for ${finalDamage} ${resolvedType}`;
+  } else if (blocked) {
+    message = `${source.character.name} hits ${target.character.name} for ${finalDamage} ${resolvedType} (blocked)`;
+  } else {
+    message = `${source.character.name} hits ${target.character.name} for ${finalDamage} ${resolvedType}`;
+  }
+
+  pushLog(log, message, {
     sourceId: source.character.id,
     targetId: target.character.id,
     kind: 'damage',
-    damageType: type,
-    amount: dmg,
+    damageType: resolvedType,
+    amount: finalDamage,
+    crit,
+    blocked,
   });
+
+  const resultResolution = { ...resolution, damageType: resolvedType, crit, blocked };
+  return { hit: true, amount: finalDamage, crit, blocked, damageType: resolvedType, resolution: resultResolution };
 }
 
-function applyEffect(source, target, effect, now, log) {
+function applyEffect(source, target, effect, now, log, context = {}) {
   switch (effect.type) {
     case 'PhysicalDamage': {
-      const base = effect.value + randBetween(source.derived.minMeleeAttack, source.derived.maxMeleeAttack);
-      applyDamage(source, target, base, 'physical', log);
-      break;
+      const bonus = typeof effect.value === 'number' ? effect.value : 0;
+      const base = bonus + randBetween(source.derived.minMeleeAttack, source.derived.maxMeleeAttack);
+      return applyDamage(source, target, base, 'physical', log, context);
     }
     case 'MagicDamage': {
-      const base = effect.value + randBetween(source.derived.minMagicAttack, source.derived.maxMagicAttack);
-      applyDamage(source, target, base, 'magical', log);
-      break;
+      const bonus = typeof effect.value === 'number' ? effect.value : 0;
+      const base = bonus + randBetween(source.derived.minMagicAttack, source.derived.maxMagicAttack);
+      return applyDamage(source, target, base, 'magical', log, context);
     }
     case 'Heal': {
-      const amount = effect.value;
+      const amount = typeof effect.value === 'number' ? effect.value : 0;
       const before = source.health;
       source.health = Math.min(source.health + amount, source.derived.health);
       const healed = source.health - before;
@@ -41,49 +141,73 @@ function applyEffect(source, target, effect, now, log) {
         kind: 'heal',
         amount: healed,
       });
-      break;
+      return null;
     }
     case 'BuffDamagePct': {
-      source.damageBuff += effect.amount;
-      source.buffs.push({ amount: effect.amount, expires: now + effect.duration });
-      pushLog(log, `${source.character.name} gains +${Math.round(effect.amount * 100)}% damage`, {
+      const amount = typeof effect.amount === 'number' ? effect.amount : 0;
+      const duration = typeof effect.duration === 'number' ? effect.duration : 0;
+      source.damageBuff += amount;
+      source.buffs.push({ amount, expires: now + duration });
+      pushLog(log, `${source.character.name} gains +${Math.round(amount * 100)}% damage`, {
         sourceId: source.character.id,
         targetId: source.character.id,
         kind: 'buff',
-        amount: effect.amount,
-        duration: effect.duration,
+        amount,
+        duration,
       });
-      break;
+      return null;
     }
     case 'Stun': {
-      target.stunnedUntil = Math.max(target.stunnedUntil, now + effect.duration);
+      const type = getDamageType(source, effect.type);
+      const resolution = resolveAttack(source, target, type, log, context.resolution);
+      if (!resolution.hit) {
+        return { hit: false, amount: 0, damageType: resolution.damageType, resolution };
+      }
+      const duration = typeof effect.duration === 'number' ? effect.duration : 0;
+      target.stunnedUntil = Math.max(target.stunnedUntil, now + duration);
       pushLog(log, `${target.character.name} is stunned`, {
         sourceId: target.character.id,
         targetId: source.character.id,
         kind: 'stun',
-        duration: effect.duration,
+        duration,
       });
-      break;
+      const resultResolution = { ...resolution, damageType: resolution.damageType };
+      return { hit: true, amount: 0, damageType: resultResolution.damageType, resolution: resultResolution };
     }
     case 'Poison': {
+      const type = getDamageType(source, effect.type);
+      const resolution = resolveAttack(source, target, type, log, context.resolution);
+      if (!resolution.hit) {
+        return { hit: false, amount: 0, damageType: resolution.damageType, resolution };
+      }
+      const damage = typeof effect.damage === 'number' ? effect.damage : 0;
+      const interval = typeof effect.interval === 'number' ? effect.interval : 1;
+      const duration = typeof effect.duration === 'number' ? effect.duration : 0;
       target.dots.push({
-        damage: effect.damage,
-        interval: effect.interval,
-        nextTick: now + effect.interval,
-        expires: now + effect.duration,
+        damage,
+        interval,
+        nextTick: now + interval,
+        expires: now + duration,
       });
       pushLog(log, `${target.character.name} is poisoned`, {
         sourceId: target.character.id,
         targetId: source.character.id,
         kind: 'poison',
-        interval: effect.interval,
-        duration: effect.duration,
-        damage: effect.damage,
+        interval,
+        duration,
+        damage,
       });
-      break;
+      const resultResolution = { ...resolution, damageType: resolution.damageType };
+      return {
+        hit: true,
+        amount: 0,
+        damageType: resultResolution.damageType,
+        resolution: resultResolution,
+        appliedEffect: 'Poison',
+      };
     }
     default:
-      break;
+      return null;
   }
 }
 

--- a/systems/equipmentService.js
+++ b/systems/equipmentService.js
@@ -25,6 +25,7 @@ function createItem(entry) {
   item.resourceBonuses = Object.freeze({ ...(item.resourceBonuses || {}) });
   item.resistances = Object.freeze({ ...(item.resistances || {}) });
   item.scaling = Object.freeze({ ...(item.scaling || {}) });
+  item.chanceBonuses = Object.freeze({ ...(item.chanceBonuses || {}) });
   item.onHitEffects = Object.freeze((item.onHitEffects || []).map(cloneEffect).filter(Boolean));
   return Object.freeze(item);
 }


### PR DESCRIPTION
## Summary
- add asymptotic crit/block/dodge/hit chance calculations that combine paired attributes and gear bonuses
- apply the new chance stats inside combat resolution for abilities, basic attacks, and on-hit effects
- refresh equipment data and the UI so chance bonuses appear on items and character summaries

## Testing
- Not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68ca1a45bac8832081a0c7a523700915