### PR TITLE
Restyle job log cards without striping

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -1396,22 +1396,16 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-log-entry {
   border:2px solid #000;
   padding:10px 12px;
-  background:#f5f3ef;
+  background:#fff;
   display:flex;
   flex-direction:column;
   gap:8px;
   position:relative;
-  box-shadow:4px 4px 0 rgba(0,0,0,0.8);
+  box-shadow:4px 4px 0 #000;
 }
-.job-log-entry.log-crafted {
-  background:
-    repeating-linear-gradient(135deg, rgba(0,0,0,0.08) 0 6px, transparent 6px 12px),
-    #f5f3ef;
-}
+.job-log-entry.log-crafted,
 .job-log-entry.log-failed {
-  background:
-    repeating-linear-gradient(135deg, rgba(0,0,0,0.12) 0 6px, transparent 6px 12px),
-    #f5f3ef;
+  background:#fff;
 }
 .job-log-header {
   display:flex;
@@ -1444,20 +1438,18 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   letter-spacing:1px;
   font-weight:bold;
   color:#000;
-  background:#f5f3ef;
-  box-shadow:2px 2px 0 rgba(0,0,0,0.8);
+  background:#fff;
+  box-shadow:2px 2px 0 #000;
 }
 .job-log-badge.success {
-  background:
-    repeating-linear-gradient(135deg, #ffffff 0 4px, #cbcbcb 4px 8px);
+  background:#fff;
 }
 .job-log-badge.failure {
-  background:
-    repeating-linear-gradient(135deg, #f1f1f1 0 3px, #bcbcbc 3px 6px);
+  background:#000;
+  color:#fff;
 }
 .job-log-badge.warning {
-  background:
-    repeating-linear-gradient(135deg, #f0f0f0 0 2px, #a9a9a9 2px 4px);
+  background:#fff;
 }
 .job-log-details {
   display:flex;


### PR DESCRIPTION
## Summary
- restyle job log entries to use the solid black-and-white card treatment from the shop and inventory
- remove striped backgrounds from job log badges and adjust the failure badge for contrast

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce100f5b408320bf635e131786ce2c