### PR TITLE
Allow basic attack in rotations

### DIFF
--- a/domain/ability.js
+++ b/domain/ability.js
@@ -35,6 +35,7 @@ class Ability {
     cooldown,
     scaling = [],
     effects = [],
+    isBasicAttack = false,
   }) {
     this.id = id;
     this.name = name;
@@ -46,6 +47,7 @@ class Ability {
     this.cooldown = cooldown; // seconds
     this.scaling = scaling; // array of stat names
     this.effects = effects; // array of Effect descriptors
+    this.isBasicAttack = !!isBasicAttack;
   }
 }
 

--- a/systems/abilityService.js
+++ b/systems/abilityService.js
@@ -6,15 +6,31 @@ const Effect = require('../domain/effect');
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const ABILITIES_FILE = path.join(DATA_DIR, 'abilities.json');
 
+const BASIC_ATTACK_BLUEPRINT = {
+  id: 0,
+  name: 'Basic Attack',
+  school: 'basic',
+  cooldown: 0,
+  costs: [],
+  scaling: [],
+  effects: [],
+  isBasicAttack: true,
+};
+
 let abilityCache = null;
 
 async function getAbilities() {
   if (!abilityCache) {
     const data = await readJSON(ABILITIES_FILE);
-    abilityCache = data.map(a => new Ability({
-      ...a,
-      effects: a.effects.map(e => new Effect(e)),
-    }));
+    const abilityData = Array.isArray(data) ? data.slice() : [];
+    abilityData.unshift(BASIC_ATTACK_BLUEPRINT);
+    abilityCache = abilityData.map(entry => {
+      const effects = Array.isArray(entry.effects) ? entry.effects.map(e => new Effect(e)) : [];
+      return new Ability({
+        ...entry,
+        effects,
+      });
+    });
   }
   return abilityCache;
 }

--- a/systems/challengeGA.js
+++ b/systems/challengeGA.js
@@ -201,10 +201,10 @@ function breedRotation(rotA = [], rotB = [], abilityIds) {
     if (rotA.length && Math.random() < 0.5) {
       abilityId = rotA[i % rotA.length];
     }
-    if (!abilityId && rotB.length && Math.random() < 0.7) {
+    if ((abilityId == null) && rotB.length && Math.random() < 0.7) {
       abilityId = rotB[i % rotB.length];
     }
-    if (!abilityId) {
+    if (abilityId == null) {
       abilityId = abilityIds[randomInt(abilityIds.length)];
     }
     rotation.push(abilityId);

--- a/systems/dungeonGA.js
+++ b/systems/dungeonGA.js
@@ -348,10 +348,10 @@ function breedRotation(rotA = [], rotB = [], abilityIds) {
     if (rotA.length && Math.random() < 0.5) {
       abilityId = rotA[i % rotA.length];
     }
-    if (!abilityId && rotB.length && Math.random() < 0.7) {
+    if ((abilityId == null) && rotB.length && Math.random() < 0.7) {
       abilityId = rotB[i % rotB.length];
     }
-    if (!abilityId) {
+    if (abilityId == null) {
       abilityId = abilityIds[randomInt(abilityIds.length)];
     }
     rotation.push(abilityId);

--- a/systems/rotationEngine.js
+++ b/systems/rotationEngine.js
@@ -10,6 +10,12 @@ function getAction(combatant, now, abilityMap) {
     return { type: 'basic', reason: 'missingAbility', abilityId };
   }
 
+  if (ability.isBasicAttack) {
+    combatant.rotationIndex =
+      (combatant.rotationIndex + 1) % combatant.character.rotation.length;
+    return { type: 'basic', reason: 'rotationBasic', ability };
+  }
+
   const cooldownReady =
     !combatant.cooldowns[abilityId] || combatant.cooldowns[abilityId] <= now;
   const costs =

--- a/ui/main.js
+++ b/ui/main.js
@@ -18,6 +18,9 @@ function setRotationDamageType(value) {
   if (rotationDamageTypeSelect) {
     rotationDamageTypeSelect.value = rotationDamageType;
   }
+  if (rotationInitialized) {
+    renderAbilityPool();
+  }
 }
 
 if (rotationDamageTypeSelect) {
@@ -931,7 +934,7 @@ function formatAbilityCost(ability) {
   return parts.length ? parts.join(', ') : 'None';
 }
 
-function abilityTooltip(ability) {
+function abilityTooltip(ability, options = {}) {
   const container = document.createElement('div');
   container.className = 'tooltip-grid';
   const add = (label, value) => {
@@ -943,6 +946,20 @@ function abilityTooltip(ability) {
     v.innerHTML = value;
     container.appendChild(v);
   };
+  if (ability && ability.isBasicAttack) {
+    const derived = getActiveDerivedStats();
+    const typeHint = options && typeof options.basicType === 'string' ? options.basicType : rotationDamageType;
+    const normalized = normalizeDamageType(typeHint);
+    const effectType = normalized === 'magic' ? 'MagicDamage' : 'PhysicalDamage';
+    const effectText = describeEffect({ type: effectType, value: 0 }, { derived });
+    const schoolLabel = normalized === 'magic' ? 'Magical' : 'Physical';
+    add('School', schoolLabel);
+    add('Cost', 'None');
+    add('Cooldown', 'None');
+    add('Scaling', 'Weapon Damage');
+    add('Effects', effectText || 'None');
+    return container;
+  }
   add('School', ability.school);
   add('Cost', formatAbilityCost(ability));
   const cooldownText = Number.isFinite(ability.cooldown) ? `${ability.cooldown}s` : 'None';
@@ -3530,7 +3547,6 @@ async function initRotation() {
   await loadAbilityCatalog();
   rotation = [...(currentCharacter.rotation || [])];
   setRotationDamageType(currentCharacter ? currentCharacter.basicType : null);
-  renderAbilityPool();
   renderRotationList();
   const list = document.getElementById('rotation-list');
   list.addEventListener('dragover', handleDragOverList);
@@ -3546,18 +3562,27 @@ function renderAbilityPool() {
   const mag = document.getElementById('magical-abilities');
   phys.innerHTML = '';
   mag.innerHTML = '';
-  abilityCatalog.forEach(ab => {
+  const appendCard = (container, ability) => {
     const card = document.createElement('div');
-    card.textContent = ab.name;
+    card.textContent = ability.name;
     card.className = 'ability-card';
-    card.dataset.id = ab.id;
+    card.dataset.id = ability.id;
     card.draggable = true;
     card.addEventListener('dragstart', handleDragStart);
-    attachTooltip(card, () => abilityTooltip(ab));
+    attachTooltip(card, () => abilityTooltip(ability, { basicType: rotationDamageType }));
+    container.appendChild(card);
+  };
+  abilityCatalog.forEach(ab => {
+    if (!ab) return;
+    if (ab.isBasicAttack) {
+      appendCard(phys, ab);
+      appendCard(mag, ab);
+      return;
+    }
     if (ab.school === 'physical') {
-      phys.appendChild(card);
+      appendCard(phys, ab);
     } else if (ab.school === 'magical') {
-      mag.appendChild(card);
+      appendCard(mag, ab);
     }
   });
 }
@@ -3583,7 +3608,7 @@ function renderRotationList() {
         renderRotationList();
       }
     });
-    attachTooltip(li, () => abilityTooltip(ability));
+    attachTooltip(li, () => abilityTooltip(ability, { basicType: rotationDamageType }));
     list.appendChild(li);
   });
   list.scrollTop = atBottom ? list.scrollHeight : prevScroll;
@@ -5740,7 +5765,7 @@ function renderOpponentPreview(opponent) {
       chip.className = 'rotation-chip';
       chip.textContent = ability ? ability.name : `Ability ${id}`;
       if (ability) {
-        attachTooltip(chip, () => abilityTooltip(ability));
+        attachTooltip(chip, () => abilityTooltip(ability, { basicType: opponent.basicType }));
       }
       rotationList.appendChild(chip);
     });


### PR DESCRIPTION
## Summary
- expose a synthetic Basic Attack ability and mark it on ability models
- treat the basic attack slot specially in the rotation engine and GA breeding helpers
- surface basic attack in the rotation UI with updated tooltips tied to the selected damage type

## Testing
- npm start *(fails: Failed to connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7763f1048320abaa9e7d7c7987ae