### PR TITLE
Ensure dungeon boss health displays defeat state

### DIFF
--- a/systems/dungeonService.js
+++ b/systems/dungeonService.js
@@ -160,6 +160,8 @@ async function finalizeMatch(match, result) {
       character: serializeCharacter(doc),
       gold: typeof doc.gold === 'number' ? doc.gold : 0,
       metrics: result.metrics || null,
+      finalParty: Array.isArray(result.finalParty) ? result.finalParty : null,
+      finalBoss: result.finalBoss || null,
     });
     finalizeEntry(entry);
   });

--- a/ui/main.js
+++ b/ui/main.js
@@ -4486,6 +4486,20 @@ function handleDungeonUpdate(data) {
 }
 
 function handleDungeonEnd(data) {
+  if (data) {
+    if (Array.isArray(data.finalParty) && dungeonBars) {
+      data.finalParty.forEach(member => {
+        if (!member || !member.id) return;
+        const group = dungeonBars.get(member.id);
+        if (group) {
+          updateDungeonBarGroup(group, member);
+        }
+      });
+    }
+    if (data.finalBoss && dungeonBossBars) {
+      updateDungeonBarGroup(dungeonBossBars, data.finalBoss);
+    }
+  }
   if (dungeonLogElement) {
     const outcome = data.winnerSide === 'party' ? 'Victory!' : 'Defeat...';
     appendDungeonLogs([{ message: outcome }], [], null);


### PR DESCRIPTION
## Summary
- include the final party and boss combat states when broadcasting dungeon end events
- update the client to apply the final dungeon states on end messages so the boss health bar reaches zero

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce75bdb6148320a3a1744e0bbc4ce0