### PR TITLE
Add configurable challenge GA settings

### DIFF
--- a/data/challengeConfig.json
+++ b/data/challengeConfig.json
@@ -1,0 +1,21 @@
+{
+  "generations": 1,
+  "population": {
+    "minSize": 10,
+    "stepSize": 10,
+    "stepInterval": 3,
+    "maxSize": 100
+  },
+  "mutation": {
+    "genomeRate": 0.2,
+    "gearRate": 0.25
+  },
+  "rotation": {
+    "maxLength": 6
+  },
+  "rewards": {
+    "baseXpPct": 0.04,
+    "rewardMultiplierStep": 0.15,
+    "baseGold": 12
+  }
+}


### PR DESCRIPTION
## Summary
- add a challenge configuration file with knobs for generations, population sizing, mutation, rotation, and rewards
- load the challenge configuration in the GA, threading it through context for population building, mutation, and rewards
- evolve multiple generations when finding a champion so training depth can be tuned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce7bfb1f408320ae5d5d61ab1512ef