### PR TITLE
Restyle job activity cards and remove redundant summary

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -1951,62 +1951,6 @@ function getJobLogInfo(entry) {
   };
 }
 
-function formatJobLogMessage(entry) {
-  const info = getJobLogInfo(entry);
-  if (!info) return '';
-  const {
-    itemName,
-    rarity,
-    generatedMaterials,
-    attempted,
-    statGain,
-    reason,
-    describeCreationRoll,
-    creation,
-  } = info;
-  if (info.type === 'crafted') {
-    const rarityText = rarity ? `${rarity} ` : '';
-    let message = `Crafted ${rarityText}${itemName}.`;
-    if (generatedMaterials.length) {
-      const generatedText = generatedMaterials.map(m => `${m.name} ×${m.amount}`).join(', ');
-      const creationSummary = describeCreationRoll('succeeded');
-      if (creationSummary) {
-        message += ` ${creationSummary}`;
-      }
-      message += ` Generated missing materials: ${generatedText}.`;
-    } else if (attempted) {
-      const creationSummary = describeCreationRoll(creation.succeeded ? 'succeeded' : 'failed');
-      if (creationSummary) {
-        message += ` ${creationSummary}`;
-      }
-    }
-    if (statGain) {
-      message += ` Gained +${statGain.amount} ${statGain.stat}.`;
-    }
-    return message;
-  }
-  if (reason === 'insufficient-materials' && info.missingMaterials.length) {
-    const missingText = info.missingMaterials
-      .map(m => `${m.name} (${m.available}/${m.required})`)
-      .join(', ');
-    let message = `Attempted to craft ${itemName} but lacked ${missingText}.`;
-    if (attempted) {
-      const creationSummary = describeCreationRoll('failed', { includeTargets: true });
-      if (creationSummary) {
-        message += ` ${creationSummary}`;
-      }
-    }
-    return message;
-  }
-  if (attempted) {
-    const creationSummary = describeCreationRoll(creation.succeeded ? 'succeeded' : 'failed');
-    if (creationSummary) {
-      return `Attempted to craft ${itemName} but it failed. ${creationSummary}`;
-    }
-  }
-  return `Attempted to craft ${itemName} but it failed.`;
-}
-
 function buildJobLogListItem(entry) {
   const info = getJobLogInfo(entry);
   const li = document.createElement('li');
@@ -2105,14 +2049,6 @@ function buildJobLogListItem(entry) {
 
   if (info.statGain) {
     addDetail('Stat Gain', `+${info.statGain.amount} ${info.statGain.stat}`);
-  }
-
-  const summaryText = formatJobLogMessage(entry);
-  if (summaryText) {
-    const summary = document.createElement('p');
-    summary.className = 'job-log-summary';
-    summary.textContent = summaryText;
-    details.appendChild(summary);
   }
 
   li.appendChild(details);

--- a/ui/style.css
+++ b/ui/style.css
@@ -1395,20 +1395,23 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 .job-log-entry {
   border:2px solid #000;
-  padding:12px 14px;
-  background:#fff;
+  padding:10px 12px;
+  background:#f5f3ef;
   display:flex;
   flex-direction:column;
-  gap:10px;
-  box-shadow:3px 3px 0 rgba(0,0,0,0.2);
+  gap:8px;
+  position:relative;
+  box-shadow:4px 4px 0 rgba(0,0,0,0.8);
 }
 .job-log-entry.log-crafted {
-  border-color:#1b5e20;
-  background:#e6f7e6;
+  background:
+    repeating-linear-gradient(135deg, rgba(0,0,0,0.08) 0 6px, transparent 6px 12px),
+    #f5f3ef;
 }
 .job-log-entry.log-failed {
-  border-color:#8b1e24;
-  background:#ffe6e6;
+  background:
+    repeating-linear-gradient(135deg, rgba(0,0,0,0.12) 0 6px, transparent 6px 12px),
+    #f5f3ef;
 }
 .job-log-header {
   display:flex;
@@ -1434,28 +1437,32 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   color:#333;
 }
 .job-log-badge {
-  padding:4px 10px;
+  padding:3px 9px;
   border:2px solid #000;
-  font-size:11px;
+  font-size:10px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  background:#000;
-  color:#fff;
+  color:#000;
+  background:#f5f3ef;
+  box-shadow:2px 2px 0 rgba(0,0,0,0.8);
 }
 .job-log-badge.success {
-  background:#1b5e20;
+  background:
+    repeating-linear-gradient(135deg, #ffffff 0 4px, #cbcbcb 4px 8px);
 }
 .job-log-badge.failure {
-  background:#8b1e24;
+  background:
+    repeating-linear-gradient(135deg, #f1f1f1 0 3px, #bcbcbc 3px 6px);
 }
 .job-log-badge.warning {
-  background:#c56a11;
+  background:
+    repeating-linear-gradient(135deg, #f0f0f0 0 2px, #a9a9a9 2px 4px);
 }
 .job-log-details {
   display:flex;
   flex-direction:column;
-  gap:6px;
+  gap:4px;
 }
 .job-log-detail {
   display:flex;
@@ -1463,25 +1470,19 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   align-items:flex-start;
 }
 .job-log-detail .label {
-  min-width:140px;
+  min-width:120px;
   font-size:11px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  color:#111;
+  color:#000;
 }
 .job-log-detail .value {
   flex:1;
   font-size:12px;
   line-height:1.4;
-  color:#000;
-}
-.job-log-summary {
-  margin:8px 0 0;
-  font-size:12px;
-  line-height:1.5;
-  font-weight:bold;
   color:#111;
+  font-family:'Courier New', monospace;
 }
 .job-log-footer {
   font-size:11px;


### PR DESCRIPTION
## Summary
- restyle the job activity cards with monochrome patterns and bolder pixel-style shadows to match the game's vintage aesthetic
- adjust badge and detail styling to stay within the black-and-white palette while keeping statuses distinct
- remove the redundant narrative summary text from each activity card to make the feed more compact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce07f792d483208d26846b84360631