### PR TITLE
Restyle character page layout

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -2378,7 +2378,6 @@ function populateLoadoutSummary(container, derived) {
     });
     attrTable.appendChild(tr);
   });
-  container.appendChild(attrTable);
 
   const derivedTable = document.createElement('table');
   derivedTable.className = 'stats-table';
@@ -2406,7 +2405,12 @@ function populateLoadoutSummary(container, derived) {
   addRow('Dodge Chance', formatChanceValue(derived.dodgeChance));
   const basic = derived.basicAttackEffectType === 'MagicDamage' ? 'Magic' : 'Physical';
   addRow('Basic Attack', basic);
-  container.appendChild(derivedTable);
+
+  const tables = document.createElement('div');
+  tables.className = 'summary-tables';
+  tables.appendChild(attrTable);
+  tables.appendChild(derivedTable);
+  container.appendChild(tables);
 
   const chanceBonuses = derived.chanceBonuses || {};
   const chanceTable = document.createElement('table');
@@ -2436,17 +2440,30 @@ function populateLoadoutSummary(container, derived) {
     tr.appendChild(totalTd);
     chanceTable.appendChild(tr);
   });
-  container.appendChild(chanceTable);
 
-  const heading = document.createElement('div');
-  heading.textContent = 'On-Hit Effects';
-  heading.style.fontWeight = 'bold';
-  container.appendChild(heading);
+  const extras = document.createElement('div');
+  extras.className = 'summary-extras';
+
+  const chanceCard = document.createElement('div');
+  chanceCard.className = 'chance-card';
+  const chanceHeading = document.createElement('div');
+  chanceHeading.className = 'card-heading';
+  chanceHeading.textContent = 'Chance Breakdown';
+  chanceCard.appendChild(chanceHeading);
+  chanceCard.appendChild(chanceTable);
+  extras.appendChild(chanceCard);
+
+  const effectsCard = document.createElement('div');
+  effectsCard.className = 'onhit-card';
+  const effectsHeading = document.createElement('div');
+  effectsHeading.className = 'card-heading';
+  effectsHeading.textContent = 'On-Hit Effects';
+  effectsCard.appendChild(effectsHeading);
   const effects = Array.isArray(derived.onHitEffects) ? derived.onHitEffects : [];
   if (!effects.length) {
     const none = document.createElement('div');
     none.textContent = 'None';
-    container.appendChild(none);
+    effectsCard.appendChild(none);
   } else {
     const list = document.createElement('ul');
     list.className = 'simple-list';
@@ -2455,9 +2472,13 @@ function populateLoadoutSummary(container, derived) {
       li.textContent = describeOnHit(entry);
       list.appendChild(li);
     });
-    container.appendChild(list);
+    effectsCard.appendChild(list);
   }
+  extras.appendChild(effectsCard);
+
+  container.appendChild(extras);
 }
+
 
 async function renderCharacter() {
   const pane = document.getElementById('character');
@@ -2479,51 +2500,172 @@ async function renderCharacter() {
 
   pane.innerHTML = '';
   const xpNeeded = xpForNextLevel(currentCharacter.level || 1);
-  const table = document.createElement('table');
-  table.className = 'stats-table';
+  const xpCurrent = currentCharacter.xp || 0;
+  const gold = currentPlayer ? currentPlayer.gold || 0 : 0;
+  const derived = (inventoryView && inventoryView.derived) || computeDerived(currentCharacter);
 
-  const addSection = label => {
-    const tr = document.createElement('tr');
-    tr.className = 'section';
-    const td = document.createElement('td');
-    td.colSpan = 2;
-    td.textContent = label;
-    tr.appendChild(td);
-    table.appendChild(tr);
-  };
+  const page = document.createElement('div');
+  page.className = 'character-page';
+  pane.appendChild(page);
 
-  const addRow = (label, value) => {
-    const tr = document.createElement('tr');
-    const l = document.createElement('td');
+  const hero = document.createElement('div');
+  hero.className = 'character-hero';
+  page.appendChild(hero);
+
+  const emblem = document.createElement('div');
+  emblem.className = 'hero-emblem';
+  emblem.textContent = (currentCharacter.name || '?').slice(0, 1).toUpperCase();
+  hero.appendChild(emblem);
+
+  const heroBody = document.createElement('div');
+  heroBody.className = 'hero-body';
+  hero.appendChild(heroBody);
+
+  const heroHeader = document.createElement('div');
+  heroHeader.className = 'hero-header';
+  heroBody.appendChild(heroHeader);
+
+  const heroName = document.createElement('div');
+  heroName.className = 'hero-name';
+  heroName.textContent = currentCharacter.name;
+  heroHeader.appendChild(heroName);
+
+  const heroType = document.createElement('div');
+  heroType.className = 'hero-type';
+  heroType.textContent = displayDamageType(currentCharacter.basicType);
+  heroHeader.appendChild(heroType);
+
+  const metaGrid = document.createElement('div');
+  metaGrid.className = 'hero-meta-grid';
+  heroBody.appendChild(metaGrid);
+  const metaEntries = [
+    { label: 'Level', value: currentCharacter.level || 1 },
+    { label: 'Gold', value: gold },
+    { label: 'Basic Attack', value: derived.basicAttackEffectType === 'MagicDamage' ? 'Magic' : 'Physical' },
+  ];
+  metaEntries.forEach(({ label, value }) => {
+    const item = document.createElement('div');
+    item.className = 'hero-meta-item';
+    const l = document.createElement('div');
+    l.className = 'label';
     l.textContent = label;
-    const v = document.createElement('td');
+    const v = document.createElement('div');
+    v.className = 'value';
     v.textContent = value;
-    tr.appendChild(l);
-    tr.appendChild(v);
-    table.appendChild(tr);
-  };
+    item.appendChild(l);
+    item.appendChild(v);
+    metaGrid.appendChild(item);
+  });
 
-  addSection('Info');
-  addRow('Name', currentCharacter.name);
-  addRow('Level', currentCharacter.level || 1);
-  addRow('XP', `${currentCharacter.xp || 0} / ${xpNeeded}`);
-  addRow('Gold', currentPlayer ? currentPlayer.gold || 0 : 0);
-  addRow('Damage Type', displayDamageType(currentCharacter.basicType));
+  const xpSection = document.createElement('div');
+  xpSection.className = 'hero-xp';
+  heroBody.appendChild(xpSection);
+  const xpLabel = document.createElement('div');
+  xpLabel.className = 'xp-label';
+  xpLabel.textContent = xpNeeded > 0 ? `XP ${xpCurrent} / ${xpNeeded}` : `XP ${xpCurrent}`;
+  xpSection.appendChild(xpLabel);
+  const xpBar = document.createElement('div');
+  xpBar.className = 'xp-bar';
+  xpSection.appendChild(xpBar);
+  const xpFill = document.createElement('div');
+  xpFill.className = 'xp-bar-fill';
+  const progress = xpNeeded > 0 ? Math.min(1, Math.max(0, xpCurrent / xpNeeded)) : 1;
+  xpFill.style.width = `${progress * 100}%`;
+  xpBar.appendChild(xpFill);
+  if (xpNeeded > 0 && xpCurrent >= xpNeeded) {
+    xpSection.classList.add('ready');
+    const ready = document.createElement('div');
+    ready.className = 'xp-ready-text';
+    ready.textContent = 'Ready to level up!';
+    xpSection.appendChild(ready);
+  } else if (xpNeeded > 0) {
+    const hint = document.createElement('div');
+    hint.className = 'xp-hint';
+    hint.textContent = `${Math.max(0, xpNeeded - xpCurrent)} XP to next level`;
+    xpSection.appendChild(hint);
+  } else {
+    const hint = document.createElement('div');
+    hint.className = 'xp-hint';
+    hint.textContent = 'Maximum level reached';
+    xpSection.appendChild(hint);
+  }
 
-  pane.appendChild(table);
-
-  const summary = document.createElement('div');
-  summary.className = 'loadout-summary';
-  populateLoadoutSummary(summary, inventoryView ? inventoryView.derived : null);
-  pane.appendChild(summary);
-
-  if ((currentCharacter.xp || 0) >= xpNeeded) {
+  const heroActions = document.createElement('div');
+  heroActions.className = 'hero-actions';
+  hero.appendChild(heroActions);
+  if (xpNeeded > 0 && xpCurrent >= xpNeeded) {
+    const status = document.createElement('div');
+    status.className = 'hero-status ready';
+    status.textContent = 'Advancement available';
+    heroActions.appendChild(status);
     const btn = document.createElement('button');
     btn.textContent = 'Level Up';
     btn.addEventListener('click', showLevelUpForm);
-    pane.appendChild(btn);
+    heroActions.appendChild(btn);
+  } else {
+    const status = document.createElement('div');
+    status.className = 'hero-status';
+    status.textContent = xpNeeded > 0 ? `${Math.max(0, xpNeeded - xpCurrent)} XP needed` : 'Standing at the peak';
+    heroActions.appendChild(status);
   }
+  const heroNote = document.createElement('div');
+  heroNote.className = 'hero-note';
+  heroNote.textContent = 'Tweak gear in the loadout and prepare your next rotation.';
+  heroActions.appendChild(heroNote);
+
+  const grid = document.createElement('div');
+  grid.className = 'character-grid';
+  page.appendChild(grid);
+
+  const highlightCard = document.createElement('div');
+  highlightCard.className = 'character-card highlight-card';
+  const highlightTitle = document.createElement('h3');
+  highlightTitle.textContent = 'Battle Snapshot';
+  highlightCard.appendChild(highlightTitle);
+  const highlightGrid = document.createElement('div');
+  highlightGrid.className = 'highlight-grid';
+  const highlightStats = [
+    { label: 'Health', value: Math.round(derived.health || 0) },
+    { label: 'Mana', value: Math.round(derived.mana || 0) },
+    { label: 'Stamina', value: Math.round(derived.stamina || 0) },
+    { label: 'Melee ATK', value: `${Math.round(derived.minMeleeAttack || 0)}-${Math.round(derived.maxMeleeAttack || 0)}` },
+    { label: 'Magic ATK', value: `${Math.round(derived.minMagicAttack || 0)}-${Math.round(derived.maxMagicAttack || 0)}` },
+    { label: 'Attack Rate', value: `${(derived.attackIntervalSeconds || 0).toFixed(2)}s` },
+    { label: 'Hit Chance', value: formatChanceValue(derived.hitChance) },
+    { label: 'Crit Chance', value: formatChanceValue(derived.critChance) },
+    { label: 'Block Chance', value: formatChanceValue(derived.blockChance) },
+    { label: 'Dodge Chance', value: formatChanceValue(derived.dodgeChance) },
+    { label: 'Melee Resist', value: `${Math.round((derived.meleeResist || 0) * 100)}%` },
+    { label: 'Magic Resist', value: `${Math.round((derived.magicResist || 0) * 100)}%` },
+  ];
+  highlightStats.forEach(({ label, value }) => {
+    const item = document.createElement('div');
+    item.className = 'highlight-item';
+    const l = document.createElement('div');
+    l.className = 'label';
+    l.textContent = label;
+    const v = document.createElement('div');
+    v.className = 'value';
+    v.textContent = value;
+    item.appendChild(l);
+    item.appendChild(v);
+    highlightGrid.appendChild(item);
+  });
+  highlightCard.appendChild(highlightGrid);
+  grid.appendChild(highlightCard);
+
+  const loadoutCard = document.createElement('div');
+  loadoutCard.className = 'character-card loadout-card';
+  const loadoutTitle = document.createElement('h3');
+  loadoutTitle.textContent = 'Loadout Breakdown';
+  loadoutCard.appendChild(loadoutTitle);
+  const summary = document.createElement('div');
+  summary.className = 'loadout-summary';
+  populateLoadoutSummary(summary, derived);
+  loadoutCard.appendChild(summary);
+  grid.appendChild(loadoutCard);
 }
+
 
 function showLevelUpForm() {
   if (document.getElementById('levelup-dialog')) return;

--- a/ui/style.css
+++ b/ui/style.css
@@ -6,7 +6,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #content { border:1px solid #000; padding:8px; }
 .tab-pane { display:none; }
 .tab-pane.active { display:block; }
-.tab-pane#character.active { display:flex; flex-direction:column; align-items:center; }
+.tab-pane#character.active { display:block; }
 .hidden { display:none !important; }
 #auth, #character-select { border:1px solid #000; padding:8px; margin:20px auto; }
 #game { max-width:800px; margin:20px auto; }
@@ -116,9 +116,180 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #battle-log .log-message.neutral { align-self:center; background:#fff; color:#000; border-style:dashed; text-align:center; }
 #battle-dialog .dialog-buttons { text-align:right; margin-top:16px; }
 
-.stats-table { border-collapse:collapse; margin-bottom:8px; }
+.stats-table { border-collapse:collapse; margin-bottom:8px; width:100%; }
 .stats-table th, .stats-table td { border:1px solid #000; padding:4px; }
 .stats-table .section td { font-weight:bold; text-align:center; }
+
+.character-page { display:flex; flex-direction:column; gap:16px; width:100%; }
+.character-hero {
+  display:flex;
+  gap:16px;
+  align-items:stretch;
+  border:2px solid #000;
+  background:#fff;
+  padding:16px;
+  box-shadow:0 0 0 4px #000 inset;
+}
+.hero-emblem {
+  width:120px;
+  min-height:120px;
+  border:2px solid #000;
+  background:repeating-linear-gradient(45deg, #000 0px, #000 6px, #fff 6px, #fff 12px);
+  color:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:48px;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:4px;
+}
+.hero-body { flex:1; display:flex; flex-direction:column; gap:12px; }
+.hero-header { display:flex; align-items:baseline; gap:12px; }
+.hero-name { font-size:28px; text-transform:uppercase; letter-spacing:2px; }
+.hero-type {
+  border:1px solid #000;
+  background:#000;
+  color:#fff;
+  padding:4px 8px;
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.hero-meta-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(120px,1fr));
+  gap:8px;
+}
+.hero-meta-item {
+  border:1px solid #000;
+  background:#fff;
+  padding:6px;
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+}
+.hero-meta-item .label {
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  color:#555;
+}
+.hero-meta-item .value { font-size:16px; font-weight:bold; }
+.hero-xp { display:flex; flex-direction:column; gap:6px; }
+.xp-label { font-weight:bold; letter-spacing:1px; }
+.xp-bar { border:1px solid #000; height:16px; background:#f8f8f8; position:relative; overflow:hidden; }
+.xp-bar::before {
+  content:'';
+  position:absolute;
+  inset:0;
+  background:repeating-linear-gradient(90deg, #f8f8f8 0px, #f8f8f8 6px, #e4e4e4 6px, #e4e4e4 12px);
+  opacity:0.7;
+}
+.xp-bar-fill {
+  position:relative;
+  height:100%;
+  background:#000;
+  box-shadow:0 0 0 1px #000 inset;
+}
+.hero-xp.ready .xp-bar-fill { animation:pulse-bar 1s steps(2) infinite; }
+.xp-hint { font-size:12px; color:#444; text-transform:uppercase; letter-spacing:1px; }
+.xp-ready-text { font-size:12px; font-weight:bold; text-transform:uppercase; letter-spacing:1px; }
+.hero-actions {
+  display:flex;
+  flex-direction:column;
+  justify-content:space-between;
+  min-width:160px;
+  gap:12px;
+}
+.hero-status {
+  border:1px solid #000;
+  padding:8px;
+  background:#fff;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:12px;
+  text-align:center;
+}
+.hero-status.ready { background:#000; color:#fff; }
+.hero-note {
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  color:#444;
+}
+.character-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(260px,1fr));
+  gap:16px;
+}
+.character-card {
+  border:2px solid #000;
+  background:#fff;
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  box-shadow:0 0 0 3px #000 inset;
+}
+.character-card h3 {
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:16px;
+}
+.highlight-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(120px,1fr));
+  gap:12px;
+}
+.highlight-item {
+  border:1px solid #000;
+  background:repeating-linear-gradient(0deg, #fff 0px, #fff 8px, #f0f0f0 8px, #f0f0f0 16px);
+  padding:8px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.highlight-item .label {
+  font-size:10px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  color:#555;
+}
+.highlight-item .value { font-size:18px; font-weight:bold; }
+.character-card .loadout-summary { display:flex; flex-direction:column; gap:16px; }
+.summary-tables {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(220px,1fr));
+  gap:12px;
+}
+.summary-extras {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(220px,1fr));
+  gap:12px;
+  align-items:start;
+}
+.chance-card, .onhit-card {
+  border:1px solid #000;
+  background:#fff;
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.card-heading {
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-weight:bold;
+}
+.onhit-card .simple-list { flex:1; }
+
+@keyframes pulse-bar {
+  0%, 100% { opacity:1; }
+  50% { opacity:0.4; }
+}
 
 #levelup-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
 #levelup-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }


### PR DESCRIPTION
## Summary
- redesign the character tab to use a hero header, battle snapshot, and loadout cards
- add supporting retro pixel styling including hero badge, grids, and animated xp bar
- restructure loadout summary markup to group attribute, chance, and effect sections for the new layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca28584a9c83208ece55a4d01f4670