### PR TITLE
Add agility-scaling ability suite

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -188,5 +188,67 @@
         "damageScaling": { "wisdom": 0.25 }
       }
     ]
+  },
+  {
+    "id": 14,
+    "name": "Restage",
+    "school": "physical",
+    "costs": [
+      { "type": "mana", "value": 10 },
+      { "type": "stamina", "value": 10 }
+    ],
+    "cooldown": 20,
+    "scaling": ["agility"],
+    "effects": [
+      {
+        "type": "PhysicalDamage",
+        "value": 10,
+        "scaling": { "agility": 0.75 }
+      },
+      {
+        "type": "NextAbilityDamage",
+        "value": 10,
+        "scaling": { "agility": 0.75 },
+        "matchLastResult": true,
+        "target": "self"
+      }
+    ]
+  },
+  {
+    "id": 15,
+    "name": "Sharpen Mind",
+    "school": "magical",
+    "costType": "mana",
+    "costValue": 12,
+    "cooldown": 16,
+    "scaling": ["agility"],
+    "effects": [
+      {
+        "type": "BuffChance",
+        "stat": "critChance",
+        "amount": 8,
+        "amountScaling": { "agility": 0.15 },
+        "durationType": "selfAttackIntervals",
+        "durationCount": 1,
+        "target": "self"
+      }
+    ]
+  },
+  {
+    "id": 16,
+    "name": "Piercing Blow",
+    "school": "physical",
+    "costType": "stamina",
+    "costValue": 25,
+    "cooldown": 18,
+    "scaling": ["agility"],
+    "effects": [
+      {
+        "type": "PhysicalDamage",
+        "value": 14,
+        "scaling": { "agility": 0.9 },
+        "ignoreResistOnCrit": true
+      }
+    ]
   }
 ]

--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -65,6 +65,7 @@ function createCombatant(character, equipmentMap) {
     dots: [],
     hots: [],
     resourceOverTime: [],
+    pendingDamageBonuses: [],
     stunnedAttacksRemaining: 0,
     onHitEffects: derived.onHitEffects || [],
     basicAttackEffectType: derived.basicAttackEffectType,
@@ -129,12 +130,31 @@ function executeCombatAction(actor, target, now, abilityMap, log) {
         abilityId: action.ability.id,
       });
       let lastResolution = null;
+      let lastResult = null;
       let landedDamage = false;
+      let pendingBonusAvailable = true;
       const damageResults = [];
-      action.ability.effects.forEach(effect => {
-        const result = applyEffect(actor, target, effect, now, log, { resolution: lastResolution });
+      action.ability.effects.forEach((effect, index) => {
+        const effectContext = {
+          resolution: lastResolution,
+          lastResult,
+          ability: action.ability,
+          actor,
+          target,
+          actionType: 'ability',
+          effectIndex: index,
+          consumeDamageBonus: pendingBonusAvailable,
+          now,
+        };
+        const result = applyEffect(actor, target, effect, now, log, effectContext);
         if (result && result.resolution) {
           lastResolution = result.resolution;
+        }
+        if (result) {
+          lastResult = result;
+        }
+        if (result && result.bonusDamageConsumed) {
+          pendingBonusAvailable = false;
         }
         if (effect.type === 'Stun' && result && result.hit) {
           summary.stunApplied = true;
@@ -162,7 +182,7 @@ function executeCombatAction(actor, target, now, abilityMap, log) {
         summary.damageEvents = summarizeDamageEvents(target, damageResults, 'ability');
         summary.totalDamage = summary.damageEvents.reduce((acc, entry) => acc + entry.amount, 0);
       }
-      const contextForOnHit = { ability: action.ability };
+      const contextForOnHit = { ability: action.ability, actionType: 'ability' };
       const primary = damageResults.find(res => res && res.damageType);
       if (primary) {
         contextForOnHit.damageType = primary.damageType;
@@ -258,7 +278,14 @@ function executeCombatAction(actor, target, now, abilityMap, log) {
         effectType === 'PhysicalDamage'
           ? { type: 'PhysicalDamage', value: 0 }
           : { type: 'MagicDamage', value: 0 };
-      const result = applyEffect(actor, target, effect, now, log);
+      const basicContext = {
+        actor,
+        target,
+        actionType: 'basic',
+        consumeDamageBonus: true,
+        now,
+      };
+      const result = applyEffect(actor, target, effect, now, log, basicContext);
       if (result && result.hit && Number.isFinite(result.amount) && result.amount > 0) {
         const resolvedDamageType = result.damageType || (effectType === 'PhysicalDamage' ? 'physical' : 'magical');
         handleDamageTaken(target, actor, resolvedDamageType, result.amount, now, log);
@@ -282,6 +309,7 @@ function executeCombatAction(actor, target, now, abilityMap, log) {
         const contextForOnHit = {
           damageType: result.damageType || (effectType === 'PhysicalDamage' ? 'physical' : 'magical'),
           resolution: result.resolution,
+          actionType: 'basic',
         };
         processOnHitEffects(actor, target, 'basic', contextForOnHit, now, log);
       }
@@ -542,7 +570,15 @@ function processOnHitEffects(source, target, trigger, context = {}, now, log) {
     } else if (!resolution.damageType) {
       resolution.damageType = baseType;
     }
-    const outcome = applyEffect(source, target, effect, now, log, { resolution });
+    const effectContext = {
+      resolution,
+      actor: source,
+      target,
+      actionType: context && context.actionType ? context.actionType : null,
+      consumeDamageBonus: false,
+      now,
+    };
+    const outcome = applyEffect(source, target, effect, now, log, effectContext);
     if (outcome && outcome.hit && Number.isFinite(outcome.amount) && outcome.amount > 0) {
       const resolvedDamageType = outcome.damageType || baseType;
       handleDamageTaken(target, source, resolvedDamageType, outcome.amount, now, log);


### PR DESCRIPTION
## Summary
- add Restage, Sharpen Mind, and Piercing Blow abilities that scale with agility and include stored damage, crit buffs, and armor piercing
- extend combat and effects engines to support stored damage bonuses, agility-scaling crit buffs, and physical resistance bypass on criticals
- update UI descriptions so new mechanics and scaling information appear in ability tooltips

## Testing
- node -e "require('./systems/effectsEngine')"
- node -e "require('./systems/combatEngine')"

------
https://chatgpt.com/codex/tasks/task_e_68ce7479e1308320b96d94fac48824b4