### PR TITLE
Add useable item slot indicators to battle UI

### DIFF
--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -117,6 +117,17 @@ function state(c) {
     maxHealth: c.derived.health,
     maxMana: c.derived.mana,
     maxStamina: c.derived.stamina,
+    useables: USEABLE_SLOTS.map(slot => {
+      const entry =
+        c.useables && Array.isArray(c.useables)
+          ? c.useables.find(useable => useable && useable.slot === slot)
+          : null;
+      return {
+        slot,
+        hasItem: !!entry,
+        used: !!(entry && entry.used),
+      };
+    }),
   };
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -76,6 +76,28 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #battle-dialog .combatant { flex:1; border:1px solid #000; padding:12px; }
 #battle-dialog .combatant .name { font-weight:bold; text-align:center; margin-bottom:8px; }
 #battle-dialog .bars { display:flex; flex-direction:column; gap:6px; }
+#battle-dialog .useable-slots { display:flex; justify-content:center; gap:8px; margin-top:8px; }
+#battle-dialog .useable-slot { width:18px; height:18px; border:1px solid #000; background:#fff; position:relative; }
+#battle-dialog .useable-slot::before,
+#battle-dialog .useable-slot::after {
+  content:"";
+  position:absolute;
+  top:3px;
+  bottom:3px;
+  left:50%;
+  width:2px;
+  background:#000;
+  transform-origin:center;
+  opacity:0;
+}
+#battle-dialog .useable-slot::before { transform:translateX(-50%) rotate(45deg); }
+#battle-dialog .useable-slot::after { transform:translateX(-50%) rotate(-45deg); }
+#battle-dialog .useable-slot.available { background:#000; }
+#battle-dialog .useable-slot.empty::before,
+#battle-dialog .useable-slot.empty::after,
+#battle-dialog .useable-slot.used::before,
+#battle-dialog .useable-slot.used::after { opacity:1; }
+#battle-dialog .useable-slot.used { background:#fff; }
 .bar {
   position:relative;
   border:1px solid #000;


### PR DESCRIPTION
## Summary
- include useable slot availability details in combat state updates
- display useable slot indicators beneath combatant resource bars and keep them synced during fights
- style the indicators to show when an item is ready versus consumed or empty

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb3c986b208320a41c05ca725d76f7