### PR TITLE
Guard against missing delete on material containers

### DIFF
--- a/systems/jobService.js
+++ b/systems/jobService.js
@@ -308,8 +308,10 @@ function setMaterialCount(container, id, value) {
   if (typeof container.set === 'function') {
     if (numeric > 0) {
       container.set(id, numeric);
-    } else {
+    } else if (typeof container.delete === 'function') {
       container.delete(id);
+    } else {
+      delete container[id];
     }
   } else if (numeric > 0) {
     container[id] = numeric;


### PR DESCRIPTION
## Summary
- avoid calling a missing delete function when updating material containers
- fall back to removing the property directly when the container lacks a delete method

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce135ee1a88320b1e73ef4468aa96d