### PR TITLE
Fix job material recovery share from mongoose docs

### DIFF
--- a/systems/jobService.js
+++ b/systems/jobService.js
@@ -68,13 +68,26 @@ function normalizeAttributeMap(attributes) {
   if (!attributes || typeof attributes !== 'object') {
     return result;
   }
-  Object.entries(attributes).forEach(([key, value]) => {
+  let source = attributes;
+  if (typeof source.toObject === 'function') {
+    source = source.toObject();
+  } else if (source._doc && typeof source._doc === 'object') {
+    source = source._doc;
+  }
+  if (!source || typeof source !== 'object') {
+    return result;
+  }
+  Object.entries(source).forEach(([key, value]) => {
     if (!key) {
+      return;
+    }
+    const normalizedKey = typeof key === 'string' ? key.trim().toLowerCase() : null;
+    if (!normalizedKey) {
       return;
     }
     const numeric = Number(value);
     if (Number.isFinite(numeric) && numeric > 0) {
-      result[key] = numeric;
+      result[normalizedKey] = numeric;
     }
   });
   return result;


### PR DESCRIPTION
## Summary
- normalize character attributes by converting mongoose subdocuments to plain objects before computing totals
- lowercase attribute keys to ensure job attribute lookups succeed when calculating material recovery chance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdfb825d6c832094f27a4156e3dfe1