### PR TITLE
Move gold and inventory ownership to characters

### DIFF
--- a/domain/character.js
+++ b/domain/character.js
@@ -9,6 +9,8 @@ class Character {
     xp = 0,
     rotation = [],
     equipment = {},
+    gold = 0,
+    items = [],
   }) {
     this.id = id;
     this.playerId = playerId;
@@ -19,6 +21,8 @@ class Character {
     this.xp = xp;
     this.rotation = rotation;
     this.equipment = equipment; // {weapon:null, helmet:null, chest:null, legs:null, feet:null, hands:null}
+    this.gold = gold;
+    this.items = items;
   }
 }
 

--- a/domain/player.js
+++ b/domain/player.js
@@ -1,9 +1,7 @@
 class Player {
-  constructor({ id, name, gold = 0, items = [], characterId = null }) {
+  constructor({ id, name, characterId = null }) {
     this.id = id;
     this.name = name;
-    this.gold = gold;
-    this.items = items;
     this.characterId = characterId;
   }
 }

--- a/index.js
+++ b/index.js
@@ -154,14 +154,11 @@ app.post("/shop/purchase", async (req, res) => {
   const { playerId, itemId, characterId } = req.body || {};
   const pid = parseInt(playerId, 10);
   const cid = parseInt(characterId, 10);
-  if (!pid || !itemId) {
-    return res.status(400).json({ error: "playerId and itemId required" });
+  if (!pid || !cid || !itemId) {
+    return res.status(400).json({ error: "playerId, characterId and itemId required" });
   }
   try {
-    await purchaseItem(pid, itemId);
-    if (!cid) {
-      return res.json({ success: true });
-    }
+    await purchaseItem(pid, cid, itemId);
     const data = await getInventory(pid, cid);
     res.json(data);
   } catch (err) {

--- a/models/Character.js
+++ b/models/Character.js
@@ -43,6 +43,8 @@ const characterSchema = new mongoose.Schema(
     rotation: { type: [Number], default: [] },
     equipment: { type: equipmentSchema, default: () => ({}) },
     useables: { type: useableSchema, default: () => ({}) },
+    gold: { type: Number, default: 0 },
+    items: { type: [String], default: [] },
   },
   { timestamps: true }
 );

--- a/models/Player.js
+++ b/models/Player.js
@@ -4,8 +4,6 @@ const playerSchema = new mongoose.Schema(
   {
     playerId: { type: Number, unique: true, index: true, required: true },
     name: { type: String, required: true },
-    gold: { type: Number, default: 0 },
-    items: { type: [String], default: [] },
     characterId: { type: Number, default: null },
   },
   { timestamps: true }

--- a/models/utils.js
+++ b/models/utils.js
@@ -38,12 +38,10 @@ function ensureAttributesShape(attributes = {}) {
 function serializePlayer(doc) {
   const plain = toPlainObject(doc);
   if (!plain) return null;
-  const { playerId, name, gold, items, characterId } = plain;
+  const { playerId, name, characterId } = plain;
   return {
     id: typeof playerId === 'number' ? playerId : null,
     name,
-    gold: typeof gold === 'number' ? gold : 0,
-    items: Array.isArray(items) ? [...items] : [],
     characterId: characterId != null ? characterId : null,
   };
 }
@@ -62,6 +60,8 @@ function serializeCharacter(doc) {
     rotation,
     equipment,
     useables,
+    gold,
+    items,
   } = plain;
   return {
     id: typeof characterId === 'number' ? characterId : null,
@@ -74,6 +74,8 @@ function serializeCharacter(doc) {
     rotation: Array.isArray(rotation) ? [...rotation] : [],
     equipment: ensureEquipmentShape(equipment),
     useables: ensureUseableShape(useables),
+    gold: typeof gold === 'number' ? gold : 0,
+    items: Array.isArray(items) ? [...items] : [],
   };
 }
 

--- a/systems/playerService.js
+++ b/systems/playerService.js
@@ -50,8 +50,6 @@ async function registerPlayer(name) {
   const playerDoc = await PlayerModel.create({
     playerId,
     name,
-    gold: 0,
-    items: [],
     characterId: null,
   });
   return { player: serializePlayer(playerDoc) };
@@ -86,6 +84,8 @@ async function createCharacter(playerId, name) {
     rotation: [],
     equipment: ensureEquipmentShape({}),
     useables: ensureUseableShape({}),
+    gold: 0,
+    items: [],
   });
   return serializeCharacter(characterDoc);
 }

--- a/systems/shopService.js
+++ b/systems/shopService.js
@@ -1,34 +1,34 @@
-const PlayerModel = require('../models/Player');
-const { serializePlayer } = require('../models/utils');
+const CharacterModel = require('../models/Character');
+const { serializeCharacter } = require('../models/utils');
 const { getItemById } = require('./equipmentService');
 
-async function purchaseItem(playerId, itemId) {
-  if (!playerId || !itemId) {
-    throw new Error('playerId and itemId required');
+async function purchaseItem(playerId, characterId, itemId) {
+  if (!playerId || !characterId || !itemId) {
+    throw new Error('playerId, characterId and itemId required');
   }
-  const [playerDoc, item] = await Promise.all([
-    PlayerModel.findOne({ playerId }),
+  const [characterDoc, item] = await Promise.all([
+    CharacterModel.findOne({ characterId, playerId }),
     getItemById(itemId),
   ]);
-  if (!playerDoc) {
-    throw new Error('player not found');
+  if (!characterDoc) {
+    throw new Error('character not found');
   }
   if (!item) {
     throw new Error('item not found');
   }
   const cost = typeof item.cost === 'number' ? item.cost : 0;
-  const gold = typeof playerDoc.gold === 'number' ? playerDoc.gold : 0;
+  const gold = typeof characterDoc.gold === 'number' ? characterDoc.gold : 0;
   if (gold < cost) {
     throw new Error('not enough gold');
   }
-  playerDoc.gold = gold - cost;
-  if (!Array.isArray(playerDoc.items)) {
-    playerDoc.items = [];
+  characterDoc.gold = gold - cost;
+  if (!Array.isArray(characterDoc.items)) {
+    characterDoc.items = [];
   }
-  playerDoc.items.push(item.id);
-  await playerDoc.save();
+  characterDoc.items.push(item.id);
+  await characterDoc.save();
   return {
-    player: serializePlayer(playerDoc),
+    character: serializeCharacter(characterDoc),
   };
 }
 


### PR DESCRIPTION
## Summary
- move gold and inventory fields from players to characters across models, domain objects, and player lifecycle flows
- update inventory, shop, challenge, and adventure services so gold and items are awarded to and consumed from the active character
- adjust the frontend state management and views to read gold and owned items from the current character instead of the player

## Testing
- npm start *(fails: unable to resolve MongoDB SRV record in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb636ee71483209ab2f03d86970994