### PR TITLE
Add agility scaling to Poison Dart ability

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -82,7 +82,13 @@
     "cooldown": 14,
     "scaling": ["agility"],
     "effects": [
-      { "type": "Poison", "damage": 3, "duration": 6, "interval": 2 }
+      {
+        "type": "Poison",
+        "damage": 3,
+        "duration": 6,
+        "interval": 2,
+        "damageScaling": { "agility": 0.3 }
+      }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add agility-based damage scaling to the Poison Dart ability's dot effect
- ensure poison damage over time benefits from attribute scaling similar to other dots

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce1edeb1fc8320b72137d7d8ba54ee