### PR TITLE
Restyle job dialog and fix log contrast

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -1054,14 +1054,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:16px;
 }
 .job-card {
-  border:3px solid #fff;
-  background:#050505;
-  color:#f5f5f5;
+  border:2px solid #000;
+  background:#fff;
+  color:#111;
   padding:18px;
   display:flex;
   flex-direction:column;
   gap:12px;
-  box-shadow:6px 6px 0 rgba(255,255,255,0.18);
+  box-shadow:6px 6px 0 #000;
 }
 .job-card h3 {
   margin:0;
@@ -1080,28 +1080,36 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-weight:bold;
   text-transform:uppercase;
   padding:6px 14px;
-  border:3px solid #fff;
-  background:#050505;
-  color:#f5f5f5;
-  box-shadow:4px 4px 0 rgba(255,255,255,0.2);
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:4px 4px 0 #000;
+  transition:background 0.2s ease, color 0.2s ease;
 }
 .job-card button:hover,
 .job-card button:focus {
-  background:#f5f5f5;
-  color:#050505;
+  background:#000;
+  color:#fff;
+}
+.job-card button[disabled] {
+  background:#111;
+  color:#f0f0f0;
+  border-color:#111;
+  box-shadow:4px 4px 0 #444;
+  cursor:not-allowed;
 }
 .job-attribute {
   font-size:12px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  color:#fafafa;
+  color:#000;
 }
 .job-description {
   margin:0;
   font-size:13px;
   line-height:1.4;
-  color:#e8e8e8;
+  color:#333;
 }
 .job-meta-list {
   list-style:none;
@@ -1115,22 +1123,22 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   display:flex;
   justify-content:space-between;
   align-items:center;
-  border:2px solid #f5f5f5;
-  background:#0f0f0f;
+  border:2px solid #000;
+  background:#fefefe;
   padding:6px 10px;
-  box-shadow:3px 3px 0 rgba(255,255,255,0.18);
+  box-shadow:3px 3px 0 #000;
 }
 .job-meta-list .label {
   font-size:11px;
   text-transform:uppercase;
   letter-spacing:1px;
   font-weight:bold;
-  color:#f0f0f0;
+  color:#000;
 }
 .job-meta-list .value {
   font-family:'Courier New', monospace;
   font-size:13px;
-  color:#ffffff;
+  color:#111;
 }
 .job-empty-text {
   border:2px dashed rgba(255,255,255,0.5);
@@ -1140,6 +1148,11 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-size:13px;
   font-style:italic;
   color:inherit;
+}
+.job-card .job-empty-text {
+  border-color:rgba(0,0,0,0.4);
+  background:rgba(0,0,0,0.05);
+  color:#000;
 }
 .job-output-section .job-empty-text,
 .job-log-section .job-empty-text,
@@ -1410,7 +1423,6 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   border-color:#000;
   box-shadow:4px 4px 0 #000;
 }
-.job-log-entry.log-crafted,
 .job-log-entry.log-failed {
   background:#000;
   color:#fff;


### PR DESCRIPTION
## Summary
- restyle the job selection cards to match the monochrome shop/inventory styling
- adjust job card empty states and buttons for better contrast against the new palette
- ensure job log entries render successful crafts on white cards and failed crafts on black cards for readability

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce15d611dc832096d16f12c4493766