### PR TITLE
Convert stuns to attack-based durations

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -21,7 +21,7 @@
     "scaling": ["strength"],
     "effects": [
       { "type": "PhysicalDamage", "value": 15 },
-      { "type": "Stun", "duration": 2 }
+      { "type": "Stun", "attacks": 2 }
     ]
   },
   {
@@ -58,7 +58,7 @@
     "scaling": ["intellect"],
     "effects": [
       { "type": "MagicDamage", "value": 8 },
-      { "type": "Stun", "duration": 1 }
+      { "type": "Stun", "attacks": 1 }
     ]
   },
   {

--- a/data/equipment.json
+++ b/data/equipment.json
@@ -90,7 +90,7 @@
         {
           "trigger": "basic",
           "chance": 0.05,
-          "effect": { "type": "Stun", "duration": 1.5 }
+          "effect": { "type": "Stun", "attacks": 1 }
         }
       ]
     },
@@ -180,7 +180,7 @@
         {
           "trigger": "basic",
           "chance": 0.15,
-          "effect": { "type": "Stun", "duration": 2 }
+          "effect": { "type": "Stun", "attacks": 2 }
         }
       ]
     }
@@ -402,10 +402,9 @@
       "useEffect": {
         "type": "Stun",
         "chance": 0.25,
-        "durationType": "enemyAttackIntervals",
-        "durationCount": 1
+        "attacks": 1
       },
-      "useDuration": "1 enemy attack interval",
+      "useDuration": "1 attack",
       "useConsumed": true,
       "useTarget": "enemy"
     },

--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -65,7 +65,7 @@ function createCombatant(character, equipmentMap) {
     dots: [],
     hots: [],
     resourceOverTime: [],
-    stunnedUntil: 0,
+    stunnedAttacksRemaining: 0,
     onHitEffects: derived.onHitEffects || [],
     basicAttackEffectType: derived.basicAttackEffectType,
     attacksPerformed: 0,
@@ -105,8 +105,12 @@ function executeCombatAction(actor, target, now, abilityMap, log) {
     return summary;
   }
 
-  if (actor.stunnedUntil > now) {
-    pushLog(log, `${actor.character.name} is stunned and misses the turn`, {
+  if ((actor.stunnedAttacksRemaining || 0) > 0) {
+    const remainingBefore = Number.isFinite(actor.stunnedAttacksRemaining)
+      ? actor.stunnedAttacksRemaining
+      : 0;
+    actor.stunnedAttacksRemaining = Math.max(0, remainingBefore - 1);
+    pushLog(log, `${actor.character.name} is stunned and misses their attack`, {
       sourceId: actor.character.id,
       targetId: actor.character.id,
       kind: 'stun',

--- a/ui/main.js
+++ b/ui/main.js
@@ -254,6 +254,33 @@ function formatIntervalDuration(countRaw, singular, plural) {
 
 function formatEffectDurationText(effect) {
   if (!effect || typeof effect !== 'object') return '';
+  if (effect.type === 'Stun') {
+    if (Number.isFinite(effect.attacks)) {
+      return formatIntervalDuration(effect.attacks, 'attack');
+    }
+    if (Number.isFinite(effect.attackCount)) {
+      return formatIntervalDuration(effect.attackCount, 'attack');
+    }
+    if (Number.isFinite(effect.durationCount)) {
+      let label = 'attack';
+      let pluralLabel = 'attacks';
+      if (effect.durationType === 'enemyAttackIntervals') {
+        label = 'enemy attack';
+        pluralLabel = 'enemy attacks';
+      } else if (effect.durationType === 'userAttackIntervals' || effect.durationType === 'selfAttackIntervals') {
+        label = 'own attack';
+        pluralLabel = 'own attacks';
+      }
+      return formatIntervalDuration(effect.durationCount, label, pluralLabel);
+    }
+    if (Number.isFinite(effect.durationSeconds) || Number.isFinite(effect.duration)) {
+      const seconds = Number.isFinite(effect.durationSeconds) ? effect.durationSeconds : effect.duration;
+      if (seconds > 0) {
+        return formatIntervalDuration(1, 'attack');
+      }
+    }
+    return '';
+  }
   if (typeof effect.duration === 'number' && Number.isFinite(effect.duration)) {
     const value = effect.duration;
     const formatted = Number.isInteger(value) ? String(value) : value.toFixed(1);


### PR DESCRIPTION
## Summary
- represent stuns as a count of blocked attacks during combat and log when actors miss an attack
- resolve stun effects using attack counts, update log messaging, and format stun durations in the UI as attacks
- update ability and equipment data to describe stuns in attacks instead of seconds, including revised item text

## Testing
- `node - <<'NODE'
const { applyEffect } = require('./systems/effectsEngine');

const source = {
  character: { name: 'Attacker', id: 'a1', basicType: 'melee' },
  derived: {
    attackIntervalSeconds: 4,
    hitChance: 100,
    minMeleeAttack: 1,
    maxMeleeAttack: 1,
    minMagicAttack: 1,
    maxMagicAttack: 1,
  },
};
const target = {
  character: { name: 'Defender', id: 'd1' },
  derived: {
    attackIntervalSeconds: 6,
    dodgeChance: 0,
    meleeResist: 0,
    magicResist: 0,
  },
  stunnedAttacksRemaining: 0,
};
const effect = { type: 'Stun', attacks: 1 };
const log = [];
const result = applyEffect(source, target, effect, 0, log, {});
console.log('result', result);
console.log('stunnedAttacksRemaining', target.stunnedAttacksRemaining);
console.log('log', log);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ce6c357ad48320b1f5a3949460e145