### PR TITLE
Handle login failures caused by job processing errors

### DIFF
--- a/systems/playerService.js
+++ b/systems/playerService.js
@@ -69,9 +69,16 @@ async function getPlayerCharacters(playerId) {
   const characterDocs = await CharacterModel.find({ playerId });
   const characters = [];
   for (const doc of characterDocs) {
-    const { changed } = await processJobForCharacter(doc);
-    if (changed) {
-      await doc.save();
+    try {
+      const { changed } = await processJobForCharacter(doc);
+      if (changed) {
+        await doc.save();
+      }
+    } catch (err) {
+      console.error(
+        `failed to process jobs for character ${doc && doc.characterId != null ? doc.characterId : "unknown"}`,
+        err
+      );
     }
     characters.push(serializeCharacter(doc));
   }


### PR DESCRIPTION
## Summary
- prevent login from failing when character job processing throws
- log per-character job processing errors while still returning serialized characters

## Testing
- npm start *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.fwdtteo.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0bc769888320a73446f324af82c9