### PR TITLE
Show character tab first and add adventure previews to selection cards

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -41,7 +41,7 @@
       <button data-tab="rotation">Rotation</button>
     </nav>
     <section id="content">
-      <div id="shop" class="tab-pane active">
+      <div id="shop" class="tab-pane">
         <div id="shop-header">
           <div id="shop-gold">Gold: 0</div>
           <div id="shop-message" class="message hidden"></div>
@@ -89,7 +89,7 @@
           </div>
         </div>
       </div>
-      <div id="character" class="tab-pane"></div>
+      <div id="character" class="tab-pane active"></div>
       <div id="inventory" class="tab-pane">
         <div id="inventory-message" class="message hidden"></div>
         <div class="inventory-layout">

--- a/ui/style.css
+++ b/ui/style.css
@@ -3,6 +3,7 @@ body { margin:0; background:#fff; color:#000; font-family:'Courier New', monospa
 button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor:pointer; font-family:'Courier New', monospace; }
 #tabs { display:flex; border-bottom:1px solid #000; }
 #tabs button { flex:1; border-bottom:none; }
+#tabs button.active { background:#000; color:#fff; }
 #content { border:1px solid #000; padding:8px; }
 .tab-pane { display:none; }
 .tab-pane.active { display:block; }
@@ -162,6 +163,54 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-size:12px;
   text-transform:uppercase;
   letter-spacing:1px;
+}
+
+.character-card .character-adventure {
+  border:1px solid #000;
+  padding:6px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  background:#fff;
+}
+.character-card .character-adventure .adventure-title {
+  font-size:11px;
+  font-weight:bold;
+}
+.character-card .adventure-progress-bar {
+  position:relative;
+  height:10px;
+  border:1px solid #000;
+  background:repeating-linear-gradient(90deg, #fff 0px, #fff 6px, #f2f2f2 6px, #f2f2f2 12px);
+  overflow:hidden;
+}
+.character-card .adventure-progress-fill {
+  position:absolute;
+  inset:0;
+  background:#000;
+  transition:width 0.2s ease-in-out;
+}
+.character-card .adventure-status-text {
+  font-size:12px;
+  font-weight:bold;
+}
+.character-card .adventure-time-remaining {
+  font-size:11px;
+  color:#444;
+}
+.character-card .character-adventure.adventure-loading .adventure-status-text {
+  font-style:italic;
+}
+.character-card .character-adventure.adventure-complete {
+  background:#f7f7f7;
+}
+.character-card .character-adventure.adventure-defeat {
+  border-style:dashed;
+}
+.character-card .character-adventure.adventure-error .adventure-status-text {
+  font-style:italic;
 }
 
 .character-card-list.empty {


### PR DESCRIPTION
## Summary
- open the game view directly on the character tab via a shared tab activator and add a swap character button to return to selection
- surface each character's adventure progress and remaining time on the roster cards with cached status lookups
- style the new adventure preview elements and highlight the active tab button for clarity

## Testing
- node --check ui/main.js

------
https://chatgpt.com/codex/tasks/task_e_68ccc55a64d08320a3fd61f6582779dd