### PR TITLE
Restyle UI tabs to match retro theme

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -6,16 +6,24 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="auth">
-    <input id="player-name" placeholder="Name" />
-    <button id="login-btn">Login</button>
-    <button id="register-btn">Register</button>
-    <div id="auth-error" class="hidden"></div>
+  <div id="auth" class="gate-panel">
+    <div class="gate-title">Armory Access</div>
+    <div class="gate-body">
+      <label for="player-name">Player Handle</label>
+      <input id="player-name" placeholder="Name" />
+      <div class="gate-actions">
+        <button id="login-btn">Login</button>
+        <button id="register-btn">Register</button>
+      </div>
+      <div id="auth-error" class="message hidden"></div>
+    </div>
   </div>
-  <div id="character-select" class="hidden">
-    <h2>Select Character</h2>
-    <ul id="character-list"></ul>
-    <button id="create-character">Create Character</button>
+  <div id="character-select" class="gate-panel hidden">
+    <div class="gate-title">Select Your Fighter</div>
+    <div class="gate-body">
+      <ul id="character-list" class="character-list"></ul>
+      <button id="create-character">Create Character</button>
+    </div>
   </div>
   <div id="name-dialog" class="hidden">
     <div class="dialog-box">
@@ -28,7 +36,7 @@
     </div>
   </div>
   <div id="game" class="hidden">
-    <nav id="tabs">
+    <nav id="tabs" class="tab-bar">
       <button data-tab="shop">Shop</button>
       <button data-tab="character">Character</button>
       <button data-tab="inventory">Inventory</button>
@@ -36,61 +44,138 @@
       <button data-tab="rotation">Rotation</button>
     </nav>
     <section id="content">
-      <div id="shop" class="tab-pane active">
-        <div id="shop-header">
-          <div id="shop-gold">Gold: 0</div>
-          <div id="shop-message" class="message hidden"></div>
-        </div>
-        <div id="shop-grid" class="item-grid"></div>
-      </div>
-      <div id="character" class="tab-pane"></div>
-      <div id="inventory" class="tab-pane">
-        <div id="inventory-message" class="message hidden"></div>
-        <div class="inventory-layout">
-          <div class="inventory-column">
-            <h3>Owned Gear</h3>
-            <div id="inventory-grid" class="item-grid"></div>
-          </div>
-          <div class="inventory-column equipment-panel">
-            <h3>Equipped</h3>
-            <div id="equipment-slots" class="equipment-slots"></div>
-            <h3>Loadout Summary</h3>
-            <div id="loadout-summary" class="loadout-summary"></div>
-          </div>
-        </div>
-      </div>
-      <div id="battle" class="tab-pane">
-        <div id="battle-modes">
-          <button data-mode="matchmaking">Matchmaking</button>
-          <button data-mode="challenge">Challenge</button>
-          <button data-mode="adventure">Adventure</button>
-        </div>
-        <div id="battle-area"></div>
-      </div>
-      <div id="rotation" class="tab-pane">
-        <div id="rotation-container">
-          <div class="rotation-settings">
-            <label for="rotation-damage-type">Damage Type</label>
-            <select id="rotation-damage-type">
-              <option value="melee">Melee</option>
-              <option value="magic">Magic</option>
-            </select>
-          </div>
-          <div class="lists">
-            <div class="pool">
-              <h3>Physical Abilities</h3>
-              <div id="physical-abilities" class="ability-grid"></div>
-              <h3>Magical Abilities</h3>
-              <div id="magical-abilities" class="ability-grid"></div>
+      <div id="shop" class="tab-pane active tab-page">
+        <div class="page-hero">
+          <div class="hero-emblem emblem-small">SH</div>
+          <div class="hero-body">
+            <div class="hero-header">
+              <div class="hero-name">Shop</div>
+              <div class="hero-type">Pixel Bazaar</div>
             </div>
-            <div>
-              <h3>Rotation</h3>
-              <ul id="rotation-list" class="drop-zone"></ul>
-              <div id="rotation-delete" class="drop-zone delete-zone">Drop here to remove</div>
+            <div class="hero-meta-grid">
+              <div class="hero-meta-item">
+                <div class="label">Wallet</div>
+                <div class="value" id="shop-gold">Gold: 0</div>
+              </div>
+              <div class="hero-meta-item full">
+                <div class="label">Status</div>
+                <div id="shop-message" class="message hidden"></div>
+              </div>
             </div>
           </div>
-          <button id="save-rotation">Save Rotation</button>
-          <div id="rotation-error" class="hidden"></div>
+        </div>
+        <div class="page-section">
+          <div class="section-title">Available Stock</div>
+          <div id="shop-grid" class="item-grid"></div>
+        </div>
+      </div>
+      <div id="character" class="tab-pane tab-page"></div>
+      <div id="inventory" class="tab-pane tab-page">
+        <div class="page-hero">
+          <div class="hero-emblem emblem-small">IV</div>
+          <div class="hero-body">
+            <div class="hero-header">
+              <div class="hero-name">Inventory</div>
+              <div class="hero-type">Arsenal Locker</div>
+            </div>
+            <div class="hero-meta-grid">
+              <div class="hero-meta-item full">
+                <div class="label">Status</div>
+                <div id="inventory-message" class="message hidden"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="page-section inventory-section">
+          <div class="section-title">Loadout Control</div>
+          <div class="inventory-layout">
+            <div class="inventory-column">
+              <h3>Owned Gear</h3>
+              <div id="inventory-grid" class="item-grid"></div>
+            </div>
+            <div class="inventory-column equipment-panel">
+              <h3>Equipped</h3>
+              <div id="equipment-slots" class="equipment-slots"></div>
+              <h3>Loadout Summary</h3>
+              <div id="loadout-summary" class="loadout-summary"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="battle" class="tab-pane tab-page">
+        <div class="page-hero">
+          <div class="hero-emblem emblem-small">BT</div>
+          <div class="hero-body">
+            <div class="hero-header">
+              <div class="hero-name">Battle</div>
+              <div class="hero-type">Live Engagements</div>
+            </div>
+            <div class="hero-meta-grid">
+              <div class="hero-meta-item">
+                <div class="label">Directive</div>
+                <div class="value">Select a mode to deploy your rotation.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="page-section battle-section">
+          <div class="section-title">Engagement Console</div>
+          <div id="battle-modes" class="mode-selector">
+            <button data-mode="matchmaking">Matchmaking</button>
+            <button data-mode="challenge">Challenge</button>
+            <button data-mode="adventure">Adventure</button>
+          </div>
+          <div id="battle-area" class="battle-area"></div>
+        </div>
+      </div>
+      <div id="rotation" class="tab-pane tab-page">
+        <div class="page-hero">
+          <div class="hero-emblem emblem-small">RT</div>
+          <div class="hero-body">
+            <div class="hero-header">
+              <div class="hero-name">Rotation</div>
+              <div class="hero-type">Command Script</div>
+            </div>
+            <div class="hero-meta-grid">
+              <div class="hero-meta-item">
+                <div class="label">Basic Attack</div>
+                <div class="value" id="rotation-basic-type">Auto</div>
+              </div>
+              <div class="hero-meta-item full">
+                <div class="label">Notes</div>
+                <div class="value">Drag abilities to craft a loop of three or more.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="page-section rotation-section">
+          <div class="section-title">Rotation Planner</div>
+          <div id="rotation-container" class="rotation-shell">
+            <div class="rotation-settings">
+              <label for="rotation-damage-type">Damage Type</label>
+              <select id="rotation-damage-type">
+                <option value="melee">Melee</option>
+                <option value="magic">Magic</option>
+              </select>
+            </div>
+            <div class="rotation-grid">
+              <div class="pool">
+                <h3>Physical Abilities</h3>
+                <div id="physical-abilities" class="ability-grid"></div>
+                <h3>Magical Abilities</h3>
+                <div id="magical-abilities" class="ability-grid"></div>
+              </div>
+              <div class="rotation-drop">
+                <h3>Rotation</h3>
+                <ul id="rotation-list" class="drop-zone"></ul>
+                <div id="rotation-delete" class="drop-zone delete-zone">Drop here to remove</div>
+              </div>
+            </div>
+            <div class="rotation-footer">
+              <button id="save-rotation">Save Rotation</button>
+              <div id="rotation-error" class="message hidden"></div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/ui/main.js
+++ b/ui/main.js
@@ -8,6 +8,7 @@ let rotationInitialized = false;
 let rotationDamageType = 'melee';
 
 const rotationDamageTypeSelect = document.getElementById('rotation-damage-type');
+const rotationBasicTypeLabel = document.getElementById('rotation-basic-type');
 
 function normalizeDamageType(value) {
   return value === 'magic' ? 'magic' : 'melee';
@@ -17,6 +18,10 @@ function setRotationDamageType(value) {
   rotationDamageType = normalizeDamageType(value);
   if (rotationDamageTypeSelect) {
     rotationDamageTypeSelect.value = rotationDamageType;
+  }
+  if (rotationBasicTypeLabel) {
+    rotationBasicTypeLabel.textContent =
+      rotationDamageType === 'magic' ? 'Magic' : 'Melee';
   }
 }
 
@@ -651,6 +656,7 @@ function initTabs() {
     buttons.forEach(btn => {
       btn.addEventListener('click', () => {
         const target = btn.getAttribute('data-tab');
+        buttons.forEach(b => b.classList.toggle('active', b === btn));
         document.querySelectorAll('.tab-pane').forEach(pane => {
           pane.classList.toggle('active', pane.id === target);
         });

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,67 +1,428 @@
 * { box-sizing: border-box; }
-body { margin:0; background:#fff; color:#000; font-family:'Courier New', monospace; }
-button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor:pointer; font-family:'Courier New', monospace; }
-#tabs { display:flex; border-bottom:1px solid #000; }
-#tabs button { flex:1; border-bottom:none; }
-#content { border:1px solid #000; padding:8px; }
+
+body {
+  margin: 0;
+  background: repeating-linear-gradient(0deg, #fff 0px, #fff 12px, #f5f5f5 12px, #f5f5f5 24px);
+  color: #000;
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.5px;
+}
+
+button {
+  background: #fff;
+  color: #000;
+  border: 2px solid #000;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  box-shadow: 0 0 0 2px #000 inset;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+button:hover,
+button:focus {
+  background: #000;
+  color: #fff;
+  outline: none;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: #fff;
+  color: #000;
+}
+
+input,
+select {
+  background: #fff;
+  border: 2px solid #000;
+  padding: 8px;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+select {
+  cursor: pointer;
+}
+
+.hidden { display:none !important; }
+
+.message {
+  border: 2px solid #000;
+  padding: 6px 8px;
+  background: #fff;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.message.error {
+  background: #000;
+  color: #fff;
+}
+
+#game {
+  max-width: 1100px;
+  margin: 32px auto 48px;
+  padding: 24px;
+  background: #fff;
+  border: 4px double #000;
+  box-shadow: 0 0 0 8px #000 inset;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.tab-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  padding: 16px;
+  background: #000;
+  border: 4px double #000;
+  box-shadow: 0 0 0 6px #000 inset;
+}
+
+#tabs button {
+  border: 2px solid #fff;
+  background: #fff;
+  color: #000;
+  padding: 12px;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+#tabs button.active {
+  background: #000;
+  color: #fff;
+  border-color: #fff;
+}
+
+#content {
+  border: 4px double #000;
+  padding: 24px;
+  background: #fdfdfd;
+  box-shadow: 0 0 0 6px #000 inset;
+}
+
 .tab-pane { display:none; }
 .tab-pane.active { display:block; }
-.tab-pane#character.active { display:block; }
-.hidden { display:none !important; }
-#auth, #character-select { border:1px solid #000; padding:8px; margin:20px auto; }
-#game { max-width:800px; margin:20px auto; }
-#auth { max-width:300px; }
-#character-select { max-width:600px; }
-#auth input { width:100%; margin-bottom:8px; }
-#character-list { list-style:none; padding:0; }
-#character-list li { margin-bottom:4px; display:flex; justify-content:space-between; align-items:center; }
-#character-list li .info { white-space:pre; margin-right:8px; }
+.tab-pane.active.tab-page { display:flex; }
+.tab-page { display:flex; flex-direction:column; gap:24px; }
 
-#rotation-container {
-  margin-top:8px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-}
-#rotation-container .rotation-settings {
-  width:100%;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:8px;
-}
-#rotation-container .rotation-settings label {
-  font-weight:bold;
-}
-#rotation-container .lists {
-  display:flex;
-  gap:32px;
-  align-items:flex-start;
-  justify-content:center;
-}
-#rotation-container .pool {
-  max-width:400px;
-}
-#rotation-container .ability-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(100px,1fr)); gap:8px; margin-bottom:16px; }
-#rotation-container .ability-card { border:1px solid #000; padding:8px; text-align:center; cursor:move; }
-#rotation-container ul { list-style:none; padding:0 0 8px; margin:0; border:1px solid #000; min-width:150px; min-height:200px; max-height:300px; overflow-y:auto; }
-#rotation-container li { border-bottom:1px solid #000; padding:4px; cursor:move; }
-#rotation-container li:last-child { border-bottom:none; }
-#rotation-error { margin-top:8px; }
-
-#rotation-delete {
-  border:1px dashed #000;
-  padding:8px;
-  min-height:40px;
-  margin-top:8px;
-  text-align:center;
-  color:#a00;
+.gate-panel {
+  max-width: 420px;
+  margin: 48px auto;
+  border: 4px double #000;
+  background: #fff;
+  box-shadow: 0 0 0 8px #000 inset;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
-#name-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
-#name-dialog .dialog-box { border:1px solid #000; padding:8px; }
-#name-dialog input { width:200px; margin-top:4px; }
-#name-dialog .dialog-buttons { margin-top:8px; text-align:right; }
+.gate-title {
+  font-size: 20px;
+  font-weight: bold;
+  text-align: center;
+  letter-spacing: 2px;
+}
+
+.gate-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.gate-body input {
+  width: 100%;
+}
+
+.gate-body label {
+  font-weight: bold;
+  font-size: 12px;
+}
+
+.gate-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.character-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.character-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 2px solid #000;
+  padding: 10px 12px;
+  background: #fff;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+.character-list li .info {
+  white-space: pre;
+  margin-right: 8px;
+  font-size: 12px;
+  letter-spacing: 1px;
+}
+
+.page-hero {
+  display: flex;
+  gap: 16px;
+  align-items: stretch;
+  border: 2px solid #000;
+  background: #fff;
+  padding: 16px;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+.page-hero .hero-emblem {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.emblem-small {
+  width: 110px;
+  min-height: 110px;
+  font-size: 36px;
+}
+
+.hero-meta-item.full {
+  grid-column: 1 / -1;
+}
+
+.hero-meta-item.full .message,
+.hero-meta-item.full .value {
+  display: block;
+  width: 100%;
+}
+
+.page-section {
+  border: 2px solid #000;
+  background: #fff;
+  padding: 16px;
+  box-shadow: 0 0 0 4px #000 inset;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-title {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  font-weight: bold;
+}
+
+.mode-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.mode-selector button {
+  width: 100%;
+  min-height: 52px;
+}
+
+.battle-area {
+  border: 2px solid #000;
+  background: #fff;
+  padding: 16px;
+  min-height: 220px;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+.inventory-section .inventory-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.inventory-column {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 2px solid #000;
+  background: #fff;
+  padding: 12px;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.inventory-column h3 {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 14px;
+  letter-spacing: 1px;
+  border-bottom: 2px solid #000;
+  padding-bottom: 6px;
+}
+
+.rotation-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.rotation-shell .rotation-settings {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  align-self: stretch;
+  border: 2px solid #000;
+  background: #fff;
+  padding: 12px;
+  box-shadow: 0 0 0 3px #000 inset;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.rotation-shell .rotation-settings select {
+  min-width: 140px;
+}
+
+.rotation-shell .rotation-grid {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.rotation-shell .pool,
+.rotation-shell .rotation-drop {
+  flex: 1;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 2px solid #000;
+  background: #fff;
+  padding: 12px;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.rotation-shell h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 14px;
+}
+
+.rotation-shell .ability-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.rotation-shell .ability-card {
+  border: 2px solid #000;
+  padding: 8px;
+  text-align: center;
+  cursor: move;
+  background: #fff;
+  box-shadow: 0 0 0 3px #000 inset;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.rotation-shell ul {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  border: 2px solid #000;
+  min-height: 240px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: #fff;
+  box-shadow: 0 0 0 3px #000 inset;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rotation-shell li {
+  border: 2px solid #000;
+  padding: 6px;
+  cursor: move;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: #fff;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.rotation-shell .delete-zone {
+  border: 2px dashed #000;
+  padding: 10px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background: #fff;
+  box-shadow: 0 0 0 3px #000 inset;
+  color: #a00;
+}
+
+.rotation-shell .rotation-footer {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.rotation-shell .rotation-footer .message {
+  margin: 0;
+}
+
+.rotation-shell #rotation-error {
+  min-width: 200px;
+}
+
+#name-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#name-dialog .dialog-box {
+  border: 3px solid #000;
+  padding: 16px;
+  background: #fff;
+  box-shadow: 0 0 0 6px #000 inset;
+}
+
+#name-dialog input {
+  width: 220px;
+  margin-top: 8px;
+}
+
+#name-dialog .dialog-buttons {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
 
 .tooltip { position:absolute; background:#fff; border:1px solid #000; padding:4px; pointer-events:none; z-index:1000; }
 .tooltip.hidden { display:none; }
@@ -70,12 +431,59 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .tooltip-grid { display:grid; grid-template-columns:auto auto; gap:2px 8px; }
 .tooltip-grid .label { font-weight:bold; text-align:right; }
 
-#battle-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; padding:16px; z-index:1000; }
-#battle-dialog .dialog-box { border:1px solid #000; padding:16px; width:100%; max-width:800px; background:#fff; display:flex; flex-direction:column; }
-#battle-dialog .combatants-row { display:flex; gap:16px; margin-bottom:16px; }
-#battle-dialog .combatant { flex:1; border:1px solid #000; padding:12px; }
-#battle-dialog .combatant .name { font-weight:bold; text-align:center; margin-bottom:8px; }
-#battle-dialog .bars { display:flex; flex-direction:column; gap:6px; }
+#battle-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+#battle-dialog .dialog-box {
+  border: 3px solid #000;
+  padding: 20px;
+  width: 100%;
+  max-width: 820px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 0 0 6px #000 inset;
+}
+
+#battle-dialog .combatants-row {
+  display: flex;
+  gap: 16px;
+}
+
+#battle-dialog .combatant {
+  flex: 1;
+  border: 2px solid #000;
+  padding: 12px;
+  background: #fff;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+#battle-dialog .combatant .name {
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+#battle-dialog .bars {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .bar {
   position:relative;
   border:1px solid #000;
@@ -109,11 +517,44 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   pointer-events:none;
   white-space:nowrap;
 }
-#battle-log { border:1px solid #000; height:220px; overflow-y:auto; padding:8px; display:flex; flex-direction:column; gap:8px; margin-top:16px; }
-#battle-log .log-message { max-width:75%; padding:6px 8px; border:1px solid #000; }
-#battle-log .log-message.you { align-self:flex-start; background:#000; color:#fff; border-color:#000; }
-#battle-log .log-message.opponent { align-self:flex-end; background:#fff; color:#000; border-color:#000; text-align:right; }
-#battle-log .log-message.neutral { align-self:center; background:#fff; color:#000; border-style:dashed; text-align:center; }
+#battle-log {
+  border: 2px solid #000;
+  height: 220px;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+  background: #fff;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+#battle-log .log-message {
+  max-width: 75%;
+  padding: 6px 8px;
+  border: 2px solid #000;
+  background: #fff;
+}
+#battle-log .log-message.you {
+  align-self: flex-start;
+  background: #000;
+  color: #fff;
+  border-color: #000;
+}
+#battle-log .log-message.opponent {
+  align-self: flex-end;
+  background: #fff;
+  color: #000;
+  border-color: #000;
+  text-align: right;
+}
+#battle-log .log-message.neutral {
+  align-self: center;
+  background: #fff;
+  color: #000;
+  border-style: dashed;
+  text-align: center;
+}
 #battle-dialog .dialog-buttons { text-align:right; margin-top:16px; }
 
 .stats-table { border-collapse:collapse; margin-bottom:8px; width:100%; }
@@ -291,69 +732,324 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   50% { opacity:0.4; }
 }
 
-#levelup-dialog { position:fixed; top:0; left:0; width:100%; height:100%; background:#fff; display:flex; align-items:center; justify-content:center; }
-#levelup-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
-#levelup-dialog .dialog-buttons { margin-top:8px; text-align:right; }
-
-#shop-header { display:flex; justify-content:space-between; align-items:center; gap:8px; margin-bottom:8px; }
-#shop-gold { font-weight:bold; }
-.message { border:1px solid #000; padding:4px 6px; background:#fff; }
-.message.error { background:#000; color:#fff; }
-.item-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(150px,1fr)); gap:8px; }
-.item-card { border:1px solid #000; padding:8px; display:flex; flex-direction:column; gap:6px; background:#fff; min-height:150px; }
-.item-card .name { font-weight:bold; text-transform:uppercase; }
-.item-card .meta { font-size:12px; }
-.item-card .cost { font-weight:bold; }
-.item-card .owned { font-size:12px; }
-.item-card button { margin-top:auto; }
-
-.inventory-layout { display:flex; gap:16px; flex-wrap:wrap; }
-.inventory-column { flex:1; min-width:220px; }
-.inventory-column h3 { margin-top:0; border-bottom:1px solid #000; padding-bottom:4px; }
-.equipment-panel { max-width:320px; }
-.equipment-slots { display:grid; grid-template-columns:repeat(2, minmax(140px,1fr)); gap:8px; margin-bottom:16px; }
-.equipment-slot { border:1px solid #000; padding:8px; min-height:110px; display:flex; flex-direction:column; background:#fff; }
-.equipment-slot.empty { border-style:dashed; }
-.equipment-slot .slot-name { font-weight:bold; margin-bottom:4px; }
-.equipment-slot .item-name { flex-grow:1; }
-.equipment-slot button { margin-top:8px; }
-
-.loadout-summary { display:flex; flex-direction:column; gap:12px; }
-.loadout-summary .stats-table { width:100%; }
-.simple-list { list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:4px; }
-.simple-list li { border:1px solid #000; padding:4px 6px; background:#fff; }
-.challenge-panel { border:1px solid #000; padding:12px; display:flex; flex-direction:column; gap:12px; background:#fff; }
-.challenge-round { font-weight:bold; text-transform:uppercase; text-align:center; font-size:18px; }
-.challenge-reward, .challenge-next { border:1px solid #000; padding:6px; background:#fff; }
-.challenge-actions { display:flex; justify-content:center; gap:8px; }
-.challenge-message { align-self:center; }
-.challenge-empty { border:1px dashed #000; padding:8px; text-align:center; }
-.adventure-panel { border:1px solid #000; padding:12px; display:flex; flex-direction:column; gap:12px; background:#fff; }
-.adventure-status-text { font-weight:bold; text-transform:uppercase; text-align:center; font-size:18px; }
-.adventure-progress { display:flex; flex-direction:column; gap:4px; }
-.adventure-progress-bar { height:16px; border:2px solid #000; background:#dcdcdc; border-radius:0; overflow:hidden; }
-.adventure-progress-bar .fill {
-  height:100%;
-  width:0%;
-  background:repeating-linear-gradient(90deg, #111 0px, #111 8px, #2b2b2b 8px, #2b2b2b 16px);
-  transition:width 0.4s steps(12);
+#levelup-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.adventure-progress-label { text-align:center; font-size:12px; color:#111; text-transform:uppercase; letter-spacing:1px; }
-.adventure-timers { display:flex; justify-content:space-between; flex-wrap:wrap; gap:6px; font-size:14px; }
-.adventure-actions { display:flex; justify-content:center; gap:8px; flex-wrap:wrap; align-items:center; }
-.adventure-day-picker { display:flex; align-items:center; gap:6px; font-size:14px; }
-.adventure-day-picker select { font-family:'Courier New', monospace; padding:4px; border:1px solid #000; background:#fff; }
+
+#levelup-dialog .dialog-box {
+  border: 3px solid #000;
+  padding: 16px;
+  width: 320px;
+  background: #fff;
+  box-shadow: 0 0 0 6px #000 inset;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#levelup-dialog .dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+#shop-gold {
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+
+.item-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.item-card {
+  border: 2px solid #000;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #fff;
+  min-height: 170px;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.item-card .name {
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.item-card .meta {
+  font-size: 12px;
+  letter-spacing: 0.5px;
+}
+
+.item-card .cost {
+  font-weight: bold;
+}
+
+.item-card .owned {
+  font-size: 12px;
+}
+
+.item-card button {
+  margin-top: auto;
+}
+
+.equipment-panel {
+  max-width: 360px;
+}
+
+.equipment-slots {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.equipment-slot {
+  border: 2px solid #000;
+  padding: 12px;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.equipment-slot.empty {
+  border-style: dashed;
+}
+
+.equipment-slot .slot-name {
+  font-weight: bold;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.equipment-slot .item-name {
+  flex-grow: 1;
+}
+
+.equipment-slot button {
+  margin-top: 8px;
+}
+
+.loadout-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.loadout-summary .stats-table {
+  width: 100%;
+}
+
+.simple-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.simple-list li {
+  border: 2px solid #000;
+  padding: 6px 8px;
+  background: #fff;
+  box-shadow: 0 0 0 2px #000 inset;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.challenge-panel {
+  border: 2px solid #000;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: #fff;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+.challenge-round {
+  font-weight: bold;
+  text-transform: uppercase;
+  text-align: center;
+  font-size: 18px;
+  letter-spacing: 1px;
+}
+
+.challenge-reward,
+.challenge-next {
+  border: 2px solid #000;
+  padding: 8px;
+  background: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.challenge-actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.challenge-message {
+  align-self: center;
+}
+
+.challenge-empty {
+  border: 2px dashed #000;
+  padding: 12px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background: #fff;
+}
+
+.adventure-panel {
+  border: 2px solid #000;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: #fff;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+.adventure-status-text {
+  font-weight: bold;
+  text-transform: uppercase;
+  text-align: center;
+  font-size: 18px;
+  letter-spacing: 1px;
+}
+
+.adventure-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.adventure-progress-bar {
+  height: 16px;
+  border: 2px solid #000;
+  background: #dcdcdc;
+  border-radius: 0;
+  overflow: hidden;
+}
+
+.adventure-progress-bar .fill {
+  height: 100%;
+  width: 0%;
+  background: repeating-linear-gradient(90deg, #111 0px, #111 8px, #2b2b2b 8px, #2b2b2b 16px);
+  transition: width 0.4s steps(12);
+}
+
+.adventure-progress-label {
+  text-align: center;
+  font-size: 12px;
+  color: #111;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.adventure-timers {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.adventure-actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.adventure-day-picker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.adventure-day-picker select {
+  font-family: 'Courier New', monospace;
+  padding: 6px;
+  border: 2px solid #000;
+  background: #fff;
+}
+
 .adventure-message { text-align:center; }
 .adventure-log { border:2px solid #000; background:#070707; color:#fff; padding:8px; max-height:260px; overflow-y:auto; display:flex; flex-direction:column; gap:8px; }
 .adventure-log h3 { margin:0; font-size:16px; text-transform:uppercase; letter-spacing:1px; color:#fff; }
-.adventure-events { display:flex; flex-direction:column; gap:8px; }
-.adventure-event { border:1px solid #fff; padding:8px; background:#000; color:#fff; font-size:14px; display:flex; flex-direction:column; gap:6px; box-shadow:0 0 0 2px #000 inset; }
-.adventure-event .event-header { display:flex; justify-content:space-between; font-size:11px; color:#ccc; letter-spacing:1px; text-transform:uppercase; }
-.adventure-event .event-message { font-weight:bold; }
-.adventure-event .event-meta { font-size:12px; color:#e0e0e0; }
-.adventure-event .event-cards { display:flex; flex-wrap:wrap; gap:6px; }
-.adventure-event.has-cards .event-message { margin-bottom:2px; }
-.adventure-event.empty { border:1px dashed #fff; text-align:center; font-style:italic; color:#8a8a8a; padding:12px; background:#000; }
+.adventure-event {
+  border: 2px solid #fff;
+  padding: 10px;
+  background: #000;
+  color: #fff;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.adventure-event .event-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #ccc;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.adventure-event .event-message {
+  font-weight: bold;
+}
+
+.adventure-event .event-meta {
+  font-size: 12px;
+  color: #e0e0e0;
+}
+
+.adventure-event .event-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.adventure-event.has-cards .event-message {
+  margin-bottom: 2px;
+}
+
+.adventure-event.empty {
+  border: 2px dashed #fff;
+  text-align: center;
+  font-style: italic;
+  color: #8a8a8a;
+  padding: 12px;
+  background: #000;
+}
+
 .event-card { border:1px solid #fff; background:#111; color:#fff; padding:6px 8px; font-size:12px; display:flex; flex-direction:column; gap:2px; cursor:pointer; transition:background 0.2s ease; }
 .event-card .card-title { font-size:11px; text-transform:uppercase; letter-spacing:0.5px; color:#c7c7c7; }
 .event-card .card-body { font-size:12px; font-weight:bold; }
@@ -367,22 +1063,93 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .event-card.opponent-card[data-result='defeat'] { border-color:#f28b82; }
 .event-card.opponent-card[data-result='victory'] { border-style:double; }
 .event-card.has-replay { box-shadow:0 0 0 1px #fff inset; }
-.adventure-history { border:1px solid #000; background:#f9f9f9; padding:8px; max-height:220px; overflow-y:auto; display:flex; flex-direction:column; gap:6px; }
-.adventure-history h3 { margin:0 0 6px; font-size:16px; text-transform:uppercase; }
-.adventure-history-entries { display:flex; flex-direction:column; gap:6px; }
-.adventure-history-entry { border:1px solid #d0d0d0; padding:6px; background:#fff; font-size:13px; display:flex; flex-direction:column; gap:2px; }
-.adventure-history-entry.outcome-complete { border-color:#9ccc65; background:#eef9e6; }
-.adventure-history-entry.outcome-defeat { border-color:#f28b82; background:#ffe7e7; }
-.adventure-history-empty { border:1px dashed #bbb; padding:8px; text-align:center; font-style:italic; font-size:13px; background:#fff; }
+.adventure-history {
+  border: 2px solid #000;
+  background: #f9f9f9;
+  padding: 12px;
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 0 0 3px #000 inset;
+}
+
+.adventure-history h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.adventure-history-entries {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.adventure-history-entry {
+  border: 2px solid #d0d0d0;
+  padding: 6px;
+  background: #fff;
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.adventure-history-entry.outcome-complete {
+  border-color: #9ccc65;
+  background: #eef9e6;
+}
+
+.adventure-history-entry.outcome-defeat {
+  border-color: #f28b82;
+  background: #ffe7e7;
+}
+
+.adventure-history-empty {
+  border: 2px dashed #bbb;
+  padding: 8px;
+  text-align: center;
+  font-style: italic;
+  font-size: 13px;
+  background: #fff;
+}
+
 .history-header { font-weight:bold; text-transform:uppercase; font-size:13px; }
 .history-details, .history-timeline, .history-rewards, .history-items { font-size:12px; }
 .history-items { font-style:italic; }
-.opponent-preview { border:1px solid #000; padding:8px; display:flex; flex-direction:column; gap:8px; background:#fff; }
-.opponent-header { display:flex; justify-content:space-between; align-items:flex-end; border-bottom:1px solid #000; padding-bottom:4px; }
-.opponent-name { font-weight:bold; text-transform:uppercase; }
-.opponent-meta { font-size:12px; }
-.equipment-section, .rotation-section { display:flex; flex-direction:column; gap:4px; }
-.equipment-section .section-title, .rotation-section .section-title { font-weight:bold; text-transform:uppercase; border-bottom:1px solid #000; padding-bottom:2px; }
+.opponent-preview {
+  border: 2px solid #000;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: #fff;
+  box-shadow: 0 0 0 4px #000 inset;
+}
+
+.opponent-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  border-bottom: 2px solid #000;
+  padding-bottom: 6px;
+}
+
+.opponent-name {
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.opponent-meta {
+  font-size: 12px;
+}
+
+.equipment-section { display:flex; flex-direction:column; gap:4px; }
+.equipment-section .section-title { font-weight:bold; text-transform:uppercase; border-bottom:2px solid #000; padding-bottom:4px; }
 .equipment-list { display:grid; grid-template-columns:repeat(auto-fit, minmax(140px,1fr)); gap:4px; }
 .equipment-entry { border:1px solid #000; padding:4px; display:flex; justify-content:space-between; background:#fff; }
 .equipment-entry.empty { border-style:dashed; }


### PR DESCRIPTION
## Summary
- restyle the login, character select, and main tab layouts to use page heroes, section panels, and rotation planner messaging that match the retro character page aesthetic
- overhaul shared styles for the black and white pixel theme, including tab navigation, shop and inventory grids, battle/adventure panels, and rotation drag-and-drop areas
- surface the current basic attack type and active tab state in the client script so UI labels and navigation highlight correctly

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca35aa7f948320859850237d20e4e7