### PR TITLE
Add wisdom-scaling spells and stat-based DOT support

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -120,5 +120,67 @@
     "effects": [
       { "type": "MagicDamage", "value": 6 }
     ]
+  },
+  {
+    "id": 11,
+    "name": "Sun Beam",
+    "school": "magical",
+    "costType": "mana",
+    "costValue": 20,
+    "cooldown": 20,
+    "scaling": ["wisdom"],
+    "effects": [
+      {
+        "type": "Ignite",
+        "damage": 5,
+        "interval": 2,
+        "duration": 10,
+        "damageScaling": { "wisdom": 0.4 }
+      }
+    ]
+  },
+  {
+    "id": 12,
+    "name": "Focus",
+    "school": "magical",
+    "costType": "mana",
+    "costValue": 12,
+    "cooldown": 16,
+    "scaling": ["wisdom"],
+    "effects": [
+      {
+        "type": "ResourceOverTime",
+        "resource": "mana",
+        "value": 8,
+        "interval": 10,
+        "duration": 30,
+        "scaling": { "wisdom": 0.35 },
+        "target": "self"
+      }
+    ]
+  },
+  {
+    "id": 13,
+    "name": "Righteous Blade",
+    "school": "physical",
+    "costType": "stamina",
+    "costValue": 25,
+    "costs": [
+      { "type": "stamina", "value": 25 },
+      { "type": "mana", "value": 25 }
+    ],
+    "cooldown": 22,
+    "scaling": ["wisdom"],
+    "effects": [
+      { "type": "PhysicalDamage", "value": 12, "scaling": { "wisdom": 0.6 } },
+      {
+        "type": "Ignite",
+        "damage": 4,
+        "interval": 2,
+        "duration": 10,
+        "chance": 0.35,
+        "damageScaling": { "wisdom": 0.25 }
+      }
+    ]
   }
 ]

--- a/domain/ability.js
+++ b/domain/ability.js
@@ -1,10 +1,48 @@
+function normalizeCostEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const typeRaw = typeof entry.type === 'string' ? entry.type.trim().toLowerCase() : null;
+  if (!typeRaw) return null;
+  const valueRaw = Number(entry.value);
+  if (!Number.isFinite(valueRaw) || valueRaw <= 0) return null;
+  return { type: typeRaw, value: Math.round(valueRaw) };
+}
+
+function normalizeCosts(costType, costValue, costs) {
+  const entries = [];
+  if (Array.isArray(costs)) {
+    costs.forEach(item => {
+      const normalized = normalizeCostEntry(item);
+      if (normalized) {
+        entries.push(normalized);
+      }
+    });
+  }
+  const legacy = normalizeCostEntry({ type: costType, value: costValue });
+  if (legacy && !entries.length) {
+    entries.push(legacy);
+  }
+  return entries;
+}
+
 class Ability {
-  constructor({ id, name, school, costType, costValue, cooldown, scaling = [], effects = [] }) {
+  constructor({
+    id,
+    name,
+    school,
+    costType,
+    costValue,
+    costs,
+    cooldown,
+    scaling = [],
+    effects = [],
+  }) {
     this.id = id;
     this.name = name;
     this.school = school; // 'physical' or 'magical'
-    this.costType = costType; // 'stamina' or 'mana'
-    this.costValue = costValue;
+    this.costs = normalizeCosts(costType, costValue, costs);
+    const primaryCost = this.costs[0] || null;
+    this.costType = primaryCost ? primaryCost.type : costType; // legacy support
+    this.costValue = primaryCost ? primaryCost.value : costValue; // legacy support
     this.cooldown = cooldown; // seconds
     this.scaling = scaling; // array of stat names
     this.effects = effects; // array of Effect descriptors

--- a/systems/rotationEngine.js
+++ b/systems/rotationEngine.js
@@ -12,17 +12,45 @@ function getAction(combatant, now, abilityMap) {
 
   const cooldownReady =
     !combatant.cooldowns[abilityId] || combatant.cooldowns[abilityId] <= now;
-  const costType = ability.costType;
-  const baseCost = typeof ability.costValue === 'number' ? ability.costValue : 0;
+  const costs =
+    Array.isArray(ability.costs) && ability.costs.length
+      ? ability.costs
+      : ability.costType
+      ? [{ type: ability.costType, value: ability.costValue }]
+      : [];
   const modifiers = combatant.resourceCostModifiers || {};
-  const modifierValue = Number.isFinite(modifiers[costType]) ? modifiers[costType] : 0;
-  const costReduction = Math.max(0, Math.min(1, modifierValue));
-  const effectiveCost = Math.max(0, Math.ceil(baseCost * (1 - costReduction)));
-  const availableResource = typeof combatant[costType] === 'number' ? combatant[costType] : 0;
-  const hasResource = availableResource >= effectiveCost;
+  const payments = costs.map(entry => {
+    const resource = typeof entry.type === 'string' ? entry.type : null;
+    const baseCost = Number.isFinite(entry.value) ? entry.value : 0;
+    if (!resource || baseCost <= 0) {
+      return {
+        resource,
+        base: baseCost,
+        required: 0,
+        available: resource && Number.isFinite(combatant[resource]) ? combatant[resource] : 0,
+        hasEnough: true,
+      };
+    }
+    const modifierValue = Number.isFinite(modifiers[resource]) ? modifiers[resource] : 0;
+    const costReduction = Math.max(0, Math.min(1, modifierValue));
+    const effective = Math.max(0, Math.ceil(baseCost * (1 - costReduction)));
+    const available = Number.isFinite(combatant[resource]) ? combatant[resource] : 0;
+    return {
+      resource,
+      base: baseCost,
+      required: effective,
+      available,
+      hasEnough: available >= effective,
+    };
+  });
+  const hasResources = payments.every(payment => payment.hasEnough !== false);
 
-  if (cooldownReady && hasResource) {
-    combatant[costType] -= effectiveCost;
+  if (cooldownReady && hasResources) {
+    payments.forEach(payment => {
+      if (!payment || !payment.resource || payment.required <= 0) return;
+      if (!Number.isFinite(combatant[payment.resource])) return;
+      combatant[payment.resource] -= payment.required;
+    });
     combatant.cooldowns[abilityId] = now + ability.cooldown;
     combatant.rotationIndex =
       (combatant.rotationIndex + 1) % combatant.character.rotation.length;
@@ -40,15 +68,13 @@ function getAction(combatant, now, abilityMap) {
     };
   }
 
-    return {
-      type: 'basic',
-      reason: 'resource',
-      ability,
-      abilityId,
-      resourceType: costType,
-      required: effectiveCost,
-      available: availableResource,
-    };
+  return {
+    type: 'basic',
+    reason: 'resource',
+    ability,
+    abilityId,
+    costs: payments,
+  };
 }
 
 module.exports = { getAction };


### PR DESCRIPTION
## Summary
- add Sun Beam, Focus, and Righteous Blade abilities that scale from wisdom
- support multi-resource ability costs and stat-based damage over time/resource regeneration on the backend
- update UI descriptions to display scaling details and combined costs for abilities

## Testing
- node -e "require('./systems/effectsEngine.js')"
- node -e "require('./systems/rotationEngine.js')"

------
https://chatgpt.com/codex/tasks/task_e_68ce16a2ce1083209c23a1654795aafe