### PR TITLE
Revamp inventory UI with shop-style cards and filters

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -92,6 +92,49 @@
       <div id="character" class="tab-pane active"></div>
       <div id="inventory" class="tab-pane">
         <div id="inventory-message" class="message hidden"></div>
+        <div class="inventory-controls">
+          <div class="inventory-controls-bar">
+            <button
+              id="inventory-filter-toggle"
+              class="inventory-filter-toggle"
+              type="button"
+              aria-expanded="false"
+              aria-controls="inventory-filter-panel"
+            >
+              Show Filters ▾
+            </button>
+            <div class="inventory-controls-actions">
+              <button id="inventory-filter-reset" class="filter-reset" type="button">Reset Filters</button>
+            </div>
+          </div>
+          <div id="inventory-filter-panel" class="inventory-filter-panel">
+            <div class="inventory-filter-groups">
+              <div class="filter-section" data-inventory-section="categories">
+                <h3>Categories</h3>
+                <div id="inventory-category-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section" data-inventory-section="slots">
+                <h3>Slots</h3>
+                <div id="inventory-slot-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section" data-inventory-section="weaponTypes">
+                <h3>Weapon Types</h3>
+                <div id="inventory-weapon-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section" data-inventory-section="scaling">
+                <h3>Scaling</h3>
+                <div id="inventory-scaling-filter" class="filter-options"></div>
+              </div>
+              <div class="filter-section" data-inventory-section="effects">
+                <h3>Effects</h3>
+                <div id="inventory-effect-filter" class="filter-options"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="inventory-results-header">
+          <div id="inventory-results-summary"></div>
+        </div>
         <div class="inventory-layout">
           <div class="inventory-column">
             <h3>Owned Items</h3>

--- a/ui/main.js
+++ b/ui/main.js
@@ -199,7 +199,25 @@ let shopControlsInitialized = false;
 let shopCatalogCache = [];
 let shopTotalItems = 0;
 
+const inventoryFilters = {
+  categories: new Set(),
+  slots: new Set(),
+  weaponTypes: new Set(),
+  scaling: new Set(),
+  effects: new Set(),
+};
+const inventoryFilterOptionValues = {
+  categories: SHOP_CATEGORY_DEFINITIONS.map(option => option.value),
+  slots: [],
+  weaponTypes: [],
+  scaling: [],
+  effects: [],
+};
+let inventoryFiltersInitialized = false;
+let inventoryItemsCache = [];
+
 setSetValues(shopFilters.categories, SHOP_CATEGORY_DEFINITIONS.map(option => option.value));
+setSetValues(inventoryFilters.categories, SHOP_CATEGORY_DEFINITIONS.map(option => option.value));
 
 function displayDamageType(type) {
   if (!type) return 'Melee';
@@ -1200,10 +1218,34 @@ function buildScalingOptions(items) {
   return [...ordered, ...extras].map(stat => ({ value: stat, label: statLabel(stat) }));
 }
 
-function renderCheckboxGroup(containerId, options, valueSet) {
+function buildEffectOptionsForItems(items) {
+  const available = new Set();
+  items.forEach(item => {
+    if (!item) return;
+    if (Array.isArray(item.onHitEffects) && item.onHitEffects.length) {
+      available.add('onHit');
+    }
+    if (item.useEffect) {
+      available.add('useEffect');
+    }
+    if (formatAttributeBonuses(item.attributeBonuses)) {
+      available.add('attributeBonus');
+    }
+    if (formatChanceBonuses(item.chanceBonuses)) {
+      available.add('chanceBonus');
+    }
+    if (formatResourceBonuses(item.resourceBonuses)) {
+      available.add('resourceBonus');
+    }
+  });
+  return SHOP_EFFECT_OPTIONS.filter(option => available.has(option.value));
+}
+
+function renderCheckboxGroup(containerId, options, valueSet, onChange) {
   const container = document.getElementById(containerId);
   if (!container) return;
   container.innerHTML = '';
+  const handleChange = typeof onChange === 'function' ? onChange : updateShopDisplay;
   options.forEach(option => {
     const label = document.createElement('label');
     label.className = 'filter-option';
@@ -1217,7 +1259,7 @@ function renderCheckboxGroup(containerId, options, valueSet) {
       } else {
         valueSet.delete(option.value);
       }
-      updateShopDisplay();
+      handleChange();
     });
     const text = document.createElement('span');
     text.textContent = option.label;
@@ -1308,6 +1350,322 @@ function updateShopDisplay() {
   if (summary) {
     summary.textContent = `${filtered.length} of ${shopTotalItems} items displayed`;
   }
+}
+
+
+function updateInventoryFilterToggleLabel(button, isOpen) {
+  if (!button) return;
+  button.textContent = isOpen ? 'Hide Filters ▴' : 'Show Filters ▾';
+}
+
+function toggleInventoryFilterSection(sectionKey, visible) {
+  const section = document.querySelector(`[data-inventory-section='${sectionKey}']`);
+  if (!section) return;
+  if (visible) {
+    section.classList.remove('hidden');
+  } else {
+    section.classList.add('hidden');
+  }
+}
+
+function initializeInventoryControls(items) {
+  const categoryOptions = SHOP_CATEGORY_DEFINITIONS;
+  const slotOptions = buildSlotOptions(items);
+  const weaponOptions = buildWeaponTypeOptions(items);
+  const scalingOptions = buildScalingOptions(items);
+  const effectOptions = buildEffectOptionsForItems(items);
+
+  inventoryFilterOptionValues.categories = categoryOptions.map(option => option.value);
+  inventoryFilterOptionValues.slots = slotOptions.map(option => option.value);
+  inventoryFilterOptionValues.weaponTypes = weaponOptions.map(option => option.value);
+  inventoryFilterOptionValues.scaling = scalingOptions.map(option => option.value);
+  inventoryFilterOptionValues.effects = effectOptions.map(option => option.value);
+
+  pruneSetToOptions(inventoryFilters.categories, categoryOptions);
+  pruneSetToOptions(inventoryFilters.slots, slotOptions);
+  pruneSetToOptions(inventoryFilters.weaponTypes, weaponOptions);
+  pruneSetToOptions(inventoryFilters.scaling, scalingOptions);
+  pruneSetToOptions(inventoryFilters.effects, effectOptions);
+
+  renderCheckboxGroup('inventory-category-filter', categoryOptions, inventoryFilters.categories, updateInventoryDisplay);
+  renderCheckboxGroup('inventory-slot-filter', slotOptions, inventoryFilters.slots, updateInventoryDisplay);
+  renderCheckboxGroup('inventory-weapon-filter', weaponOptions, inventoryFilters.weaponTypes, updateInventoryDisplay);
+  renderCheckboxGroup('inventory-scaling-filter', scalingOptions, inventoryFilters.scaling, updateInventoryDisplay);
+  renderCheckboxGroup('inventory-effect-filter', effectOptions, inventoryFilters.effects, updateInventoryDisplay);
+
+  toggleInventoryFilterSection('slots', slotOptions.length > 0);
+  toggleInventoryFilterSection('weaponTypes', weaponOptions.length > 0);
+  toggleInventoryFilterSection('scaling', scalingOptions.length > 0);
+  toggleInventoryFilterSection('effects', effectOptions.length > 0);
+}
+
+function resetInventoryFilters() {
+  const defaultCategories = inventoryFilterOptionValues.categories.length
+    ? inventoryFilterOptionValues.categories
+    : SHOP_CATEGORY_DEFINITIONS.map(option => option.value);
+  setSetValues(inventoryFilters.categories, defaultCategories);
+  inventoryFilters.slots.clear();
+  inventoryFilters.weaponTypes.clear();
+  inventoryFilters.scaling.clear();
+  inventoryFilters.effects.clear();
+}
+
+function ensureInventoryFilterControls() {
+  if (inventoryFiltersInitialized) return;
+  const toggle = document.getElementById('inventory-filter-toggle');
+  const panel = document.getElementById('inventory-filter-panel');
+  if (toggle && panel) {
+    updateInventoryFilterToggleLabel(toggle, panel.classList.contains('open'));
+    toggle.addEventListener('click', () => {
+      const isOpen = panel.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      updateInventoryFilterToggleLabel(toggle, isOpen);
+    });
+  }
+  const resetButton = document.getElementById('inventory-filter-reset');
+  if (resetButton) {
+    resetButton.addEventListener('click', () => {
+      resetInventoryFilters();
+      initializeInventoryControls(inventoryItemsCache.map(entry => entry.item));
+      updateInventoryDisplay();
+    });
+  }
+  inventoryFiltersInitialized = true;
+}
+
+function applyInventoryFilters(entries) {
+  return entries.filter(({ item }) => {
+    if (!item) return false;
+    if (!inventoryFilters.categories.size) {
+      return false;
+    }
+    const categoryKey = getShopCategoryKey(item);
+    if (!inventoryFilters.categories.has(categoryKey)) {
+      return false;
+    }
+    if (inventoryFilters.slots.size && !inventoryFilters.slots.has(item.slot)) {
+      return false;
+    }
+    if (inventoryFilters.weaponTypes.size) {
+      const type = normalizeWeaponType(item.type);
+      if (!inventoryFilters.weaponTypes.has(type)) {
+        return false;
+      }
+    }
+    if (inventoryFilters.scaling.size) {
+      const statKeys = getItemStatKeys(item);
+      if (!statKeys.some(stat => inventoryFilters.scaling.has(stat))) {
+        return false;
+      }
+    }
+    if (inventoryFilters.effects.size) {
+      for (const effect of inventoryFilters.effects) {
+        if (effect === 'onHit' && !(Array.isArray(item.onHitEffects) && item.onHitEffects.length)) {
+          return false;
+        }
+        if (effect === 'useEffect' && !item.useEffect) {
+          return false;
+        }
+        if (effect === 'attributeBonus' && !formatAttributeBonuses(item.attributeBonuses)) {
+          return false;
+        }
+        if (effect === 'chanceBonus' && !formatChanceBonuses(item.chanceBonuses)) {
+          return false;
+        }
+        if (effect === 'resourceBonus' && !formatResourceBonuses(item.resourceBonuses)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  });
+}
+
+function updateInventoryDisplay() {
+  const grid = document.getElementById('inventory-grid');
+  if (!grid) return;
+  const summary = document.getElementById('inventory-results-summary');
+  const messageEl = document.getElementById('inventory-message');
+  grid.innerHTML = '';
+  const total = inventoryItemsCache.length;
+  if (!total) {
+    const empty = document.createElement('div');
+    empty.className = 'shop-empty';
+    empty.textContent = 'No gear owned yet.';
+    grid.appendChild(empty);
+    if (summary) summary.textContent = '0 items owned';
+    return;
+  }
+  const filteredEntries = applyInventoryFilters(inventoryItemsCache);
+  const filteredCount = filteredEntries.length;
+  if (filteredCount) {
+    filteredEntries.forEach(entry => {
+      const card = createInventoryItemCard(entry, messageEl);
+      if (card) {
+        grid.appendChild(card);
+      }
+    });
+  } else {
+    const empty = document.createElement('div');
+    empty.className = 'shop-empty';
+    empty.textContent = inventoryFilters.categories.size
+      ? 'No items match the selected filters.'
+      : 'Select a category to view items.';
+    grid.appendChild(empty);
+  }
+  if (summary) {
+    summary.textContent = `${filteredCount} of ${total} items shown`;
+  }
+}
+
+function createInventoryItemCard(entry, messageEl) {
+  if (!entry || !entry.item) return null;
+  const { item, count } = entry;
+  const card = document.createElement('div');
+  card.className = 'shop-item-card inventory-item-card';
+
+  const header = document.createElement('div');
+  header.className = 'card-header';
+  const name = document.createElement('div');
+  name.className = 'card-name';
+  name.textContent = item.name || 'Unknown Item';
+  header.appendChild(name);
+  const rarity = document.createElement('div');
+  rarity.className = 'card-rarity';
+  rarity.textContent = item.rarity || 'Common';
+  header.appendChild(rarity);
+  card.appendChild(header);
+
+  const tags = document.createElement('div');
+  tags.className = 'card-tags';
+  if (item.slot) {
+    const slotTag = document.createElement('span');
+    slotTag.className = 'card-tag';
+    slotTag.textContent = slotLabel(item.slot) || titleCase(item.slot);
+    tags.appendChild(slotTag);
+  }
+  if (isUseableItem(item) && item.category) {
+    const categoryTag = document.createElement('span');
+    categoryTag.className = 'card-tag';
+    categoryTag.textContent = titleCase(item.category);
+    tags.appendChild(categoryTag);
+  }
+  if (item.type && !isUseableItem(item)) {
+    const typeTag = document.createElement('span');
+    typeTag.className = 'card-tag';
+    typeTag.textContent = titleCase(item.type);
+    tags.appendChild(typeTag);
+  }
+  if (tags.childElementCount) {
+    card.appendChild(tags);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'card-description inventory-card-meta';
+  meta.textContent = formatItemMeta(item);
+  card.appendChild(meta);
+
+  const footer = document.createElement('div');
+  footer.className = 'card-footer inventory-card-footer';
+  const countLabel = document.createElement('div');
+  countLabel.className = 'card-cost inventory-card-count';
+  countLabel.textContent = `Owned ×${count}`;
+  footer.appendChild(countLabel);
+
+  const actions = document.createElement('div');
+  actions.className = 'inventory-card-actions';
+
+  if (isUseableItem(item)) {
+    const equippedSlots = getUseableSlotsForItem(item.id);
+    if (equippedSlots.length) {
+      const status = document.createElement('div');
+      status.className = 'inventory-card-status';
+      status.textContent = `Equipped: ${equippedSlots.map(slotLabel).join(', ')}`;
+      card.appendChild(status);
+      card.classList.add('equipped');
+    }
+    USEABLE_SLOTS.forEach(slotName => {
+      const btn = document.createElement('button');
+      btn.textContent = `Equip ${slotLabel(slotName)}`;
+      const slotItem = getEquippedSlotItem(slotName);
+      if (slotItem && slotItem.id === item.id) {
+        btn.disabled = true;
+      }
+      btn.addEventListener('click', () => equipItem(slotName, item.id, messageEl));
+      actions.appendChild(btn);
+    });
+  } else {
+    const equippedItem = getEquippedSlotItem(item.slot);
+    if (equippedItem && equippedItem.id === item.id) {
+      const status = document.createElement('div');
+      status.className = 'inventory-card-status';
+      status.textContent = 'Equipped';
+      card.appendChild(status);
+      card.classList.add('equipped');
+    }
+    const equipButton = document.createElement('button');
+    equipButton.textContent = `Equip ${slotLabel(item.slot)}`;
+    if (equippedItem && equippedItem.id === item.id) {
+      equipButton.disabled = true;
+    }
+    equipButton.addEventListener('click', () => equipItem(item.slot, item.id, messageEl));
+    actions.appendChild(equipButton);
+  }
+
+  footer.appendChild(actions);
+  card.appendChild(footer);
+
+  attachTooltip(card, () => itemTooltip(item));
+  return card;
+}
+
+function createInventoryMaterialCard(material, count) {
+  if (!material) return null;
+  const card = document.createElement('div');
+  card.className = 'shop-item-card inventory-material-card';
+
+  const header = document.createElement('div');
+  header.className = 'card-header';
+  const name = document.createElement('div');
+  name.className = 'card-name';
+  name.textContent = material.name || 'Material';
+  header.appendChild(name);
+  const rarity = document.createElement('div');
+  rarity.className = 'card-rarity';
+  rarity.textContent = material.rarity || 'Common';
+  header.appendChild(rarity);
+  card.appendChild(header);
+
+  const tags = document.createElement('div');
+  tags.className = 'card-tags';
+  const tag = document.createElement('span');
+  tag.className = 'card-tag';
+  tag.textContent = 'Material';
+  tags.appendChild(tag);
+  card.appendChild(tags);
+
+  const meta = document.createElement('div');
+  meta.className = 'card-description inventory-card-meta';
+  meta.textContent = formatItemMeta(material);
+  card.appendChild(meta);
+
+  if (material.description) {
+    const description = document.createElement('div');
+    description.className = 'card-description inventory-card-description';
+    description.textContent = material.description;
+    card.appendChild(description);
+  }
+
+  const footer = document.createElement('div');
+  footer.className = 'card-footer inventory-card-footer';
+  const countLabel = document.createElement('div');
+  countLabel.className = 'card-cost inventory-card-count';
+  countLabel.textContent = `Owned ×${count}`;
+  footer.appendChild(countLabel);
+  card.appendChild(footer);
+
+  attachTooltip(card, () => itemTooltip(material));
+  return card;
 }
 
 function applyShopFilters(items) {
@@ -4162,113 +4520,44 @@ async function renderInventory() {
   const grid = document.getElementById('inventory-grid');
   const materialGrid = document.getElementById('material-grid');
   const slots = document.getElementById('equipment-slots');
-  const summary = document.getElementById('loadout-summary');
-  if (!grid || !materialGrid || !slots || !summary) return;
+  const loadoutSummary = document.getElementById('loadout-summary');
+  const resultsSummary = document.getElementById('inventory-results-summary');
+  if (!grid || !materialGrid || !slots || !loadoutSummary) return;
   grid.textContent = 'Loading...';
   materialGrid.textContent = 'Loading...';
   slots.innerHTML = '';
-  summary.innerHTML = '';
+  loadoutSummary.innerHTML = '';
+  if (resultsSummary) resultsSummary.textContent = 'Loading inventory...';
   try {
     await ensureInventory();
   } catch (err) {
     grid.textContent = 'Failed to load inventory.';
     materialGrid.textContent = '';
     showMessage(message, err.message || 'Failed to load inventory', true);
+    if (resultsSummary) resultsSummary.textContent = '';
     return;
   }
   clearMessage(message);
   grid.innerHTML = '';
   materialGrid.innerHTML = '';
   const inventoryItems = Array.isArray(inventoryView.inventory) ? inventoryView.inventory : [];
-  if (!inventoryItems.length) {
-    const empty = document.createElement('div');
-    empty.textContent = 'No gear owned yet.';
-    grid.appendChild(empty);
-  } else {
-    inventoryItems.forEach(({ item, count }) => {
-      const card = document.createElement('div');
-      card.className = 'item-card';
-      const name = document.createElement('div');
-      name.className = 'name';
-      name.textContent = item.name;
-      card.appendChild(name);
-      const meta = document.createElement('div');
-      meta.className = 'meta';
-      meta.textContent = formatItemMeta(item);
-      card.appendChild(meta);
-      const countDiv = document.createElement('div');
-      countDiv.className = 'owned';
-      countDiv.textContent = `Count: ${count}`;
-      card.appendChild(countDiv);
-      if (isUseableItem(item)) {
-        const equippedSlots = getUseableSlotsForItem(item.id);
-        if (equippedSlots.length) {
-          const equippedTag = document.createElement('div');
-          equippedTag.className = 'meta';
-          equippedTag.textContent = `Equipped: ${equippedSlots.map(slotLabel).join(', ')}`;
-          card.appendChild(equippedTag);
-        }
-        USEABLE_SLOTS.forEach(slotName => {
-          const btn = document.createElement('button');
-          btn.textContent = `Equip ${slotLabel(slotName)}`;
-          const slotItem = getEquippedSlotItem(slotName);
-          if (slotItem && slotItem.id === item.id) {
-            btn.disabled = true;
-          }
-          btn.addEventListener('click', () => equipItem(slotName, item.id, message));
-          card.appendChild(btn);
-        });
-      } else {
-        const equippedItem = getEquippedSlotItem(item.slot);
-        if (equippedItem && equippedItem.id === item.id) {
-          const equippedTag = document.createElement('div');
-          equippedTag.className = 'meta';
-          equippedTag.textContent = 'Equipped';
-          card.appendChild(equippedTag);
-        }
-        const button = document.createElement('button');
-        button.textContent = `Equip ${slotLabel(item.slot)}`;
-        if (equippedItem && equippedItem.id === item.id) {
-          button.disabled = true;
-        }
-        button.addEventListener('click', () => equipItem(item.slot, item.id, message));
-        card.appendChild(button);
-      }
-      attachTooltip(card, () => itemTooltip(item));
-      grid.appendChild(card);
-    });
-  }
+  inventoryItemsCache = inventoryItems.filter(entry => entry && entry.item);
+  initializeInventoryControls(inventoryItemsCache.map(entry => entry.item));
+  ensureInventoryFilterControls();
+  updateInventoryDisplay();
 
   const materialItems = Array.isArray(inventoryView.materials) ? inventoryView.materials : [];
   if (!materialItems.length) {
     const emptyMaterial = document.createElement('div');
+    emptyMaterial.className = 'shop-empty';
     emptyMaterial.textContent = 'No materials collected yet.';
     materialGrid.appendChild(emptyMaterial);
   } else {
     materialItems.forEach(({ material, count }) => {
-      if (!material) return;
-      const card = document.createElement('div');
-      card.className = 'material-card';
-      const name = document.createElement('div');
-      name.className = 'name';
-      name.textContent = material.name;
-      card.appendChild(name);
-      const meta = document.createElement('div');
-      meta.className = 'meta';
-      meta.textContent = formatItemMeta(material);
-      card.appendChild(meta);
-      const countDiv = document.createElement('div');
-      countDiv.className = 'owned';
-      countDiv.textContent = `Count: ${count}`;
-      card.appendChild(countDiv);
-      if (material.description) {
-        const desc = document.createElement('div');
-        desc.className = 'meta description';
-        desc.textContent = material.description;
-        card.appendChild(desc);
+      const card = createInventoryMaterialCard(material, count);
+      if (card) {
+        materialGrid.appendChild(card);
       }
-      attachTooltip(card, () => itemTooltip(material));
-      materialGrid.appendChild(card);
     });
   }
 
@@ -4287,6 +4576,7 @@ async function renderInventory() {
     slotDiv.appendChild(label);
     const equipped = getEquippedSlotItem(slot);
     if (equipped) {
+      slotDiv.classList.add('filled');
       const itemName = document.createElement('div');
       itemName.className = 'item-name';
       itemName.textContent = equipped.name;
@@ -4325,6 +4615,7 @@ async function renderInventory() {
     slotDiv.appendChild(label);
     const equipped = getEquippedSlotItem(slot);
     if (equipped) {
+      slotDiv.classList.add('filled');
       const itemName = document.createElement('div');
       itemName.className = 'item-name';
       itemName.textContent = equipped.name;
@@ -4352,7 +4643,8 @@ async function renderInventory() {
     slots.appendChild(slotDiv);
   });
 
-  populateLoadoutSummary(summary, inventoryView.derived);
+  loadoutSummary.innerHTML = '';
+  populateLoadoutSummary(loadoutSummary, inventoryView.derived);
 }
 
 async function equipItem(slot, itemId, messageEl) {

--- a/ui/style.css
+++ b/ui/style.css
@@ -535,19 +535,86 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #shop-gold { font-weight:bold; text-transform:uppercase; }
 .message { border:1px solid #000; padding:4px 6px; background:#fff; }
 .message.error { background:#000; color:#fff; }
-.item-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(150px,1fr)); gap:8px; }
-.item-card { border:1px solid #000; padding:8px; display:flex; flex-direction:column; gap:6px; background:#fff; min-height:150px; }
-.item-card .name { font-weight:bold; text-transform:uppercase; }
-.item-card .meta { font-size:12px; }
-.item-card .cost { font-weight:bold; }
-.item-card .owned { font-size:12px; }
-.item-card button { margin-top:auto; }
-.material-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(150px,1fr)); gap:8px; }
-.material-card { border:1px solid #000; padding:8px; display:flex; flex-direction:column; gap:6px; background:#fff; min-height:130px; }
-.material-card .name { font-weight:bold; text-transform:uppercase; }
-.material-card .meta { font-size:12px; }
-.material-card .meta.description { font-style:italic; color:#333; }
-.material-card .owned { font-size:12px; }
+.item-grid,
+.material-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(200px, 1fr));
+  gap:16px;
+}
+
+.inventory-item-card,
+.inventory-material-card {
+  position:relative;
+}
+
+.inventory-card-meta {
+  color:#111;
+  font-size:12px;
+}
+
+.inventory-card-description {
+  color:#333;
+  font-size:12px;
+  font-style:italic;
+}
+
+.inventory-item-card .inventory-card-status {
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  border:1px dashed #000;
+  padding:2px 6px;
+  align-self:flex-start;
+}
+
+.inventory-item-card.equipped {
+  background:#000;
+  color:#fff;
+  border-color:#fff;
+  box-shadow:4px 4px 0 #000, 0 0 0 2px #fff inset;
+}
+
+.inventory-item-card.equipped .card-description {
+  color:#f2f2f2;
+}
+
+.inventory-item-card.equipped .card-rarity,
+.inventory-item-card.equipped .card-tag {
+  border-color:#fff;
+  color:#fff;
+}
+
+.inventory-item-card.equipped .inventory-card-status,
+.inventory-item-card.equipped .inventory-card-count {
+  border-color:#fff;
+  color:#fff;
+}
+
+.inventory-item-card.equipped button {
+  background:#fff;
+  color:#000;
+}
+
+.inventory-card-footer {
+  gap:12px;
+}
+
+.inventory-card-count {
+  font-size:12px;
+  letter-spacing:1px;
+}
+
+.inventory-card-actions {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  justify-content:flex-end;
+}
+
+.inventory-card-actions button {
+  flex:1 0 auto;
+}
+
 
 .shop-layout { display:flex; gap:16px; align-items:flex-start; flex-wrap:wrap; }
 #shop-controls { flex:0 0 260px; border:2px solid #000; background:#fff; padding:16px; display:flex; flex-direction:column; gap:16px; box-shadow:6px 6px 0 #000; }
@@ -585,28 +652,235 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .shop-item-card button { font-weight:bold; text-transform:uppercase; box-shadow:3px 3px 0 #000; padding:6px 10px; }
 .shop-empty { padding:24px; text-align:center; text-transform:uppercase; letter-spacing:1px; font-weight:bold; border:2px dashed #000; }
 
+.inventory-controls {
+  border:2px solid #000;
+  background:#fff;
+  box-shadow:6px 6px 0 #000;
+  margin-bottom:16px;
+  display:flex;
+  flex-direction:column;
+}
+
+.inventory-controls-bar {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  padding:12px 16px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-weight:bold;
+}
+
+.inventory-controls-actions {
+  display:flex;
+  align-items:center;
+  gap:12px;
+}
+
+.inventory-filter-toggle {
+  font-weight:bold;
+  text-transform:uppercase;
+  box-shadow:4px 4px 0 #000;
+  padding:8px 12px;
+  background:#fff;
+  color:#000;
+  border:2px solid #000;
+}
+
+.inventory-filter-panel {
+  display:none;
+  border-top:2px solid #000;
+  padding:16px;
+  background:repeating-linear-gradient(90deg, #fff 0px, #fff 8px, #f4f4f4 8px, #f4f4f4 16px);
+}
+
+.inventory-filter-panel.open {
+  display:block;
+}
+
+.inventory-filter-groups {
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+}
+
+.inventory-filter-panel .filter-section {
+  flex:1;
+  min-width:180px;
+}
+
+.inventory-filter-panel h3 {
+  margin:0;
+  text-transform:uppercase;
+  font-size:14px;
+  letter-spacing:1px;
+}
+
+.inventory-filter-panel .filter-options {
+  flex-direction:row;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.inventory-results-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:8px 4px;
+  margin-bottom:16px;
+  text-transform:uppercase;
+  font-size:12px;
+  letter-spacing:1px;
+  font-weight:bold;
+}
+
+#inventory-results-summary {
+  font-weight:bold;
+}
+
 @media (max-width: 900px) {
   .shop-layout { flex-direction:column; }
   #shop-controls { width:100%; }
 }
 
-.inventory-layout { display:flex; gap:16px; flex-wrap:wrap; }
-.inventory-column { flex:1; min-width:220px; }
-.inventory-column h3 { margin-top:0; border-bottom:1px solid #000; padding-bottom:4px; }
-.equipment-panel { max-width:320px; }
-.equipment-slots { display:grid; grid-template-columns:repeat(2, minmax(140px,1fr)); gap:8px; margin-bottom:16px; }
-.slot-section-header { grid-column:1 / -1; font-weight:bold; text-transform:uppercase; letter-spacing:1px; padding:4px 0; }
-.equipment-slots .slot-section-header:first-child { padding-top:0; }
-.equipment-slot { border:1px solid #000; padding:8px; min-height:110px; display:flex; flex-direction:column; background:#fff; }
-.equipment-slot.empty { border-style:dashed; }
-.equipment-slot .slot-name { font-weight:bold; margin-bottom:4px; }
-.equipment-slot .item-name { flex-grow:1; }
-.equipment-slot button { margin-top:8px; }
-.equipment-slot.useable-slot { background:#f8f8f8; }
-.equipment-slot.useable-slot.empty { background:#fff; }
+.inventory-controls-bar { flex-wrap:wrap; }
 
-.loadout-summary { display:flex; flex-direction:column; gap:12px; }
-.loadout-summary .stats-table { width:100%; }
+@media (max-width: 700px) {
+  .inventory-filter-panel .filter-options {
+    flex-direction:column;
+  }
+}
+
+.inventory-layout {
+  display:grid;
+  grid-template-columns:minmax(0, 1fr) minmax(280px, 1fr);
+  gap:16px;
+  align-items:start;
+}
+
+@media (max-width: 980px) {
+  .inventory-layout {
+    grid-template-columns:1fr;
+  }
+}
+
+.inventory-column {
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  border:2px solid #000;
+  background:#fff;
+  padding:16px;
+  box-shadow:6px 6px 0 #000;
+  min-height:100%;
+}
+
+.inventory-column h3 {
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  border-bottom:2px solid #000;
+  padding-bottom:6px;
+}
+
+.inventory-column .item-grid,
+.inventory-column .material-grid {
+  flex:1;
+}
+
+.equipment-panel {
+  min-width:0;
+}
+
+.equipment-slots {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));
+  gap:12px;
+  margin-bottom:16px;
+}
+
+.slot-section-header {
+  grid-column:1 / -1;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  padding:4px 0;
+}
+
+.equipment-slots .slot-section-header:first-child {
+  padding-top:0;
+}
+
+.equipment-slot {
+  border:2px solid #000;
+  padding:12px;
+  min-height:130px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  background:#fff;
+  box-shadow:3px 3px 0 #000;
+}
+
+.equipment-slot.empty {
+  border-style:dashed;
+  background:repeating-linear-gradient(45deg, #fff 0px, #fff 6px, #f7f7f7 6px, #f7f7f7 12px);
+  color:#555;
+}
+
+.equipment-slot.filled {
+  background:#000;
+  color:#fff;
+}
+
+.equipment-slot.filled .meta {
+  color:#f5f5f5;
+}
+
+.equipment-slot .slot-name {
+  font-weight:bold;
+  margin-bottom:4px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.equipment-slot .item-name {
+  flex-grow:1;
+}
+
+.equipment-slot button {
+  margin-top:auto;
+  align-self:flex-start;
+  box-shadow:3px 3px 0 #000;
+}
+
+.equipment-slot.filled button {
+  background:#fff;
+  color:#000;
+}
+
+.loadout-summary {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  border-top:2px dashed #000;
+  padding-top:12px;
+}
+
+.loadout-summary .stats-table {
+  width:100%;
+  border-collapse:collapse;
+}
+
+.loadout-summary .stats-table th,
+.loadout-summary .stats-table td {
+  border:1px solid #000;
+  padding:4px 6px;
+  text-transform:uppercase;
+  font-size:12px;
+  letter-spacing:1px;
+}
 .simple-list { list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:4px; }
 .simple-list li { border:1px solid #000; padding:4px 6px; background:#fff; }
 .challenge-panel { border:1px solid #000; padding:12px; display:flex; flex-direction:column; gap:12px; background:#fff; }


### PR DESCRIPTION
## Summary
- add a collapsible shop-style filter bar and results summary to the inventory tab
- restyle inventory items, materials, and equipment panels to use the shop card aesthetic and updated grid layout
- implement reusable inventory filter logic and card builders that drive the new presentation and controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd86f6cbb88320a78ba950e822b742