### PR TITLE
Rework inventory layout to top filters

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -96,44 +96,48 @@
           <div id="inventory-message" class="message hidden"></div>
         </div>
         <div class="inventory-layout">
-          <aside id="inventory-controls">
-            <div class="filter-section">
-              <h3>Categories</h3>
-              <div id="inventory-category-filter" class="filter-options"></div>
+          <div id="inventory-controls" class="inventory-filter-bar">
+            <div class="inventory-filters-grid">
+              <div class="filter-section">
+                <h3>Categories</h3>
+                <div id="inventory-category-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section">
+                <h3>Slots</h3>
+                <div id="inventory-slot-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section">
+                <h3>Weapon Types</h3>
+                <div id="inventory-weapon-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section">
+                <h3>Scaling</h3>
+                <div id="inventory-scaling-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section">
+                <h3>Effects</h3>
+                <div id="inventory-effect-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section">
+                <h3>Sort Order</h3>
+                <select id="inventory-sort">
+                  <option value="name-asc">Name • A to Z</option>
+                  <option value="name-desc">Name • Z to A</option>
+                  <option value="rarity-desc">Rarity • High to Low</option>
+                  <option value="rarity-asc">Rarity • Low to High</option>
+                  <option value="cost-asc">Cost • Low to High</option>
+                  <option value="cost-desc">Cost • High to Low</option>
+                  <option value="damage-desc">Damage • High to Low</option>
+                  <option value="damage-asc">Damage • Low to High</option>
+                  <option value="stat-desc">Stat Bonus • High to Low</option>
+                  <option value="stat-asc">Stat Bonus • Low to High</option>
+                </select>
+              </div>
             </div>
-            <div class="filter-section">
-              <h3>Slots</h3>
-              <div id="inventory-slot-filter" class="filter-options"></div>
+            <div class="inventory-filter-actions">
+              <button id="inventory-reset" class="filter-reset">Reset Filters</button>
             </div>
-            <div class="filter-section">
-              <h3>Weapon Types</h3>
-              <div id="inventory-weapon-filter" class="filter-options"></div>
-            </div>
-            <div class="filter-section">
-              <h3>Scaling</h3>
-              <div id="inventory-scaling-filter" class="filter-options"></div>
-            </div>
-            <div class="filter-section">
-              <h3>Effects</h3>
-              <div id="inventory-effect-filter" class="filter-options"></div>
-            </div>
-            <div class="filter-section">
-              <h3>Sort Order</h3>
-              <select id="inventory-sort">
-                <option value="name-asc">Name • A to Z</option>
-                <option value="name-desc">Name • Z to A</option>
-                <option value="rarity-desc">Rarity • High to Low</option>
-                <option value="rarity-asc">Rarity • Low to High</option>
-                <option value="cost-asc">Cost • Low to High</option>
-                <option value="cost-desc">Cost • High to Low</option>
-                <option value="damage-desc">Damage • High to Low</option>
-                <option value="damage-asc">Damage • Low to High</option>
-                <option value="stat-desc">Stat Bonus • High to Low</option>
-                <option value="stat-asc">Stat Bonus • Low to High</option>
-              </select>
-            </div>
-            <button id="inventory-reset" class="filter-reset">Reset Filters</button>
-          </aside>
+          </div>
           <div class="inventory-results">
             <div class="inventory-results-header">
               <div id="inventory-results-summary"></div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -541,9 +541,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .item-card .cost { font-weight:bold; }
 .item-card .owned { font-size:12px; }
 .item-card button { margin-top:auto; text-transform:uppercase; font-weight:bold; box-shadow:3px 3px 0 #000; }
-.shop-layout, .inventory-layout { display:flex; gap:16px; align-items:flex-start; flex-wrap:wrap; }
-#shop-controls, #inventory-controls { flex:0 0 260px; border:2px solid #000; background:#fff; padding:16px; display:flex; flex-direction:column; gap:16px; box-shadow:6px 6px 0 #000; }
+.shop-layout { display:flex; gap:16px; align-items:flex-start; flex-wrap:wrap; }
+.inventory-layout { display:flex; flex-direction:column; gap:16px; }
+#shop-controls { flex:0 0 260px; border:2px solid #000; background:#fff; padding:16px; display:flex; flex-direction:column; gap:16px; box-shadow:6px 6px 0 #000; }
+#inventory-controls { border:2px solid #000; background:#fff; padding:16px; display:flex; flex-direction:column; gap:16px; box-shadow:6px 6px 0 #000; }
 #shop-controls h3, #inventory-controls h3 { margin:0; text-transform:uppercase; font-size:14px; letter-spacing:1px; }
+.inventory-filters-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:16px; }
+.inventory-filter-actions { display:flex; justify-content:flex-end; align-items:flex-end; }
+.inventory-filter-actions .filter-reset { width:auto; }
 .filter-section { display:flex; flex-direction:column; gap:10px; border:2px solid #000; padding:12px; background:#fff; box-shadow:4px 4px 0 #000; }
 .filter-options { display:flex; flex-direction:column; gap:8px; }
 .filter-option { display:flex; align-items:center; gap:8px; text-transform:uppercase; font-size:12px; letter-spacing:1px; cursor:pointer; }
@@ -578,8 +583,15 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .shop-empty { padding:24px; text-align:center; text-transform:uppercase; letter-spacing:1px; font-weight:bold; border:2px dashed #000; }
 
 @media (max-width: 900px) {
-  .shop-layout, .inventory-layout { flex-direction:column; }
-  #shop-controls, #inventory-controls { width:100%; }
+  .shop-layout { flex-direction:column; }
+  #shop-controls { width:100%; }
+}
+
+@media (max-width: 720px) {
+  #inventory-controls { padding:12px; }
+  .inventory-filters-grid { grid-template-columns:1fr; }
+  .inventory-filter-actions { justify-content:stretch; align-items:stretch; }
+  .inventory-filter-actions .filter-reset { width:100%; }
 }
 
 #inventory-header { display:flex; justify-content:space-between; align-items:flex-start; gap:8px; margin-bottom:12px; flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- move the inventory filters into a full-width top bar and keep the item and equipment panels beneath it
- adjust the inventory layout styling so filters flow horizontally and remain responsive alongside the two-column item/equipment grid

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd83acb6cc8320b9bea6fcf070659a