### PR TITLE
Restyle job cards with a solid dark theme

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -983,7 +983,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   display:flex;
   flex-direction:column;
   font-family:'Courier New', monospace;
-  background-image:repeating-linear-gradient(45deg, rgba(255,255,255,0.05) 0, rgba(255,255,255,0.05) 4px, transparent 4px, transparent 8px);
+  background-image:none;
 }
 .job-dialog-header {
   display:flex;
@@ -1054,14 +1054,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:16px;
 }
 .job-card {
-  border:3px solid #000;
-  background:#fff;
-  color:#000;
+  border:3px solid #fff;
+  background:#050505;
+  color:#f5f5f5;
   padding:18px;
   display:flex;
   flex-direction:column;
   gap:12px;
-  box-shadow:6px 6px 0 rgba(0,0,0,0.85);
+  box-shadow:6px 6px 0 rgba(255,255,255,0.18);
 }
 .job-card h3 {
   margin:0;
@@ -1080,28 +1080,28 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-weight:bold;
   text-transform:uppercase;
   padding:6px 14px;
-  border:3px solid #000;
-  background:#fff;
-  color:#000;
-  box-shadow:4px 4px 0 #000;
+  border:3px solid #fff;
+  background:#050505;
+  color:#f5f5f5;
+  box-shadow:4px 4px 0 rgba(255,255,255,0.2);
 }
 .job-card button:hover,
 .job-card button:focus {
-  background:#000;
-  color:#fff;
+  background:#f5f5f5;
+  color:#050505;
 }
 .job-attribute {
   font-size:12px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  color:#1a1a1a;
+  color:#fafafa;
 }
 .job-description {
   margin:0;
   font-size:13px;
   line-height:1.4;
-  color:#1a1a1a;
+  color:#e8e8e8;
 }
 .job-meta-list {
   list-style:none;
@@ -1115,22 +1115,22 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   display:flex;
   justify-content:space-between;
   align-items:center;
-  border:2px solid #000;
-  background:#fff;
+  border:2px solid #f5f5f5;
+  background:#0f0f0f;
   padding:6px 10px;
-  box-shadow:3px 3px 0 #000;
+  box-shadow:3px 3px 0 rgba(255,255,255,0.18);
 }
 .job-meta-list .label {
   font-size:11px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  color:#000;
+  color:#f0f0f0;
 }
 .job-meta-list .value {
   font-family:'Courier New', monospace;
   font-size:13px;
-  color:#000;
+  color:#ffffff;
 }
 .job-empty-text {
   border:2px dashed rgba(255,255,255,0.5);


### PR DESCRIPTION
## Summary
- remove the striped background pattern from the job dialog container
- restyle job cards with a black background, white text, and updated button hover treatment
- update job metadata list styling to keep details legible on the darker cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce0df71f708320a1c6fc58844ad049