### PR TITLE
Revamp shop layout with categorized filters

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -46,7 +46,48 @@
           <div id="shop-gold">Gold: 0</div>
           <div id="shop-message" class="message hidden"></div>
         </div>
-        <div id="shop-grid" class="item-grid"></div>
+        <div class="shop-layout">
+          <aside id="shop-controls">
+            <div class="filter-section">
+              <h3>Categories</h3>
+              <div id="shop-category-filter" class="filter-options"></div>
+            </div>
+            <div class="filter-section">
+              <h3>Slots</h3>
+              <div id="shop-slot-filter" class="filter-options"></div>
+            </div>
+            <div class="filter-section">
+              <h3>Weapon Types</h3>
+              <div id="shop-weapon-filter" class="filter-options"></div>
+            </div>
+            <div class="filter-section">
+              <h3>Scaling</h3>
+              <div id="shop-scaling-filter" class="filter-options"></div>
+            </div>
+            <div class="filter-section">
+              <h3>Effects</h3>
+              <div id="shop-effect-filter" class="filter-options"></div>
+            </div>
+            <div class="filter-section">
+              <h3>Sort Order</h3>
+              <select id="shop-sort">
+                <option value="cost-asc">Cost • Low to High</option>
+                <option value="cost-desc">Cost • High to Low</option>
+                <option value="damage-desc">Damage • High to Low</option>
+                <option value="damage-asc">Damage • Low to High</option>
+                <option value="stat-desc">Stat Bonus • High to Low</option>
+                <option value="stat-asc">Stat Bonus • Low to High</option>
+              </select>
+            </div>
+            <button id="shop-reset" class="filter-reset">Reset Filters</button>
+          </aside>
+          <div class="shop-results">
+            <div id="shop-results-header" class="shop-results-header">
+              <div id="shop-results-summary"></div>
+            </div>
+            <div id="shop-grid" class="shop-category-list"></div>
+          </div>
+        </div>
       </div>
       <div id="character" class="tab-pane"></div>
       <div id="inventory" class="tab-pane">

--- a/ui/style.css
+++ b/ui/style.css
@@ -482,8 +482,8 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #levelup-dialog .dialog-box { border:1px solid #000; padding:8px; width:300px; }
 #levelup-dialog .dialog-buttons { margin-top:8px; text-align:right; }
 
-#shop-header { display:flex; justify-content:space-between; align-items:center; gap:8px; margin-bottom:8px; }
-#shop-gold { font-weight:bold; }
+#shop-header { display:flex; justify-content:space-between; align-items:flex-start; gap:8px; margin-bottom:12px; flex-wrap:wrap; }
+#shop-gold { font-weight:bold; text-transform:uppercase; }
 .message { border:1px solid #000; padding:4px 6px; background:#fff; }
 .message.error { background:#000; color:#fff; }
 .item-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(150px,1fr)); gap:8px; }
@@ -493,6 +493,48 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .item-card .cost { font-weight:bold; }
 .item-card .owned { font-size:12px; }
 .item-card button { margin-top:auto; }
+
+.shop-layout { display:flex; gap:16px; align-items:flex-start; flex-wrap:wrap; }
+#shop-controls { flex:0 0 260px; border:2px solid #000; background:#fff; padding:16px; display:flex; flex-direction:column; gap:16px; box-shadow:6px 6px 0 #000; }
+#shop-controls h3 { margin:0; text-transform:uppercase; font-size:14px; letter-spacing:1px; }
+.filter-section { display:flex; flex-direction:column; gap:10px; border:2px solid #000; padding:12px; background:#fff; box-shadow:4px 4px 0 #000; }
+.filter-options { display:flex; flex-direction:column; gap:8px; }
+.filter-option { display:flex; align-items:center; gap:8px; text-transform:uppercase; font-size:12px; letter-spacing:1px; cursor:pointer; }
+.filter-option input[type='checkbox'] { appearance:none; width:16px; height:16px; border:2px solid #000; background:#fff; display:inline-block; position:relative; }
+.filter-option input[type='checkbox']:checked::after { content:''; position:absolute; top:2px; left:2px; right:2px; bottom:2px; background:#000; }
+.filter-option input[type='checkbox']:focus { outline:2px solid #000; outline-offset:2px; }
+#shop-sort { width:100%; border:2px solid #000; background:#fff; color:#000; padding:6px; text-transform:uppercase; font-family:'Courier New', monospace; }
+#shop-sort:focus { outline:2px solid #000; outline-offset:2px; }
+.filter-reset { font-weight:bold; text-transform:uppercase; box-shadow:4px 4px 0 #000; }
+
+.shop-results { flex:1; display:flex; flex-direction:column; gap:12px; }
+.shop-results-header { display:flex; justify-content:space-between; align-items:center; padding:8px 0; text-transform:uppercase; font-size:12px; letter-spacing:1px; }
+#shop-results-summary { font-weight:bold; }
+.shop-category-list { display:flex; flex-direction:column; gap:16px; }
+.shop-category { border:2px solid #000; background:#fff; box-shadow:6px 6px 0 #000; display:flex; flex-direction:column; }
+.shop-category-header { padding:14px; border-bottom:2px solid #000; text-transform:uppercase; font-weight:bold; letter-spacing:1px; display:flex; justify-content:space-between; align-items:center; }
+.shop-subsection { padding:14px; display:flex; flex-direction:column; gap:12px; }
+.shop-subsection + .shop-subsection { border-top:2px solid #000; }
+.shop-subsection-title { display:flex; justify-content:space-between; align-items:center; text-transform:uppercase; font-weight:bold; letter-spacing:1px; }
+.shop-subsection-count { font-size:12px; }
+.shop-card-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:12px; }
+.shop-item-card { border:2px solid #000; background:#fff; box-shadow:4px 4px 0 #000; padding:12px; display:flex; flex-direction:column; gap:10px; min-height:200px; }
+.shop-item-card .card-header { display:flex; justify-content:space-between; align-items:center; text-transform:uppercase; font-weight:bold; letter-spacing:1px; }
+.shop-item-card .card-rarity { border:2px solid #000; padding:2px 6px; font-size:11px; }
+.shop-item-card .card-tags { display:flex; flex-wrap:wrap; gap:6px; font-size:11px; text-transform:uppercase; letter-spacing:1px; }
+.shop-item-card .card-tag { border:1px solid #000; padding:2px 6px; }
+.shop-item-card .card-stats { display:flex; flex-direction:column; gap:6px; font-size:12px; }
+.shop-item-card .stat-line { display:flex; flex-direction:column; gap:2px; }
+.shop-item-card .stat-label { text-transform:uppercase; font-size:11px; letter-spacing:1px; font-weight:bold; }
+.shop-item-card .stat-value { line-height:1.3; }
+.shop-item-card .card-footer { display:flex; justify-content:space-between; align-items:center; font-weight:bold; text-transform:uppercase; }
+.shop-item-card button { margin-top:auto; font-weight:bold; text-transform:uppercase; box-shadow:3px 3px 0 #000; }
+.shop-empty { padding:24px; text-align:center; text-transform:uppercase; letter-spacing:1px; font-weight:bold; border:2px dashed #000; }
+
+@media (max-width: 900px) {
+  .shop-layout { flex-direction:column; }
+  #shop-controls { width:100%; }
+}
 
 .inventory-layout { display:flex; gap:16px; flex-wrap:wrap; }
 .inventory-column { flex:1; min-width:220px; }


### PR DESCRIPTION
## Summary
- add a filter-and-sort sidebar to the shop tab with a results summary container
- implement categorized item grouping, filtering, and sorting with richer card rendering
- refresh shop styling to preserve the black-and-white retro theme for the new layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb76ff2af88320a4e10d2c87b065b4