### PR TITLE
Add Ice Scroll useable item with damage-triggered freeze

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -356,6 +356,25 @@
       },
       "useDuration": "2 enemy attack intervals",
       "useConsumed": true
+    },
+    {
+      "id": "useable_ice_scroll",
+      "name": "Ice Scroll",
+      "slot": "useable",
+      "type": "scroll",
+      "category": "Scrolls",
+      "rarity": "Rare",
+      "cost": 170,
+      "useTrigger": { "type": "onDamageTaken", "damageType": "physical", "owner": true },
+      "useEffect": {
+        "type": "Stun",
+        "chance": 0.25,
+        "durationType": "enemyAttackIntervals",
+        "durationCount": 1
+      },
+      "useDuration": "1 enemy attack interval",
+      "useConsumed": true,
+      "useTarget": "enemy"
     }
   ]
 }

--- a/domain/item.js
+++ b/domain/item.js
@@ -20,6 +20,7 @@ class Item {
     useEffect = null,
     useConsumed = false,
     useDuration = null,
+    useTarget = 'self',
   }) {
     this.id = id;
     this.name = name;
@@ -41,6 +42,7 @@ class Item {
     this.useEffect = useEffect;
     this.useConsumed = useConsumed;
     this.useDuration = useDuration;
+    this.useTarget = useTarget;
   }
 }
 

--- a/systems/effectsEngine.js
+++ b/systems/effectsEngine.js
@@ -210,7 +210,8 @@ function applyEffect(source, target, effect, now, log, context = {}) {
       if (!resolution.hit) {
         return { hit: false, amount: 0, damageType: resolution.damageType, resolution };
       }
-      const duration = typeof effect.duration === 'number' ? effect.duration : 0;
+      const durationSeconds = resolveDurationSeconds(effect, context);
+      const duration = Number.isFinite(durationSeconds) ? durationSeconds : 0;
       target.stunnedUntil = Math.max(target.stunnedUntil, now + duration);
       pushLog(log, `${target.character.name} is stunned`, {
         sourceId: target.character.id,


### PR DESCRIPTION
## Summary
- add the Ice Scroll useable item with a physical-damage trigger and freeze effect
- extend combat logic to handle damage-taken triggers, chance-based effects, and enemy targeting for useables
- update stun handling and UI descriptions to support duration scaling by enemy attack intervals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb511d3bf88320895abdbcccea1607