### PR TITLE
Fix material inventory updates with nested documents

### DIFF
--- a/models/utils.js
+++ b/models/utils.js
@@ -50,6 +50,35 @@ function ensureMaterialShape(materials = {}) {
   return shaped;
 }
 
+function readMaterialCount(materials, id) {
+  if (!materials || id == null) {
+    return 0;
+  }
+  if (typeof materials.get === 'function') {
+    const value = materials.get(id);
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  }
+  const value = materials[id];
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function writeMaterialCount(materials, id, value) {
+  if (!materials || id == null) {
+    return;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return;
+  }
+  if (typeof materials.set === 'function') {
+    materials.set(id, numeric);
+  } else {
+    materials[id] = numeric;
+  }
+}
+
 function ensureAttributesShape(attributes = {}) {
   const shaped = {};
   STATS.forEach(stat => {
@@ -112,6 +141,8 @@ module.exports = {
   ensureEquipmentShape,
   ensureUseableShape,
   ensureMaterialShape,
+  readMaterialCount,
+  writeMaterialCount,
   ensureAttributesShape,
   serializeCharacter,
   serializePlayer,

--- a/systems/adventureService.js
+++ b/systems/adventureService.js
@@ -3,6 +3,8 @@ const AdventureStateModel = require('../models/AdventureState');
 const {
   serializeCharacter,
   STATS,
+  readMaterialCount,
+  writeMaterialCount,
 } = require('../models/utils');
 const { readJSON } = require('../store/jsonStore');
 const {
@@ -759,8 +761,8 @@ async function resolveAdventureEvent(state, config, bundle, eventDef, timestamp)
       if (!bundle.characterDoc.materials || typeof bundle.characterDoc.materials !== 'object') {
         bundle.characterDoc.materials = {};
       }
-      const current = Number(bundle.characterDoc.materials[material.id]) || 0;
-      bundle.characterDoc.materials[material.id] = current + 1;
+      const current = readMaterialCount(bundle.characterDoc.materials, material.id);
+      writeMaterialCount(bundle.characterDoc.materials, material.id, current + 1);
       characterDirty = true;
       if (typeof bundle.characterDoc.markModified === 'function') {
         bundle.characterDoc.markModified('materials');

--- a/systems/shopService.js
+++ b/systems/shopService.js
@@ -1,5 +1,5 @@
 const CharacterModel = require('../models/Character');
-const { serializeCharacter } = require('../models/utils');
+const { serializeCharacter, readMaterialCount, writeMaterialCount } = require('../models/utils');
 const { getItemById } = require('./equipmentService');
 const { getMaterialById } = require('./materialService');
 
@@ -27,8 +27,8 @@ async function purchaseItem(playerId, characterId, itemId) {
     if (!characterDoc.materials || typeof characterDoc.materials !== 'object') {
       characterDoc.materials = {};
     }
-    const current = Number(characterDoc.materials[material.id]) || 0;
-    characterDoc.materials[material.id] = current + 1;
+    const current = readMaterialCount(characterDoc.materials, material.id);
+    writeMaterialCount(characterDoc.materials, material.id, current + 1);
     if (typeof characterDoc.markModified === 'function') {
       characterDoc.markModified('materials');
     }


### PR DESCRIPTION
## Summary
- add helper functions that can read and write material counts on either plain objects, Maps, or Mongoose single nested subdocuments
- update the shop and adventure reward flows to use the helpers so material purchases and drops persist
- keep material serialization logic unchanged while ensuring stored counts survive to the inventory view

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ccc2a8850c8320b6e21b7fd8d78784