### PR TITLE
Add matchmaking cancellation and improve dungeon queue controls

### DIFF
--- a/systems/matchmaking.js
+++ b/systems/matchmaking.js
@@ -7,6 +7,217 @@ const { xpForNextLevel } = require('./characterService');
 const { processJobForCharacter, ensureJobIdleForDoc } = require('./jobService');
 
 const queue = [];
+const waitingEntries = new Map();
+
+function sendSafe(entry, payload) {
+  try {
+    entry.send(payload);
+  } catch (err) {
+    // Ignore send failures; the SSE stream may already be closed.
+  }
+}
+
+function removeFromQueue(entry) {
+  if (!entry) return;
+  const idx = queue.indexOf(entry);
+  if (idx !== -1) {
+    queue.splice(idx, 1);
+  }
+}
+
+function finalizeEntry(entry) {
+  if (!entry || entry.completed) return;
+  entry.completed = true;
+  if (entry.character && typeof entry.character.id === 'number') {
+    waitingEntries.delete(entry.character.id);
+  }
+  if (typeof entry.resolve === 'function') {
+    entry.resolve();
+  }
+}
+
+function cancelEntry(entry, reason = 'matchmaking cancelled') {
+  if (!entry || entry.completed || entry.status !== 'queued') {
+    return false;
+  }
+  entry.status = 'cancelled';
+  removeFromQueue(entry);
+  if (entry.character && typeof entry.character.id === 'number') {
+    waitingEntries.delete(entry.character.id);
+  }
+  sendSafe(entry, { type: 'cancelled', message: reason });
+  finalizeEntry(entry);
+  return true;
+}
+
+function nextQueuedEntry() {
+  while (queue.length > 0) {
+    const entry = queue.shift();
+    if (!entry || entry.completed) {
+      continue;
+    }
+    if (entry.status === 'queued') {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function tryStartMatch() {
+  while (queue.length >= 2) {
+    const a = nextQueuedEntry();
+    if (!a) {
+      return;
+    }
+    const b = nextQueuedEntry();
+    if (!b) {
+      queue.unshift(a);
+      return;
+    }
+    if (a.character && b.character && a.character.id === b.character.id) {
+      // Should not happen due to waitingEntries guard, but place the second back just in case.
+      queue.unshift(b);
+      queue.unshift(a);
+      return;
+    }
+    startMatch(a, b);
+    // Only start one match at a time to avoid deep recursion and to respect async execution.
+    return;
+  }
+}
+
+function startMatch(a, b) {
+  if (!a || !b) return;
+  a.status = 'matched';
+  b.status = 'matched';
+  if (a.character && typeof a.character.id === 'number') {
+    waitingEntries.delete(a.character.id);
+  }
+  if (b.character && typeof b.character.id === 'number') {
+    waitingEntries.delete(b.character.id);
+  }
+
+  getAbilities()
+    .then(abilities => {
+      const abilityMap = new Map(abilities.map(ability => [ability.id, ability]));
+      return getEquipmentMap().then(equipmentMap => ({ abilityMap, equipmentMap }));
+    })
+    .then(({ abilityMap, equipmentMap }) => {
+      return runCombat(a.character, b.character, abilityMap, equipmentMap, event => {
+        if (event.type === 'start') {
+          sendSafe(a, { type: 'start', you: event.a, opponent: event.b });
+          sendSafe(b, { type: 'start', you: event.b, opponent: event.a });
+        } else if (event.type === 'update') {
+          const payload = { type: 'update', you: event.a, opponent: event.b, log: event.log };
+          sendSafe(a, payload);
+          sendSafe(b, payload);
+        }
+      });
+    })
+    .then(async result => {
+      const participantIds = [a.character.id, b.character.id];
+      const characterDocs = await CharacterModel.find({
+        characterId: { $in: participantIds },
+      });
+      for (const doc of characterDocs) {
+        await processJobForCharacter(doc);
+      }
+      const characterMap = new Map();
+      characterDocs.forEach(doc => {
+        characterMap.set(doc.characterId, doc);
+      });
+      const consumedMap = result.consumedUseables || {};
+
+      function consumeUseables(charWrapper) {
+        const consumed = consumedMap[charWrapper.character.id] || [];
+        if (!consumed.length) return;
+        const characterDoc = characterMap.get(charWrapper.character.id);
+        if (!characterDoc) return;
+        if (!characterDoc.useables) {
+          characterDoc.useables = { useable1: null, useable2: null };
+        }
+        let modifiedUseables = false;
+        let itemsModified = false;
+        if (!Array.isArray(characterDoc.items)) {
+          characterDoc.items = [];
+        }
+        consumed.forEach(entry => {
+          const idx = characterDoc.items.indexOf(entry.itemId);
+          if (idx !== -1) {
+            characterDoc.items.splice(idx, 1);
+            itemsModified = true;
+          }
+          if (characterDoc.useables[entry.slot] === entry.itemId) {
+            const remaining = characterDoc.items.filter(id => id === entry.itemId).length;
+            if (remaining <= 0) {
+              characterDoc.useables[entry.slot] = null;
+              modifiedUseables = true;
+            }
+          }
+        });
+        if (itemsModified && typeof characterDoc.markModified === 'function') {
+          characterDoc.markModified('items');
+        }
+        if (modifiedUseables && typeof characterDoc.markModified === 'function') {
+          characterDoc.markModified('useables');
+        }
+      }
+
+      function reward(charWrapper, won) {
+        const characterDoc = characterMap.get(charWrapper.character.id);
+        if (!characterDoc) {
+          throw new Error('character not found for rewards');
+        }
+        const pct = won ? 0.05 + Math.random() * 0.05 : 0.01 + Math.random() * 0.01;
+        const xpGain = Math.round(xpForNextLevel(characterDoc.level || 1) * pct);
+        characterDoc.xp = (characterDoc.xp || 0) + xpGain;
+        const gpGain = won ? 10 : 2;
+        characterDoc.gold = (characterDoc.gold || 0) + gpGain;
+        return {
+          xpGain,
+          gpGain,
+          character: serializeCharacter(characterDoc),
+          gold: typeof characterDoc.gold === 'number' ? characterDoc.gold : 0,
+        };
+      }
+
+      consumeUseables(a);
+      consumeUseables(b);
+
+      const rewardA = reward(a, result.winnerId === a.character.id);
+      const rewardB = reward(b, result.winnerId === b.character.id);
+
+      await Promise.all(characterDocs.map(doc => doc.save()));
+
+      sendSafe(a, {
+        type: 'end',
+        winnerId: result.winnerId,
+        xpGain: rewardA.xpGain,
+        gpGain: rewardA.gpGain,
+        character: rewardA.character,
+        gold: rewardA.gold,
+      });
+      sendSafe(b, {
+        type: 'end',
+        winnerId: result.winnerId,
+        xpGain: rewardB.xpGain,
+        gpGain: rewardB.gpGain,
+        character: rewardB.character,
+        gold: rewardB.gold,
+      });
+    })
+    .catch(err => {
+      const error = { type: 'error', message: err.message };
+      sendSafe(a, error);
+      sendSafe(b, error);
+    })
+    .finally(() => {
+      finalizeEntry(a);
+      finalizeEntry(b);
+      // Attempt to start another match if there are enough queued entries remaining.
+      tryStartMatch();
+    });
+}
 
 async function loadCharacter(id) {
   const characterDoc = await CharacterModel.findOne({ characterId: id });
@@ -25,126 +236,39 @@ async function queueMatch(characterId, send) {
   if (!character.rotation || character.rotation.length < 3) {
     throw new Error('character rotation invalid');
   }
-  const abilities = await getAbilities();
-  const abilityMap = new Map(abilities.map(a => [a.id, a]));
-  const equipmentMap = await getEquipmentMap();
-  return new Promise(resolve => {
-    queue.push({ character, send, resolve });
-    if (queue.length >= 2) {
-      const a = queue.shift();
-      const b = queue.shift();
-      runCombat(a.character, b.character, abilityMap, equipmentMap, event => {
-        if (event.type === 'start') {
-          a.send({ type: 'start', you: event.a, opponent: event.b });
-          b.send({ type: 'start', you: event.b, opponent: event.a });
-        } else if (event.type === 'update') {
-          a.send({ type: 'update', you: event.a, opponent: event.b, log: event.log });
-          b.send({ type: 'update', you: event.b, opponent: event.a, log: event.log });
-        }
-      })
-        .then(async result => {
-          const participantIds = [a.character.id, b.character.id];
-          const characterDocs = await CharacterModel.find({
-            characterId: { $in: participantIds },
-          });
-          for (const doc of characterDocs) {
-            await processJobForCharacter(doc);
-          }
-          const characterMap = new Map();
-          characterDocs.forEach(doc => {
-            characterMap.set(doc.characterId, doc);
-          });
-          const consumedMap = result.consumedUseables || {};
+  if (waitingEntries.has(character.id)) {
+    throw new Error('character already queued');
+  }
 
-          function consumeUseables(charWrapper) {
-            const consumed = consumedMap[charWrapper.character.id] || [];
-            if (!consumed.length) return;
-            const characterDoc = characterMap.get(charWrapper.character.id);
-            if (!characterDoc) return;
-            if (!characterDoc.useables) {
-              characterDoc.useables = { useable1: null, useable2: null };
-            }
-            let modifiedUseables = false;
-            let itemsModified = false;
-            if (!Array.isArray(characterDoc.items)) {
-              characterDoc.items = [];
-            }
-            consumed.forEach(entry => {
-              const idx = characterDoc.items.indexOf(entry.itemId);
-              if (idx !== -1) {
-                characterDoc.items.splice(idx, 1);
-                itemsModified = true;
-              }
-              if (characterDoc.useables[entry.slot] === entry.itemId) {
-                const remaining = characterDoc.items.filter(id => id === entry.itemId).length;
-                if (remaining <= 0) {
-                  characterDoc.useables[entry.slot] = null;
-                  modifiedUseables = true;
-                }
-              }
-            });
-            if (itemsModified && typeof characterDoc.markModified === 'function') {
-              characterDoc.markModified('items');
-            }
-            if (modifiedUseables && typeof characterDoc.markModified === 'function') {
-              characterDoc.markModified('useables');
-            }
-          }
-
-          function reward(charWrapper, won) {
-            const characterDoc = characterMap.get(charWrapper.character.id);
-            if (!characterDoc) {
-              throw new Error('character not found for rewards');
-            }
-            const pct = won ? 0.05 + Math.random() * 0.05 : 0.01 + Math.random() * 0.01;
-            const xpGain = Math.round(xpForNextLevel(characterDoc.level || 1) * pct);
-            characterDoc.xp = (characterDoc.xp || 0) + xpGain;
-            const gpGain = won ? 10 : 2;
-            characterDoc.gold = (characterDoc.gold || 0) + gpGain;
-            return {
-              xpGain,
-              gpGain,
-              character: serializeCharacter(characterDoc),
-              gold: typeof characterDoc.gold === 'number' ? characterDoc.gold : 0,
-            };
-          }
-
-          consumeUseables(a);
-          consumeUseables(b);
-
-          const rewardA = reward(a, result.winnerId === a.character.id);
-          const rewardB = reward(b, result.winnerId === b.character.id);
-
-          await Promise.all(characterDocs.map(doc => doc.save()));
-
-          a.send({
-            type: 'end',
-            winnerId: result.winnerId,
-            xpGain: rewardA.xpGain,
-            gpGain: rewardA.gpGain,
-            character: rewardA.character,
-            gold: rewardA.gold,
-          });
-          b.send({
-            type: 'end',
-            winnerId: result.winnerId,
-            xpGain: rewardB.xpGain,
-            gpGain: rewardB.gpGain,
-            character: rewardB.character,
-            gold: rewardB.gold,
-          });
-          a.resolve();
-          b.resolve();
-        })
-        .catch(err => {
-          const error = { type: 'error', message: err.message };
-          a.send(error);
-          b.send(error);
-          a.resolve();
-          b.resolve();
-        });
-    }
+  let resolveFn;
+  const promise = new Promise(resolve => {
+    resolveFn = resolve;
   });
+
+  const entry = {
+    character,
+    send,
+    resolve: resolveFn,
+    promise,
+    status: 'queued',
+    completed: false,
+  };
+
+  entry.cancel = reason => cancelEntry(entry, reason);
+
+  queue.push(entry);
+  waitingEntries.set(character.id, entry);
+  tryStartMatch();
+
+  return { promise, cancel: entry.cancel };
 }
 
-module.exports = { queueMatch };
+function cancelMatchmaking(characterId, reason) {
+  const entry = waitingEntries.get(characterId);
+  if (!entry) {
+    return false;
+  }
+  return cancelEntry(entry, reason);
+}
+
+module.exports = { queueMatch, cancelMatchmaking };

--- a/ui/style.css
+++ b/ui/style.css
@@ -360,11 +360,48 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #battle-log .log-message.neutral, .battle-log .log-message.neutral { align-self:center; background:#fff; color:#000; border-style:dashed; text-align:center; }
 #battle-dialog .dialog-buttons, #dungeon-dialog .dialog-buttons { text-align:right; margin-top:16px; }
 
+.matchmaking-panel {
+  border:1px solid #000;
+  background:#fff;
+  padding:16px;
+  box-shadow:6px 6px 0 #000;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  max-width:360px;
+  margin:0 auto;
+  text-align:center;
+}
+
+.matchmaking-status {
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.matchmaking-controls {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  justify-content:center;
+}
+
+.matchmaking-controls button {
+  flex:1 1 150px;
+  font-weight:bold;
+  text-transform:uppercase;
+  padding:8px 12px;
+}
+
 .dungeon-panel { display:flex; flex-direction:column; gap:12px; }
-.dungeon-controls { display:flex; align-items:center; gap:12px; }
+.dungeon-controls { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
 .dungeon-controls label { font-weight:bold; }
 .dungeon-controls select { padding:4px 6px; }
-.dungeon-controls button { padding:6px 12px; }
+.dungeon-controls button {
+  padding:6px 12px;
+  font-weight:bold;
+  text-transform:uppercase;
+}
 .dungeon-status { min-height:20px; }
 .dungeon-preview-panel { border:1px solid #444; padding:12px; background:#f7f7f7; border-radius:4px; }
 .dungeon-preview-panel h3 { margin-top:0; }


### PR DESCRIPTION
## Summary
- improve matchmaking queue management with cancellation support and guardrails against duplicate entries
- add API endpoints and front-end controls to let players leave matchmaking and dungeon queues cleanly
- refresh battle UI styling to include themed matchmaking and dungeon queue buttons

## Testing
- npm run start *(fails: requires MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68ce67d8b8a483208f01edf05d98a122