### PR TITLE
Split crafting failure and discovery logs with clear control

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const { getEquipmentCatalog } = require("./systems/equipmentService");
 const { purchaseItem } = require("./systems/shopService");
 const { getInventory, setEquipment } = require("./systems/inventoryService");
 const { getChallengeStatus, runChallengeFight, startChallenge } = require("./systems/challengeGA");
-const { getJobStatus, selectJob, startJobWork, stopJobWork, ensureJobIdle } = require("./systems/jobService");
+const { getJobStatus, selectJob, startJobWork, stopJobWork, ensureJobIdle, clearJobLog } = require("./systems/jobService");
 const {
   getAdventureStatus,
   startAdventure,
@@ -229,6 +229,22 @@ app.post("/characters/:characterId/job/stop", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(400).json({ error: err.message || "failed to stop job" });
+  }
+});
+
+app.post("/characters/:characterId/job/log/clear", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId) {
+    return res.status(400).json({ error: "playerId and characterId required" });
+  }
+  try {
+    const status = await clearJobLog(pid, characterId);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to clear job log" });
   }
 });
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -1098,6 +1098,71 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   box-shadow:4px 4px 0 #444;
   cursor:not-allowed;
 }
+.job-confirm-overlay {
+  position:fixed;
+  inset:0;
+  background:rgba(0,0,0,0.75);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:16px;
+  z-index:1300;
+}
+.job-confirm-dialog {
+  background:#fff;
+  color:#000;
+  border:3px solid #000;
+  box-shadow:8px 8px 0 #000;
+  width:100%;
+  max-width:360px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  padding:20px;
+  font-family:'Courier New', monospace;
+}
+.job-confirm-dialog h3 {
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:16px;
+}
+.job-confirm-dialog p {
+  margin:0;
+  font-size:12px;
+  line-height:1.5;
+  color:#333;
+  text-transform:none;
+}
+.job-confirm-actions {
+  display:flex;
+  justify-content:flex-end;
+  gap:12px;
+}
+.job-confirm-actions button {
+  font-family:'Courier New', monospace;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  padding:6px 14px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:4px 4px 0 #000;
+}
+.job-confirm-actions button.confirm {
+  background:#000;
+  color:#fff;
+}
+.job-confirm-actions button:hover,
+.job-confirm-actions button:focus {
+  background:#000;
+  color:#fff;
+}
+.job-confirm-actions button.confirm:hover,
+.job-confirm-actions button.confirm:focus {
+  background:#1c1c1c;
+}
 .job-attribute {
   font-size:12px;
   text-transform:uppercase;
@@ -1362,6 +1427,35 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-size:16px;
   color:#000;
 }
+.job-log-header-bar {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+.job-log-clear {
+  font-family:'Courier New', monospace;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  padding:6px 14px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:4px 4px 0 #000;
+}
+.job-log-clear:hover,
+.job-log-clear:focus {
+  background:#000;
+  color:#fff;
+}
+.job-log-clear:disabled {
+  opacity:0.5;
+  cursor:not-allowed;
+  background:#e5e5e5;
+  color:#666;
+  box-shadow:none;
+}
 .job-output-list {
   list-style:none;
   margin:0;
@@ -1448,6 +1542,20 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-log-entry.log-failed .job-log-badge {
   border-color:#fff;
 }
+.job-log-entry.log-discovery {
+  background:#fff6c4;
+  color:#111;
+  border-color:#000;
+  box-shadow:4px 4px 0 #000;
+}
+.job-log-entry.log-discovery .job-log-detail .label,
+.job-log-entry.log-discovery .job-log-detail .value,
+.job-log-entry.log-discovery .job-log-footer {
+  color:#111;
+}
+.job-log-entry.log-discovery .job-log-badge {
+  border-color:#000;
+}
 .job-log-header {
   display:flex;
   align-items:center;
@@ -1492,6 +1600,9 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 .job-log-badge.warning {
   background:#fff;
+}
+.job-log-badge.info {
+  background:#fff6c4;
 }
 .job-log-details {
   display:flex;


### PR DESCRIPTION
## Summary
- separate failed crafting entries from resource discovery cards so the activity feed stays readable
- add a clear-log control with a confirmation dialog in the profession UI and disable it when the feed is empty
- expose a backend endpoint that clears a character's crafting log and returns refreshed job status

## Testing
- `npm run start` *(fails: requires MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2aee72888320a693d3bd6e2891c2