### PR TITLE
Add material recovery rolls to job crafting

### DIFF
--- a/data/jobConfig.json
+++ b/data/jobConfig.json
@@ -4,6 +4,8 @@
   "statGainChance": 0.05,
   "statGainAmount": 1,
   "logLimit": 30,
+  "materialRecoveryEnabled": true,
+  "materialRecoveryChanceMultiplier": 1,
   "rarityWeights": {
     "Common": 6,
     "Uncommon": 3,


### PR DESCRIPTION
## Summary
- add configurable material recovery options to the job config and backend processing
- allow jobs to generate missing materials based on attribute share with detailed log entries
- expose recovery settings and outcomes in the jobs UI so players understand the mechanic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cce9856468832094de7bfdcd552ba0