### PR TITLE
Add job log schema fields for material generation

### DIFF
--- a/models/Character.js
+++ b/models/Character.js
@@ -44,6 +44,14 @@ const jobMissingSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const jobGeneratedMaterialSchema = new mongoose.Schema(
+  {
+    materialId: { type: String, required: true },
+    amount: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
 const jobLogEntrySchema = new mongoose.Schema(
   {
     timestamp: { type: Date, default: Date.now },
@@ -56,6 +64,14 @@ const jobLogEntrySchema = new mongoose.Schema(
     reason: { type: String, default: null },
     missing: { type: [jobMissingSchema], default: undefined },
     materials: { type: materialsSchema, default: () => ({}) },
+    generatedMaterials: { type: [jobGeneratedMaterialSchema], default: undefined },
+    generationAttempted: { type: Boolean, default: false },
+    generationSucceeded: { type: Boolean, default: false },
+    generationChance: { type: Number, default: null },
+    generationShare: { type: Number, default: null },
+    generationMultiplier: { type: Number, default: null },
+    generationRoll: { type: Number, default: null },
+    generationAttribute: { type: String, default: null },
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary
- add a schema for generated materials stored in job logs
- persist creation roll metadata on job log entries so recent activity can display roll details

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdf845f2748320a52838d5879d7398