### PR TITLE
Revamp character selection screen with cards

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -13,9 +13,14 @@
     <div id="auth-error" class="hidden"></div>
   </div>
   <div id="character-select" class="hidden">
-    <h2>Select Character</h2>
-    <ul id="character-list"></ul>
-    <button id="create-character">Create Character</button>
+    <div class="character-select-header">
+      <h2>Select Your Champion</h2>
+      <p>Scroll through your roster and choose who answers the call.</p>
+    </div>
+    <div id="character-list" class="character-card-list"></div>
+    <div class="character-select-actions">
+      <button id="create-character">Create Character</button>
+    </div>
   </div>
   <div id="name-dialog" class="hidden">
     <div class="dialog-box">

--- a/ui/main.js
+++ b/ui/main.js
@@ -673,21 +673,104 @@ function isTabActive(id) {
 
 function renderCharacters() {
   const list = document.getElementById('character-list');
+  if (!list) return;
   list.innerHTML = '';
+  list.classList.toggle('empty', characters.length === 0);
+  if (!characters.length) {
+    const empty = document.createElement('div');
+    empty.className = 'character-empty-card';
+    empty.textContent = 'No characters yet. Forge a new legend!';
+    list.appendChild(empty);
+    return;
+  }
   characters.forEach(c => {
-    const li = document.createElement('li');
-    const stats = c.attributes;
-    const name = c.name || `Character ${c.id}`;
-    const info = document.createElement('span');
-    info.className = 'info';
-    const typeLabel = displayDamageType(c.basicType);
-    info.textContent = `${name} Lv${c.level || 1} (Damage: ${typeLabel}) - STR:${stats.strength} STA:${stats.stamina} AGI:${stats.agility} INT:${stats.intellect} WIS:${stats.wisdom}`;
+    const card = document.createElement('div');
+    card.className = 'character-card';
+
+    const header = document.createElement('div');
+    header.className = 'card-header';
+    card.appendChild(header);
+
+    const name = document.createElement('div');
+    name.className = 'character-name';
+    name.textContent = c.name || `Character ${c.id}`;
+    header.appendChild(name);
+
+    const level = document.createElement('div');
+    level.className = 'character-level';
+    level.textContent = `Level ${c.level || 1}`;
+    header.appendChild(level);
+
+    const type = document.createElement('div');
+    type.className = 'character-type';
+    type.textContent = `${displayDamageType(c.basicType)} Damage`;
+    card.appendChild(type);
+
+    const xpSection = document.createElement('div');
+    xpSection.className = 'character-xp';
+    card.appendChild(xpSection);
+
+    const levelValue = c.level || 1;
+    const xpNeeded = xpForNextLevel(levelValue);
+    const xpCurrent = c.xp || 0;
+    const xpLabel = document.createElement('div');
+    xpLabel.className = 'xp-label';
+    xpLabel.textContent = xpNeeded > 0 ? `XP ${xpCurrent} / ${xpNeeded}` : `XP ${xpCurrent}`;
+    xpSection.appendChild(xpLabel);
+
+    const xpBar = document.createElement('div');
+    xpBar.className = 'xp-bar';
+    xpSection.appendChild(xpBar);
+
+    const xpFill = document.createElement('div');
+    xpFill.className = 'xp-fill';
+    const progress = xpNeeded > 0 ? Math.min(1, Math.max(0, xpCurrent / xpNeeded)) : 1;
+    xpFill.style.width = `${progress * 100}%`;
+    xpBar.appendChild(xpFill);
+
+    if (xpNeeded > 0) {
+      const xpHint = document.createElement('div');
+      xpHint.className = 'xp-hint';
+      if (xpCurrent >= xpNeeded) {
+        xpHint.textContent = 'Ready to level up!';
+      } else {
+        const remaining = Math.max(0, xpNeeded - xpCurrent);
+        xpHint.textContent = `${remaining} XP to next level`;
+      }
+      xpSection.appendChild(xpHint);
+    }
+
+    const stats = c.attributes || {};
+    const attrGrid = document.createElement('div');
+    attrGrid.className = 'character-attributes';
+    STAT_KEYS.forEach(key => {
+      const attr = document.createElement('div');
+      attr.className = 'attribute';
+      const label = document.createElement('span');
+      label.className = 'label';
+      label.textContent = key.slice(0, 3).toUpperCase();
+      attr.appendChild(label);
+      const value = document.createElement('span');
+      value.className = 'value';
+      const statValue = stats[key];
+      value.textContent = Number.isFinite(statValue) ? statValue : 0;
+      attr.appendChild(value);
+      attrGrid.appendChild(attr);
+    });
+    card.appendChild(attrGrid);
+
+    const gold = document.createElement('div');
+    gold.className = 'character-gold';
+    const goldValue = Number.isFinite(c.gold) ? c.gold : 0;
+    gold.textContent = `Gold ${goldValue}`;
+    card.appendChild(gold);
+
     const btn = document.createElement('button');
-    btn.textContent = 'Select';
+    btn.textContent = 'Play';
     btn.addEventListener('click', () => enterGame(c));
-    li.appendChild(info);
-    li.appendChild(btn);
-    list.appendChild(li);
+    card.appendChild(btn);
+
+    list.appendChild(card);
   });
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -8,14 +8,179 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .tab-pane.active { display:block; }
 .tab-pane#character.active { display:block; }
 .hidden { display:none !important; }
-#auth, #character-select { border:1px solid #000; padding:8px; margin:20px auto; }
+#auth, #character-select { border:1px solid #000; padding:8px; margin:20px auto; background:#fff; box-shadow:6px 6px 0 #000; }
 #game { max-width:800px; margin:20px auto; }
 #auth { max-width:300px; }
-#character-select { max-width:600px; }
+#character-select { max-width:960px; display:flex; flex-direction:column; gap:16px; text-align:center; }
 #auth input { width:100%; margin-bottom:8px; }
-#character-list { list-style:none; padding:0; }
-#character-list li { margin-bottom:4px; display:flex; justify-content:space-between; align-items:center; }
-#character-list li .info { white-space:pre; margin-right:8px; }
+
+.character-select-header h2 {
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:2px;
+}
+
+.character-select-header p {
+  margin:4px 0 0;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.character-card-list {
+  display:flex;
+  gap:16px;
+  padding:16px;
+  overflow-x:auto;
+  border:2px solid #000;
+  background:#fff;
+  box-shadow: inset 0 0 0 4px #fff;
+  scroll-snap-type:x mandatory;
+}
+
+.character-card-list::-webkit-scrollbar {
+  height:10px;
+}
+
+.character-card-list::-webkit-scrollbar-track {
+  background:#fff;
+  border:1px solid #000;
+}
+
+.character-card-list::-webkit-scrollbar-thumb {
+  background:#000;
+}
+
+.character-card {
+  flex:0 0 220px;
+  border:2px solid #000;
+  background:#fff;
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  scroll-snap-align:start;
+  box-shadow:6px 6px 0 #000;
+  min-height:280px;
+  text-align:left;
+}
+
+.character-card .card-header {
+  display:flex;
+  align-items:flex-end;
+  justify-content:space-between;
+  gap:8px;
+}
+
+.character-card .character-name {
+  font-size:20px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  word-break:break-word;
+}
+
+.character-card .character-level {
+  font-size:14px;
+  text-transform:uppercase;
+}
+
+.character-card .character-type {
+  border:1px solid #000;
+  background:#000;
+  color:#fff;
+  padding:4px 6px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.character-card .character-xp {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.character-card .xp-label {
+  font-weight:bold;
+}
+
+.character-card .xp-bar {
+  width:100%;
+  height:12px;
+  border:1px solid #000;
+  background:#fff;
+  position:relative;
+}
+
+.character-card .xp-fill {
+  position:absolute;
+  top:0;
+  bottom:0;
+  left:0;
+  background:#000;
+}
+
+.character-card .character-attributes {
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:8px;
+}
+
+.character-card .attribute {
+  border:1px solid #000;
+  padding:4px 6px;
+  display:flex;
+  justify-content:space-between;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.character-card .attribute .value {
+  font-weight:bold;
+}
+
+.character-card .character-gold {
+  border:1px solid #000;
+  padding:4px 6px;
+  text-transform:uppercase;
+  font-weight:bold;
+}
+
+.character-card button {
+  margin-top:auto;
+  width:100%;
+  font-weight:bold;
+  text-transform:uppercase;
+}
+
+.character-select-actions {
+  display:flex;
+  justify-content:center;
+}
+
+.character-card .xp-hint {
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.character-card-list.empty {
+  justify-content:center;
+}
+
+.character-empty-card {
+  border:2px solid #000;
+  padding:24px;
+  min-width:240px;
+  min-height:200px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-weight:bold;
+  box-shadow:6px 6px 0 #000;
+}
 
 #rotation-container {
   margin-top:8px;


### PR DESCRIPTION
## Summary
- redesign the character selection markup to support a card-based roster view
- style the selection screen with a black-and-white, scrollable card layout and empty-state messaging
- render characters as data-rich cards including XP progress, core attributes, and gold before entering the game

## Testing
- npm run start *(fails: MongoDB connection not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6923934083208298040e50c211fc