### PR TITLE
Add shift controls and retro styling to jobs

### DIFF
--- a/models/utils.js
+++ b/models/utils.js
@@ -145,13 +145,15 @@ function serializeCharacter(doc) {
 
 function serializeJobSummary(job) {
   if (!job || typeof job !== 'object') {
-    return { jobId: null, startedAt: null, lastProcessedAt: null };
+    return { jobId: null, startedAt: null, lastProcessedAt: null, isWorking: false, workingSince: null };
   }
   const jobId = typeof job.jobId === 'string' ? job.jobId : null;
   return {
     jobId,
     startedAt: normalizeDate(job.startedAt),
     lastProcessedAt: normalizeDate(job.lastProcessedAt),
+    workingSince: normalizeDate(job.workingSince),
+    isWorking: !!job.isWorking,
   };
 }
 

--- a/systems/adventureService.js
+++ b/systems/adventureService.js
@@ -18,6 +18,7 @@ const {
 } = require('./challengeGA');
 const { runCombat } = require('./combatEngine');
 const { getMaterialMap } = require('./materialService');
+const { ensureJobIdleForDoc } = require('./jobService');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const ADVENTURE_CONFIG_FILE = path.join(DATA_DIR, 'adventureConfig.json');
@@ -1116,6 +1117,7 @@ async function startAdventure(characterId, options = {}) {
   if (!bundle) {
     throw error || new Error('failed to prepare adventure');
   }
+  ensureJobIdleForDoc(bundle.characterDoc);
   if (state) {
     let stateMutated = false;
     if (!Array.isArray(state.events)) {

--- a/systems/challengeGA.js
+++ b/systems/challengeGA.js
@@ -11,7 +11,7 @@ const { getEquipmentMap } = require('./equipmentService');
 const { runCombat } = require('./combatEngine');
 const { compute } = require('./derivedStats');
 const { xpForNextLevel } = require('./characterService');
-const { processJobForCharacter } = require('./jobService');
+const { processJobForCharacter, ensureJobIdleForDoc } = require('./jobService');
 
 const MIN_POPULATION_SIZE = 10;
 const POPULATION_STEP = 10;
@@ -708,6 +708,8 @@ async function startChallenge(characterId, options = {}) {
   const state = prep.state;
   const force = !!options.force;
 
+  ensureJobIdleForDoc(prep.characterDoc);
+
   if (state.currentOpponent && state.currentOpponent.character && !force) {
     return buildChallengePayload(state, prep.characterDoc.level || 1);
   }
@@ -747,6 +749,7 @@ async function startChallenge(characterId, options = {}) {
 
 async function runChallengeFight(characterId, send) {
   const prep = await prepareChallenge(characterId);
+  ensureJobIdleForDoc(prep.characterDoc);
 
   if (!prep.state.currentOpponent || !prep.state.currentOpponent.character) {
     throw new Error('no active opponent');

--- a/systems/matchmaking.js
+++ b/systems/matchmaking.js
@@ -4,7 +4,7 @@ const { getAbilities } = require('./abilityService');
 const { getEquipmentMap } = require('./equipmentService');
 const { runCombat } = require('./combatEngine');
 const { xpForNextLevel } = require('./characterService');
-const { processJobForCharacter } = require('./jobService');
+const { processJobForCharacter, ensureJobIdleForDoc } = require('./jobService');
 
 const queue = [];
 
@@ -15,6 +15,7 @@ async function loadCharacter(id) {
   if (changed) {
     await characterDoc.save();
   }
+  ensureJobIdleForDoc(characterDoc);
   return serializeCharacter(characterDoc);
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -699,43 +699,58 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   z-index:1200;
 }
 .job-dialog {
-  background:#fff;
-  border:2px solid #000;
-  box-shadow:0 0 0 4px #000 inset;
+  background:#111;
+  color:#f6f6f6;
+  border:4px solid #fff;
+  box-shadow:8px 8px 0 #000;
   width:100%;
   max-width:960px;
   max-height:90vh;
   display:flex;
   flex-direction:column;
+  font-family:'Courier New', monospace;
+  background-image:repeating-linear-gradient(45deg, rgba(255,255,255,0.05) 0, rgba(255,255,255,0.05) 4px, transparent 4px, transparent 8px);
 }
 .job-dialog-header {
   display:flex;
   align-items:center;
   justify-content:space-between;
-  padding:16px;
-  border-bottom:2px solid #000;
+  padding:18px;
+  border-bottom:4px solid #fff;
   background:#000;
   color:#fff;
+  text-transform:uppercase;
+  letter-spacing:2px;
+  box-shadow:0 4px 0 rgba(255,255,255,0.15);
 }
 .job-dialog-header h2 {
   margin:0;
   text-transform:uppercase;
-  letter-spacing:1px;
+  letter-spacing:2px;
   font-size:18px;
 }
 .job-dialog-header button {
   font-weight:bold;
   text-transform:uppercase;
-  padding:6px 12px;
-  box-shadow:3px 3px 0 #000;
+  padding:6px 16px;
+  border:3px solid #fff;
+  background:#111;
+  color:#fff;
+  box-shadow:4px 4px 0 #fff, 4px 4px 0 3px #000;
+}
+.job-dialog-header button:hover,
+.job-dialog-header button:focus {
+  background:#1f1f1f;
+  color:#fff;
 }
 .job-dialog-content {
-  padding:16px;
+  padding:20px;
   overflow-y:auto;
   display:flex;
   flex-direction:column;
-  gap:16px;
-  background:#f9f9f9;
+  gap:20px;
+  background:rgba(0,0,0,0.4);
+  border-top:4px solid rgba(255,255,255,0.1);
 }
 .job-dialog-loading {
   text-align:center;
@@ -750,6 +765,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
+  color:#fff;
+}
+.job-dialog-note {
+  margin:4px 0 0 0;
+  font-size:12px;
+  color:#d7d7d7;
+  text-transform:uppercase;
+  letter-spacing:1px;
 }
 .job-card-grid {
   display:grid;
@@ -757,13 +780,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:16px;
 }
 .job-card {
-  border:2px solid #000;
+  border:3px solid #000;
   background:#fff;
-  padding:16px;
+  color:#000;
+  padding:18px;
   display:flex;
   flex-direction:column;
   gap:12px;
-  box-shadow:0 0 0 3px #000 inset;
+  box-shadow:6px 6px 0 rgba(0,0,0,0.85);
 }
 .job-card h3 {
   margin:0;
@@ -781,20 +805,29 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   align-self:flex-start;
   font-weight:bold;
   text-transform:uppercase;
-  box-shadow:3px 3px 0 #000;
+  padding:6px 14px;
+  border:3px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:4px 4px 0 #000;
+}
+.job-card button:hover,
+.job-card button:focus {
+  background:#000;
+  color:#fff;
 }
 .job-attribute {
   font-size:12px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  color:#444;
+  color:#1a1a1a;
 }
 .job-description {
   margin:0;
   font-size:13px;
   line-height:1.4;
-  color:#222;
+  color:#1a1a1a;
 }
 .job-meta-list {
   list-style:none;
@@ -808,28 +841,38 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   display:flex;
   justify-content:space-between;
   align-items:center;
-  border:1px solid #000;
-  background:#f4f4f4;
-  padding:6px 8px;
+  border:2px solid #000;
+  background:#fff;
+  padding:6px 10px;
+  box-shadow:3px 3px 0 #000;
 }
 .job-meta-list .label {
   font-size:11px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
+  color:#000;
 }
 .job-meta-list .value {
   font-family:'Courier New', monospace;
   font-size:13px;
+  color:#000;
 }
 .job-empty-text {
-  border:1px dashed #999;
-  background:#fff;
-  padding:12px;
+  border:2px dashed rgba(255,255,255,0.5);
+  background:rgba(255,255,255,0.08);
+  padding:14px;
   text-align:center;
   font-size:13px;
   font-style:italic;
-  color:#555;
+  color:inherit;
+}
+.job-output-section .job-empty-text,
+.job-log-section .job-empty-text,
+.job-recipe-section .job-empty-text {
+  border-color:rgba(0,0,0,0.4);
+  background:rgba(0,0,0,0.05);
+  color:#000;
 }
 .job-recipe-list {
   display:flex;
@@ -837,12 +880,13 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:8px;
 }
 .job-recipe {
-  border:1px solid #000;
+  border:2px solid #000;
   background:#fff;
-  padding:10px;
+  padding:12px;
   display:flex;
   flex-direction:column;
   gap:8px;
+  box-shadow:3px 3px 0 #000;
 }
 .job-recipe-header {
   display:flex;
@@ -870,17 +914,18 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:4px;
 }
 .job-material {
-  border:1px solid #000;
-  background:#f6f6f6;
+  border:2px solid #000;
+  background:#fff;
   display:flex;
   align-items:center;
   gap:8px;
-  padding:4px 8px;
+  padding:6px 10px;
+  box-shadow:3px 3px 0 #000;
 }
 .job-material.empty {
   border-style:dashed;
-  background:#fff;
-  color:#777;
+  background:rgba(0,0,0,0.04);
+  color:#444;
   justify-content:center;
   font-style:italic;
 }
@@ -904,13 +949,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-weight:bold;
 }
 .job-active-summary {
-  border:2px solid #000;
+  border:3px solid #000;
   background:#fff;
-  padding:16px;
+  color:#000;
+  padding:20px;
   display:flex;
   flex-direction:column;
-  gap:6px;
-  box-shadow:0 0 0 3px #000 inset;
+  gap:10px;
+  box-shadow:6px 6px 0 rgba(0,0,0,0.85);
 }
 .job-active-summary h3 {
   margin:0;
@@ -922,42 +968,100 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-size:12px;
   text-transform:uppercase;
   letter-spacing:1px;
-  color:#444;
+  color:#111;
+}
+.job-shift-panel {
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  border:2px solid #000;
+  background:#fdfdfd;
+  padding:14px;
+  box-shadow:4px 4px 0 #000;
+}
+.job-shift-status {
+  align-self:flex-start;
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:2px;
+  font-weight:bold;
+  border:2px solid #000;
+  padding:4px 12px;
+  background:#fff;
+  color:#000;
+  box-shadow:2px 2px 0 #000;
+}
+.job-shift-status.working {
+  background:#000;
+  color:#fff;
+}
+.job-shift-message {
+  margin:0;
+  font-size:12px;
+  line-height:1.5;
+  color:#111;
+  text-transform:none;
+}
+.job-shift-action {
+  align-self:flex-start;
+  font-weight:bold;
+  text-transform:uppercase;
+  padding:6px 16px;
+  border:3px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:4px 4px 0 #000;
+}
+.job-shift-action:hover,
+.job-shift-action:focus {
+  background:#000;
+  color:#fff;
+}
+.job-restriction-note {
+  margin:0;
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  color:#222;
 }
 .job-stats-grid {
   display:grid;
-  grid-template-columns:repeat(auto-fit, minmax(180px,1fr));
-  gap:8px;
+  grid-template-columns:repeat(auto-fit, minmax(190px,1fr));
+  gap:12px;
 }
 .job-stat {
-  border:1px solid #000;
-  background:#f4f4f4;
-  padding:8px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  padding:10px;
   display:flex;
   flex-direction:column;
   gap:4px;
+  box-shadow:3px 3px 0 #000;
 }
 .job-stat .label {
   font-size:11px;
   text-transform:uppercase;
   letter-spacing:1px;
-  color:#555;
+  color:#111;
 }
 .job-stat .value {
   font-family:'Courier New', monospace;
   font-size:14px;
   font-weight:bold;
+  color:#000;
 }
 .job-output-section,
 .job-log-section,
 .job-recipe-section {
-  border:2px solid #000;
+  border:3px solid #000;
   background:#fff;
-  padding:16px;
+  color:#000;
+  padding:18px;
   display:flex;
   flex-direction:column;
   gap:12px;
-  box-shadow:0 0 0 3px #000 inset;
+  box-shadow:6px 6px 0 rgba(0,0,0,0.85);
 }
 .job-output-section h4,
 .job-log-section h4,
@@ -966,6 +1070,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   text-transform:uppercase;
   letter-spacing:1px;
   font-size:16px;
+  color:#000;
 }
 .job-output-list {
   list-style:none;
@@ -976,9 +1081,9 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:6px;
 }
 .job-output-item {
-  border:1px solid #000;
+  border:2px solid #000;
   background:#f7f7f7;
-  padding:6px 8px;
+  padding:8px 10px;
   display:flex;
   align-items:center;
   gap:8px;
@@ -1007,20 +1112,20 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:6px;
 }
 .job-log-list li {
-  border:1px solid #000;
-  padding:8px;
+  border:2px solid #000;
+  padding:10px;
   background:#fff;
   display:flex;
   flex-direction:column;
   gap:4px;
 }
 .job-log-list li.log-crafted {
-  border-color:#9ccc65;
-  background:#eef9e6;
+  border-color:#1b5e20;
+  background:#e6f7e6;
 }
 .job-log-list li.log-failed {
-  border-color:#f28b82;
-  background:#ffecec;
+  border-color:#8b1e24;
+  background:#ffe6e6;
 }
 .job-log-list .message {
   font-size:13px;
@@ -1028,7 +1133,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 .job-log-list .time {
   font-size:11px;
-  color:#555;
+  color:#333;
   text-transform:uppercase;
   letter-spacing:1px;
 }


### PR DESCRIPTION
## Summary
- add start and stop APIs for professions and block adventures, challenges, and matchmaking while working
- extend job serialization and processing to track shift state without auto-crafting while off duty
- redesign the jobs dialog with monochrome retro styling and add shift controls on the frontend

## Testing
- npm run start *(fails: MongoDB host not reachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cce16e9fb4832080b5a442a9b55bb8