### PR TITLE
Apply retro styling across gameplay tabs

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -654,6 +654,9 @@ function initTabs() {
         document.querySelectorAll('.tab-pane').forEach(pane => {
           pane.classList.toggle('active', pane.id === target);
         });
+        buttons.forEach(other => {
+          other.classList.toggle('active', other === btn);
+        });
         if (target === 'rotation') {
           initRotation();
         } else if (target === 'character') {

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,61 +1,308 @@
-* { box-sizing: border-box; }
-body { margin:0; background:#fff; color:#000; font-family:'Courier New', monospace; }
-button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor:pointer; font-family:'Courier New', monospace; }
-#tabs { display:flex; border-bottom:1px solid #000; }
-#tabs button { flex:1; border-bottom:none; }
-#content { border:1px solid #000; padding:8px; }
-.tab-pane { display:none; }
-.tab-pane.active { display:block; }
-.tab-pane#character.active { display:block; }
-.hidden { display:none !important; }
-#auth, #character-select { border:1px solid #000; padding:8px; margin:20px auto; }
-#game { max-width:800px; margin:20px auto; }
-#auth { max-width:300px; }
-#character-select { max-width:600px; }
-#auth input { width:100%; margin-bottom:8px; }
-#character-list { list-style:none; padding:0; }
-#character-list li { margin-bottom:4px; display:flex; justify-content:space-between; align-items:center; }
-#character-list li .info { white-space:pre; margin-right:8px; }
+:root {
+  --retro-black: #000;
+  --retro-white: #fff;
+  --retro-gray: #f3f3f3;
+  --retro-dark-gray: #111;
+}
 
-#rotation-container {
-  margin-top:8px;
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: repeating-linear-gradient(
+      90deg,
+      var(--retro-white) 0px,
+      var(--retro-white) 12px,
+      var(--retro-gray) 12px,
+      var(--retro-gray) 24px
+    );
+  color: var(--retro-black);
+  font-family: 'Courier New', monospace;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+button {
+  background: repeating-linear-gradient(
+      90deg,
+      var(--retro-white) 0px,
+      var(--retro-white) 10px,
+      #eaeaea 10px,
+      #eaeaea 20px
+    );
+  color: var(--retro-black);
+  border: 2px solid var(--retro-black);
+  padding: 10px 14px;
+  cursor: pointer;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: bold;
+  box-shadow: 0 0 0 2px var(--retro-black) inset;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+button:hover {
+  background: repeating-linear-gradient(
+      90deg,
+      #fefefe 0px,
+      #fefefe 10px,
+      #ececec 10px,
+      #ececec 20px
+    );
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button:focus {
+  outline: 2px dashed var(--retro-black);
+  outline-offset: 2px;
+}
+
+input,
+select {
+  border: 2px solid var(--retro-black);
+  padding: 8px;
+  font-family: 'Courier New', monospace;
+  background: var(--retro-white);
+  box-shadow: 0 0 0 2px var(--retro-black) inset;
+}
+
+#game {
+  width: min(1200px, 96%);
+  margin: 48px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+#tabs {
+  display: flex;
+  border: 2px solid var(--retro-black);
+  background: var(--retro-black);
+  box-shadow: 0 0 0 3px var(--retro-black) inset;
+  overflow: hidden;
+}
+
+#tabs button {
+  flex: 1;
+  border: none;
+  border-right: 1px solid var(--retro-black);
+  color: var(--retro-white);
+  background: repeating-linear-gradient(
+      135deg,
+      #1a1a1a 0px,
+      #1a1a1a 12px,
+      #2a2a2a 12px,
+      #2a2a2a 24px
+    );
+  box-shadow: none;
+}
+
+#tabs button:last-child {
+  border-right: none;
+}
+
+#tabs button.active {
+  color: var(--retro-black);
+  background: var(--retro-white);
+  box-shadow: inset 0 0 0 3px var(--retro-black);
+}
+
+#content {
+  border: 2px solid var(--retro-black);
+  padding: 24px;
+  background: var(--retro-white);
+  box-shadow: 0 0 0 4px var(--retro-black) inset, 12px 12px 0 0 rgba(0, 0, 0, 0.1);
+  min-height: 620px;
   display:flex;
   flex-direction:column;
-  align-items:center;
+}
+
+.tab-pane {
+  display: none;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.tab-pane.active {
+  display: flex;
+}
+
+.hidden { display:none !important; }
+
+#auth,
+#character-select {
+  border: 2px solid var(--retro-black);
+  padding: 16px;
+  margin: 56px auto 0;
+  background: var(--retro-white);
+  box-shadow: 0 0 0 4px var(--retro-black) inset, 12px 12px 0 0 rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#auth {
+  max-width: 320px;
+}
+
+#auth input {
+  width: 100%;
+}
+
+#character-select {
+  max-width: 640px;
+}
+
+#character-select h2 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+#character-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#character-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 2px solid var(--retro-black);
+  padding: 8px 12px;
+  background: repeating-linear-gradient(
+      90deg,
+      var(--retro-white) 0px,
+      var(--retro-white) 14px,
+      #ededed 14px,
+      #ededed 28px
+    );
+  box-shadow: 0 0 0 3px var(--retro-black) inset;
+}
+
+#character-list li .info { white-space:pre; margin-right:8px; }
+
+#rotation {
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+}
+
+#rotation-container {
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+  border:2px solid var(--retro-black);
+  background:var(--retro-white);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+  padding:24px;
 }
 #rotation-container .rotation-settings {
   width:100%;
   display:flex;
   align-items:center;
   justify-content:center;
-  gap:8px;
+  gap:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-weight:bold;
 }
 #rotation-container .rotation-settings label {
   font-weight:bold;
 }
 #rotation-container .lists {
   display:flex;
-  gap:32px;
+  flex-wrap:wrap;
+  gap:24px;
   align-items:flex-start;
-  justify-content:center;
+  justify-content:space-between;
 }
 #rotation-container .pool {
-  max-width:400px;
+  flex:1;
+  min-width:280px;
+  max-width:460px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
 }
-#rotation-container .ability-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(100px,1fr)); gap:8px; margin-bottom:16px; }
-#rotation-container .ability-card { border:1px solid #000; padding:8px; text-align:center; cursor:move; }
-#rotation-container ul { list-style:none; padding:0 0 8px; margin:0; border:1px solid #000; min-width:150px; min-height:200px; max-height:300px; overflow-y:auto; }
-#rotation-container li { border-bottom:1px solid #000; padding:4px; cursor:move; }
-#rotation-container li:last-child { border-bottom:none; }
-#rotation-error { margin-top:8px; }
+#rotation-container .ability-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(120px,1fr));
+  gap:12px;
+  border:2px solid var(--retro-black);
+  margin:0;
+  padding:12px;
+  background:repeating-linear-gradient(0deg, var(--retro-white) 0px, var(--retro-white) 10px, #f4f4f4 10px, #f4f4f4 20px);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+  max-height:320px;
+  overflow-y:auto;
+}
+#rotation-container .ability-card {
+  border:2px solid var(--retro-black);
+  padding:8px;
+  text-align:center;
+  cursor:move;
+  background:var(--retro-white);
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:12px;
+}
+#rotation-container ul {
+  list-style:none;
+  padding:12px;
+  margin:0;
+  border:2px solid var(--retro-black);
+  min-width:220px;
+  min-height:260px;
+  max-height:340px;
+  overflow-y:auto;
+  background:repeating-linear-gradient(180deg, var(--retro-white) 0px, var(--retro-white) 12px, #f5f5f5 12px, #f5f5f5 24px);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+#rotation-container li {
+  border:2px solid var(--retro-black);
+  padding:6px 8px;
+  cursor:move;
+  background:var(--retro-white);
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-weight:bold;
+  font-size:12px;
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
+#rotation-container li:last-child {
+  margin-bottom:0;
+}
+#rotation-error {
+  margin-top:0;
+  text-align:center;
+  font-weight:bold;
+  color:#a00;
+}
 
 #rotation-delete {
-  border:1px dashed #000;
-  padding:8px;
-  min-height:40px;
-  margin-top:8px;
+  border:2px dashed var(--retro-black);
+  padding:12px;
+  min-height:60px;
   text-align:center;
   color:#a00;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
 }
 
 #name-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
@@ -109,11 +356,47 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   pointer-events:none;
   white-space:nowrap;
 }
-#battle-log { border:1px solid #000; height:220px; overflow-y:auto; padding:8px; display:flex; flex-direction:column; gap:8px; margin-top:16px; }
-#battle-log .log-message { max-width:75%; padding:6px 8px; border:1px solid #000; }
-#battle-log .log-message.you { align-self:flex-start; background:#000; color:#fff; border-color:#000; }
-#battle-log .log-message.opponent { align-self:flex-end; background:#fff; color:#000; border-color:#000; text-align:right; }
-#battle-log .log-message.neutral { align-self:center; background:#fff; color:#000; border-style:dashed; text-align:center; }
+#battle-log {
+  border:2px solid var(--retro-black);
+  height:220px;
+  overflow-y:auto;
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  margin-top:0;
+  background:repeating-linear-gradient(0deg, var(--retro-white) 0px, var(--retro-white) 12px, #f3f3f3 12px, #f3f3f3 24px);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+}
+#battle-log .log-message {
+  max-width:75%;
+  padding:8px 10px;
+  border:2px solid var(--retro-black);
+  background:var(--retro-white);
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:12px;
+}
+#battle-log .log-message.you {
+  align-self:flex-start;
+  background:var(--retro-black);
+  color:var(--retro-white);
+  border-color:var(--retro-black);
+}
+#battle-log .log-message.opponent {
+  align-self:flex-end;
+  background:var(--retro-white);
+  color:var(--retro-black);
+  border-color:var(--retro-black);
+  text-align:right;
+}
+#battle-log .log-message.neutral {
+  align-self:center;
+  background:var(--retro-white);
+  color:var(--retro-black);
+  border-style:dashed;
+  text-align:center;
+}
 #battle-dialog .dialog-buttons { text-align:right; margin-top:16px; }
 
 .stats-table { border-collapse:collapse; margin-bottom:8px; width:100%; }
@@ -271,12 +554,13 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   align-items:start;
 }
 .chance-card, .onhit-card {
-  border:1px solid #000;
+  border:2px solid var(--retro-black);
   background:#fff;
-  padding:12px;
+  padding:16px;
   display:flex;
   flex-direction:column;
-  gap:8px;
+  gap:12px;
+  box-shadow:0 0 0 3px var(--retro-black) inset;
 }
 .card-heading {
   font-size:12px;
@@ -295,56 +579,309 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #levelup-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
 #levelup-dialog .dialog-buttons { margin-top:8px; text-align:right; }
 
-#shop-header { display:flex; justify-content:space-between; align-items:center; gap:8px; margin-bottom:8px; }
-#shop-gold { font-weight:bold; }
-.message { border:1px solid #000; padding:4px 6px; background:#fff; }
-.message.error { background:#000; color:#fff; }
-.item-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(150px,1fr)); gap:8px; }
-.item-card { border:1px solid #000; padding:8px; display:flex; flex-direction:column; gap:6px; background:#fff; min-height:150px; }
-.item-card .name { font-weight:bold; text-transform:uppercase; }
-.item-card .meta { font-size:12px; }
-.item-card .cost { font-weight:bold; }
-.item-card .owned { font-size:12px; }
-.item-card button { margin-top:auto; }
+#shop {
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+}
+#shop-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:16px;
+  border:2px solid var(--retro-black);
+  padding:16px;
+  background:repeating-linear-gradient(90deg, var(--retro-white) 0px, var(--retro-white) 12px, #ededed 12px, #ededed 24px);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+}
+#shop-gold {
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.message {
+  border:2px solid var(--retro-black);
+  padding:8px 12px;
+  background:repeating-linear-gradient(90deg, var(--retro-white) 0px, var(--retro-white) 16px, #f2f2f2 16px, #f2f2f2 32px);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+  letter-spacing:0.5px;
+  font-weight:bold;
+}
+.message.error {
+  background:var(--retro-black);
+  color:var(--retro-white);
+  box-shadow:0 0 0 3px var(--retro-white) inset;
+}
+.item-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(200px,1fr));
+  gap:16px;
+}
+.item-card {
+  border:2px solid var(--retro-black);
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  background:repeating-linear-gradient(0deg, var(--retro-white) 0px, var(--retro-white) 12px, #f3f3f3 12px, #f3f3f3 24px);
+  min-height:170px;
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+}
+.item-card .name {
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.item-card .meta {
+  font-size:12px;
+  color:#333;
+}
+.item-card .cost {
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.item-card .owned {
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.item-card button {
+  margin-top:auto;
+}
 
-.inventory-layout { display:flex; gap:16px; flex-wrap:wrap; }
-.inventory-column { flex:1; min-width:220px; }
-.inventory-column h3 { margin-top:0; border-bottom:1px solid #000; padding-bottom:4px; }
-.equipment-panel { max-width:320px; }
-.equipment-slots { display:grid; grid-template-columns:repeat(2, minmax(140px,1fr)); gap:8px; margin-bottom:16px; }
-.equipment-slot { border:1px solid #000; padding:8px; min-height:110px; display:flex; flex-direction:column; background:#fff; }
-.equipment-slot.empty { border-style:dashed; }
-.equipment-slot .slot-name { font-weight:bold; margin-bottom:4px; }
-.equipment-slot .item-name { flex-grow:1; }
-.equipment-slot button { margin-top:8px; }
+#battle {
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+}
+#battle-modes {
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  border:2px solid var(--retro-black);
+  padding:12px;
+  justify-content:space-between;
+  background:repeating-linear-gradient(90deg, var(--retro-white) 0px, var(--retro-white) 12px, #ededed 12px, #ededed 24px);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+}
+#battle-modes button {
+  flex:1;
+  min-width:160px;
+}
+#battle-area {
+  border:2px solid var(--retro-black);
+  padding:20px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+  min-height:320px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
 
-.loadout-summary { display:flex; flex-direction:column; gap:12px; }
-.loadout-summary .stats-table { width:100%; }
-.simple-list { list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:4px; }
-.simple-list li { border:1px solid #000; padding:4px 6px; background:#fff; }
-.challenge-panel { border:1px solid #000; padding:12px; display:flex; flex-direction:column; gap:12px; background:#fff; }
-.challenge-round { font-weight:bold; text-transform:uppercase; text-align:center; font-size:18px; }
-.challenge-reward, .challenge-next { border:1px solid #000; padding:6px; background:#fff; }
-.challenge-actions { display:flex; justify-content:center; gap:8px; }
-.challenge-message { align-self:center; }
-.challenge-empty { border:1px dashed #000; padding:8px; text-align:center; }
-.adventure-panel { border:1px solid #000; padding:12px; display:flex; flex-direction:column; gap:12px; background:#fff; }
-.adventure-status-text { font-weight:bold; text-transform:uppercase; text-align:center; font-size:18px; }
-.adventure-progress { display:flex; flex-direction:column; gap:4px; }
-.adventure-progress-bar { height:16px; border:2px solid #000; background:#dcdcdc; border-radius:0; overflow:hidden; }
+#inventory {
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+}
+.inventory-layout {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(280px,1fr));
+  gap:24px;
+}
+.inventory-column {
+  border:2px solid var(--retro-black);
+  padding:20px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+.inventory-column h3 {
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:2px;
+  border-bottom:2px solid var(--retro-black);
+  padding-bottom:6px;
+}
+.equipment-panel {
+  max-width:none;
+}
+.equipment-slots {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(160px,1fr));
+  gap:12px;
+  margin-bottom:8px;
+}
+.equipment-slot {
+  border:2px solid var(--retro-black);
+  padding:10px;
+  min-height:120px;
+  display:flex;
+  flex-direction:column;
+  background:repeating-linear-gradient(0deg, var(--retro-white) 0px, var(--retro-white) 14px, #f0f0f0 14px, #f0f0f0 28px);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+}
+.equipment-slot.empty {
+  border-style:dashed;
+}
+.equipment-slot .slot-name {
+  font-weight:bold;
+  margin-bottom:6px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.equipment-slot .item-name {
+  flex-grow:1;
+}
+.equipment-slot button {
+  margin-top:8px;
+}
+
+.loadout-summary {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.loadout-summary .stats-table {
+  width:100%;
+}
+.simple-list {
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.simple-list li {
+  border:2px solid var(--retro-black);
+  padding:6px 8px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:12px;
+}
+.challenge-panel {
+  border:2px solid var(--retro-black);
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+}
+.challenge-round {
+  font-weight:bold;
+  text-transform:uppercase;
+  text-align:center;
+  font-size:18px;
+  letter-spacing:2px;
+}
+.challenge-reward,
+.challenge-next {
+  border:2px solid var(--retro-black);
+  padding:8px 10px;
+  background:repeating-linear-gradient(90deg, var(--retro-white) 0px, var(--retro-white) 14px, #f1f1f1 14px, #f1f1f1 28px);
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
+.challenge-actions {
+  display:flex;
+  justify-content:center;
+  gap:12px;
+}
+.challenge-message {
+  align-self:center;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.challenge-empty {
+  border:2px dashed var(--retro-black);
+  padding:10px;
+  text-align:center;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
+.adventure-panel {
+  border:2px solid var(--retro-black);
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 4px var(--retro-black) inset;
+}
+.adventure-status-text {
+  font-weight:bold;
+  text-transform:uppercase;
+  text-align:center;
+  font-size:18px;
+  letter-spacing:2px;
+}
+.adventure-progress {
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.adventure-progress-bar {
+  height:16px;
+  border:2px solid var(--retro-black);
+  background:#dcdcdc;
+  border-radius:0;
+  overflow:hidden;
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
 .adventure-progress-bar .fill {
   height:100%;
   width:0%;
   background:repeating-linear-gradient(90deg, #111 0px, #111 8px, #2b2b2b 8px, #2b2b2b 16px);
   transition:width 0.4s steps(12);
 }
-.adventure-progress-label { text-align:center; font-size:12px; color:#111; text-transform:uppercase; letter-spacing:1px; }
-.adventure-timers { display:flex; justify-content:space-between; flex-wrap:wrap; gap:6px; font-size:14px; }
-.adventure-actions { display:flex; justify-content:center; gap:8px; flex-wrap:wrap; align-items:center; }
-.adventure-day-picker { display:flex; align-items:center; gap:6px; font-size:14px; }
-.adventure-day-picker select { font-family:'Courier New', monospace; padding:4px; border:1px solid #000; background:#fff; }
-.adventure-message { text-align:center; }
-.adventure-log { border:2px solid #000; background:#070707; color:#fff; padding:8px; max-height:260px; overflow-y:auto; display:flex; flex-direction:column; gap:8px; }
+.adventure-progress-label {
+  text-align:center;
+  font-size:12px;
+  color:#111;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.adventure-timers {
+  display:flex;
+  justify-content:space-between;
+  flex-wrap:wrap;
+  gap:8px;
+  font-size:14px;
+}
+.adventure-actions {
+  display:flex;
+  justify-content:center;
+  gap:12px;
+  flex-wrap:wrap;
+  align-items:center;
+}
+.adventure-day-picker {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  font-size:14px;
+}
+.adventure-day-picker select {
+  font-family:'Courier New', monospace;
+  padding:6px;
+  border:2px solid var(--retro-black);
+  background:var(--retro-white);
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
+.adventure-message {
+  text-align:center;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.adventure-log { border:2px solid var(--retro-black); background:#070707; color:#fff; padding:12px; max-height:260px; overflow-y:auto; display:flex; flex-direction:column; gap:10px; box-shadow:0 0 0 4px var(--retro-black) inset; }
 .adventure-log h3 { margin:0; font-size:16px; text-transform:uppercase; letter-spacing:1px; color:#fff; }
 .adventure-events { display:flex; flex-direction:column; gap:8px; }
 .adventure-event { border:1px solid #fff; padding:8px; background:#000; color:#fff; font-size:14px; display:flex; flex-direction:column; gap:6px; box-shadow:0 0 0 2px #000 inset; }
@@ -367,28 +904,120 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .event-card.opponent-card[data-result='defeat'] { border-color:#f28b82; }
 .event-card.opponent-card[data-result='victory'] { border-style:double; }
 .event-card.has-replay { box-shadow:0 0 0 1px #fff inset; }
-.adventure-history { border:1px solid #000; background:#f9f9f9; padding:8px; max-height:220px; overflow-y:auto; display:flex; flex-direction:column; gap:6px; }
-.adventure-history h3 { margin:0 0 6px; font-size:16px; text-transform:uppercase; }
-.adventure-history-entries { display:flex; flex-direction:column; gap:6px; }
-.adventure-history-entry { border:1px solid #d0d0d0; padding:6px; background:#fff; font-size:13px; display:flex; flex-direction:column; gap:2px; }
+.adventure-history {
+  border:2px solid var(--retro-black);
+  background:var(--retro-white);
+  padding:12px;
+  max-height:220px;
+  overflow-y:auto;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+}
+.adventure-history h3 {
+  margin:0 0 8px;
+  font-size:16px;
+  text-transform:uppercase;
+  letter-spacing:2px;
+}
+.adventure-history-entries {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.adventure-history-entry {
+  border:2px solid #d0d0d0;
+  padding:8px;
+  background:var(--retro-white);
+  font-size:13px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
 .adventure-history-entry.outcome-complete { border-color:#9ccc65; background:#eef9e6; }
 .adventure-history-entry.outcome-defeat { border-color:#f28b82; background:#ffe7e7; }
-.adventure-history-empty { border:1px dashed #bbb; padding:8px; text-align:center; font-style:italic; font-size:13px; background:#fff; }
+.adventure-history-empty {
+  border:2px dashed #bbb;
+  padding:10px;
+  text-align:center;
+  font-style:italic;
+  font-size:13px;
+  background:var(--retro-white);
+}
 .history-header { font-weight:bold; text-transform:uppercase; font-size:13px; }
 .history-details, .history-timeline, .history-rewards, .history-items { font-size:12px; }
 .history-items { font-style:italic; }
-.opponent-preview { border:1px solid #000; padding:8px; display:flex; flex-direction:column; gap:8px; background:#fff; }
-.opponent-header { display:flex; justify-content:space-between; align-items:flex-end; border-bottom:1px solid #000; padding-bottom:4px; }
-.opponent-name { font-weight:bold; text-transform:uppercase; }
+.opponent-preview {
+  border:2px solid var(--retro-black);
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  background:var(--retro-white);
+  box-shadow:0 0 0 3px var(--retro-black) inset;
+}
+.opponent-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  border-bottom:2px solid var(--retro-black);
+  padding-bottom:6px;
+}
+.opponent-name {
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
 .opponent-meta { font-size:12px; }
-.equipment-section, .rotation-section { display:flex; flex-direction:column; gap:4px; }
-.equipment-section .section-title, .rotation-section .section-title { font-weight:bold; text-transform:uppercase; border-bottom:1px solid #000; padding-bottom:2px; }
-.equipment-list { display:grid; grid-template-columns:repeat(auto-fit, minmax(140px,1fr)); gap:4px; }
-.equipment-entry { border:1px solid #000; padding:4px; display:flex; justify-content:space-between; background:#fff; }
+.equipment-section,
+.rotation-section {
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.equipment-section .section-title,
+.rotation-section .section-title {
+  font-weight:bold;
+  text-transform:uppercase;
+  border-bottom:2px solid var(--retro-black);
+  padding-bottom:4px;
+  letter-spacing:1px;
+}
+.equipment-list {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(140px,1fr));
+  gap:6px;
+}
+.equipment-entry {
+  border:2px solid var(--retro-black);
+  padding:6px;
+  display:flex;
+  justify-content:space-between;
+  background:var(--retro-white);
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
 .equipment-entry.empty { border-style:dashed; }
-.equipment-entry .slot { font-weight:bold; margin-right:4px; }
-.rotation-list { display:flex; flex-wrap:wrap; gap:4px; }
-.rotation-chip { border:1px solid #000; padding:2px 6px; background:#fff; font-size:12px; }
+.equipment-entry .slot {
+  font-weight:bold;
+  margin-right:4px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.rotation-list {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+}
+.rotation-chip {
+  border:2px solid var(--retro-black);
+  padding:4px 8px;
+  background:var(--retro-white);
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  box-shadow:0 0 0 2px var(--retro-black) inset;
+}
 .opponent-preview.compact { background:#000; color:#fff; border-color:#fff; box-shadow:0 0 0 2px #000 inset; font-size:12px; }
 .opponent-preview.compact .opponent-header { border-color:#fff; }
 .opponent-preview.compact .opponent-name { color:#fff; }


### PR DESCRIPTION
## Summary
- refresh the global UI theme with retro-inspired typography, borders, and background patterns
- restyle the shop, inventory, battle, and rotation panes so their layouts match the updated character view
- highlight the active navigation tab for clearer context across the interface

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca328b3c788320869e340f0f5858cb