### PR TITLE
Add Ice Scroll useable item with reactive freeze effect

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -337,6 +337,30 @@
       "useEffect": { "type": "Heal", "value": 50 },
       "useDuration": "instant",
       "useConsumed": true
+    },
+    {
+      "id": "useable_ice_scroll",
+      "name": "Ice Scroll",
+      "slot": "useable",
+      "type": "scroll",
+      "category": "Scrolls",
+      "rarity": "Rare",
+      "cost": 120,
+      "useTrigger": { "type": "reactive" },
+      "useConsumed": true,
+      "reactiveEffects": [
+        {
+          "trigger": { "type": "damageTaken", "damageType": "physical" },
+          "chance": 0.25,
+          "target": "attacker",
+          "consumed": true,
+          "effect": {
+            "type": "Stun",
+            "duration": 0,
+            "durationFromTargetAttackInterval": true
+          }
+        }
+      ]
     }
   ]
 }

--- a/domain/item.js
+++ b/domain/item.js
@@ -20,6 +20,7 @@ class Item {
     useEffect = null,
     useConsumed = false,
     useDuration = null,
+    reactiveEffects = [],
   }) {
     this.id = id;
     this.name = name;
@@ -41,6 +42,7 @@ class Item {
     this.useEffect = useEffect;
     this.useConsumed = useConsumed;
     this.useDuration = useDuration;
+    this.reactiveEffects = reactiveEffects;
   }
 }
 

--- a/systems/equipmentService.js
+++ b/systems/equipmentService.js
@@ -19,6 +19,18 @@ function cloneEffect(entry) {
   return cloned;
 }
 
+function cloneReactiveEffect(entry) {
+  if (!entry) return null;
+  const cloned = { ...entry };
+  if (entry.trigger) {
+    cloned.trigger = { ...entry.trigger };
+  }
+  if (entry.effect) {
+    cloned.effect = JSON.parse(JSON.stringify(entry.effect));
+  }
+  return cloned;
+}
+
 function createItem(entry) {
   const item = new Item(entry);
   item.attributeBonuses = Object.freeze({ ...(item.attributeBonuses || {}) });
@@ -29,6 +41,7 @@ function createItem(entry) {
   item.onHitEffects = Object.freeze((item.onHitEffects || []).map(cloneEffect).filter(Boolean));
   item.useTrigger = item.useTrigger ? Object.freeze({ ...item.useTrigger }) : null;
   item.useEffect = item.useEffect ? Object.freeze(cloneEffect(item.useEffect) || item.useEffect) : null;
+  item.reactiveEffects = Object.freeze((item.reactiveEffects || []).map(cloneReactiveEffect).filter(Boolean));
   return Object.freeze(item);
 }
 


### PR DESCRIPTION
## Summary
- add the Ice Scroll useable definition and expose reactive metadata to the client
- support damage-triggered useable reactions that can stun attackers and track consumption
- update the UI to describe reactive useables

## Testing
- node -e "require('./systems/effectsEngine'); console.log('effects ok')"

------
https://chatgpt.com/codex/tasks/task_e_68cb4982de3883208f4cad23819b8160