### PR TITLE
Fix ensureMaterialShape handling of Map inputs

### DIFF
--- a/models/utils.js
+++ b/models/utils.js
@@ -31,13 +31,22 @@ function ensureMaterialShape(materials = {}) {
     return {};
   }
   const shaped = {};
-  Object.entries(materials).forEach(([id, value]) => {
+  const assignIfValid = (id, value) => {
     if (id == null) return;
     const numeric = Number(value);
     if (Number.isFinite(numeric) && numeric > 0) {
       shaped[id] = numeric;
     }
-  });
+  };
+  if (materials instanceof Map) {
+    materials.forEach((value, key) => {
+      assignIfValid(key, value);
+    });
+  } else {
+    Object.entries(materials).forEach(([id, value]) => {
+      assignIfValid(id, value);
+    });
+  }
   return shaped;
 }
 


### PR DESCRIPTION
## Summary
- update ensureMaterialShape to process Map inputs as well as plain objects
- prevent material counts fetched as Maps from being discarded when serializing characters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccbf71b7808320ac5dd611f0464da9