### PR TITLE
Surface material recovery roll details in job logs

### DIFF
--- a/models/Character.js
+++ b/models/Character.js
@@ -44,6 +44,14 @@ const jobMissingSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const jobGeneratedMaterialSchema = new mongoose.Schema(
+  {
+    materialId: { type: String, required: true },
+    amount: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
 const jobLogEntrySchema = new mongoose.Schema(
   {
     timestamp: { type: Date, default: Date.now },
@@ -56,6 +64,14 @@ const jobLogEntrySchema = new mongoose.Schema(
     reason: { type: String, default: null },
     missing: { type: [jobMissingSchema], default: undefined },
     materials: { type: materialsSchema, default: () => ({}) },
+    generatedMaterials: { type: [jobGeneratedMaterialSchema], default: undefined },
+    generationAttempted: { type: Boolean, default: undefined },
+    generationSucceeded: { type: Boolean, default: undefined },
+    generationChance: { type: Number, default: undefined },
+    generationRoll: { type: Number, default: undefined },
+    generationShare: { type: Number, default: undefined },
+    generationMultiplier: { type: Number, default: undefined },
+    generationAttribute: { type: String, default: null },
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary
- persist recovery roll values on job log entries alongside chance/share metadata
- capture the roll when attempting material conjuration so both successes and failures record it
- refresh the character activity feed copy to call out the attempted conjuration with chance, roll, and results

## Testing
- node --check models/Character.js
- node --check systems/jobService.js
- node --check ui/main.js

------
https://chatgpt.com/codex/tasks/task_e_68cd81590fb08320a2e19a655759f155