### PR TITLE
Make dungeon GA configurable via JSON

### DIFF
--- a/data/dungeonConfig.json
+++ b/data/dungeonConfig.json
@@ -1,0 +1,29 @@
+{
+  "generations": 4,
+  "generationsPerExtraMember": 0,
+  "scaling": {
+    "attributePointScale": { "base": 1.2, "perExtraMember": 0.08, "minTotal": 30 },
+    "gearBudgetScale": { "base": 1.3, "perExtraMember": 0.18, "minTotal": 80 }
+  },
+  "targetDuration": { "base": 40, "perMember": 12 },
+  "population": {
+    "baseSize": 18,
+    "sizePerPartyMember": 0,
+    "maxSize": 60,
+    "generationGrowth": 0,
+    "randomInjectionRate": 0.25,
+    "mutateParentRate": 0.2625,
+    "mutatePartnerRate": 0.170625,
+    "mutateSingleParentRate": 0.6
+  },
+  "evaluationWeights": {
+    "damageToParty": 1.8,
+    "bossHealthRemaining": 1.1,
+    "partyMembersDowned": 140,
+    "duration": 6,
+    "threatSwaps": 4,
+    "winBonus": 450,
+    "lossPenalty": 120,
+    "bossDamagePenalty": 0.6
+  }
+}


### PR DESCRIPTION
## Summary
- add a dungeonConfig.json file so boss generation parameters can be tuned without code changes
- load and normalize the GA configuration before building dungeon context and use it to drive population sizing and fitness weights
- support optional config reloads so updated JSON values can be picked up without restarting the process

## Testing
- node -e "require('./systems/dungeonGA'); console.log('loaded dungeonGA')"

------
https://chatgpt.com/codex/tasks/task_e_68ce5b16c62c8320ace759ef1b9b0c06