### PR TITLE
Improve job dialog readability and monochrome contrast

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -1169,6 +1169,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-recipe {
   border:2px solid #000;
   background:#fff;
+  color:#000;
   padding:12px;
   display:flex;
   flex-direction:column;
@@ -1203,6 +1204,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-material {
   border:2px solid #000;
   background:#fff;
+  color:#000;
   display:flex;
   align-items:center;
   gap:8px;
@@ -1226,6 +1228,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-material .count {
   font-family:'Courier New', monospace;
   font-size:12px;
+  color:#000;
 }
 .job-material .owned-count {
   font-size:11px;
@@ -1370,6 +1373,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-output-item {
   border:2px solid #000;
   background:#f7f7f7;
+  color:#000;
   padding:8px 10px;
   display:flex;
   align-items:center;
@@ -1422,6 +1426,12 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   color:#000;
   border-color:#000;
   box-shadow:4px 4px 0 #000;
+}
+.job-log-entry.log-crafted .job-log-rarity,
+.job-log-entry.log-crafted .job-log-detail .label,
+.job-log-entry.log-crafted .job-log-detail .value,
+.job-log-entry.log-crafted .job-log-footer {
+  color:#000;
 }
 .job-log-entry.log-failed {
   background:#000;


### PR DESCRIPTION
## Summary
- ensure job materials, recipes, and outputs render with dark text on light monochrome cards
- keep job log success entries legible with enforced light backgrounds while preserving inverted failure styling

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ce1b3409348320a28d8b54f6bab9ff