### PR TITLE
Finalize blacksmith workshop UI and integration

### DIFF
--- a/data/jobConfig.json
+++ b/data/jobConfig.json
@@ -19,116 +19,31 @@
       "name": "Craftsman",
       "attribute": "agility",
       "description": "Refines tools and contraptions to keep adventurers ahead of danger.",
-      "category": "Tools",
-      "items": [
-        {
-          "itemId": "useable_first_aid_kit",
-          "materials": {
-            "material_heart_stone": 2,
-            "material_iron_silk": 1
-          }
-        },
-        {
-          "itemId": "useable_toxins",
-          "materials": {
-            "material_rune_dust": 1,
-            "material_runic_sigil": 1,
-            "material_heart_stone": 1
-          }
-        },
-        {
-          "itemId": "useable_vanishing_powder",
-          "materials": {
-            "material_rune_dust": 2,
-            "material_metallic_feather": 1
-          }
-        },
-        {
-          "itemId": "useable_thieving_tools",
-          "materials": {
-            "material_iron_silk": 2,
-            "material_metallic_feather": 1
-          }
-        }
-      ]
+      "category": "Tools"
     },
     {
       "id": "enchanter",
       "name": "Enchanter",
       "attribute": "intellect",
       "description": "Infuses scrolls with arcane force for precise battlefield control.",
-      "category": "Scrolls",
-      "items": [
-        {
-          "itemId": "useable_ice_scroll",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_iron_silk": 1,
-            "material_rune_dust": 1
-          }
-        },
-        {
-          "itemId": "useable_fire_scroll",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_rune_shard": 1,
-            "material_metallic_feather": 1
-          }
-        },
-        {
-          "itemId": "useable_mana_scroll",
-          "materials": {
-            "material_runic_sigil": 2,
-            "material_rune_dust": 1
-          }
-        },
-        {
-          "itemId": "useable_mana_steal_scroll",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_metallic_feather": 1,
-            "material_troll_skull": 1
-          }
-        }
-      ]
+      "category": "Scrolls"
     },
     {
       "id": "apothecary",
       "name": "Apothecary",
       "attribute": "wisdom",
       "description": "Distills restorative draughts and potent elixirs from rare reagents.",
-      "category": "Potions",
-      "items": [
-        {
-          "itemId": "useable_healing_potion",
-          "materials": {
-            "material_heart_stone": 1,
-            "material_rune_shard": 1
-          }
-        },
-        {
-          "itemId": "useable_mana_potion",
-          "materials": {
-            "material_rune_shard": 1,
-            "material_rune_dust": 1
-          }
-        },
-        {
-          "itemId": "useable_stamina_potion",
-          "materials": {
-            "material_heart_stone": 1,
-            "material_iron_silk": 1
-          }
-        },
-        {
-          "itemId": "useable_critical_potion",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_metallic_feather": 1,
-            "material_troll_skull": 1
-          }
-        }
-      ]
+      "category": "Potions"
+    },
+    {
+      "id": "blacksmith",
+      "name": "Blacksmith",
+      "attribute": "strength",
+      "description": "Salvages battered gear into raw stock and forges new arms for battle.",
+      "category": "Forging",
+      "behavior": "blacksmith",
+      "materialRecoveryEnabled": true,
+      "materialRecoveryChanceMultiplier": 1.5
     }
   ]
 }

--- a/data/jobRecipes.json
+++ b/data/jobRecipes.json
@@ -1,0 +1,147 @@
+{
+  "jobs": {
+    "craftsman": [
+      {
+        "itemId": "useable_first_aid_kit",
+        "materials": {
+          "material_heart_stone": 2,
+          "material_iron_silk": 1
+        }
+      },
+      {
+        "itemId": "useable_toxins",
+        "materials": {
+          "material_rune_dust": 1,
+          "material_runic_sigil": 1,
+          "material_heart_stone": 1
+        }
+      },
+      {
+        "itemId": "useable_vanishing_powder",
+        "materials": {
+          "material_rune_dust": 2,
+          "material_metallic_feather": 1
+        }
+      },
+      {
+        "itemId": "useable_thieving_tools",
+        "materials": {
+          "material_iron_silk": 2,
+          "material_metallic_feather": 1
+        }
+      }
+    ],
+    "enchanter": [
+      {
+        "itemId": "useable_ice_scroll",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_iron_silk": 1,
+          "material_rune_dust": 1
+        }
+      },
+      {
+        "itemId": "useable_fire_scroll",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_rune_shard": 1,
+          "material_metallic_feather": 1
+        }
+      },
+      {
+        "itemId": "useable_mana_scroll",
+        "materials": {
+          "material_runic_sigil": 2,
+          "material_rune_dust": 1
+        }
+      },
+      {
+        "itemId": "useable_mana_steal_scroll",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_metallic_feather": 1,
+          "material_troll_skull": 1
+        }
+      }
+    ],
+    "apothecary": [
+      {
+        "itemId": "useable_healing_potion",
+        "materials": {
+          "material_heart_stone": 1,
+          "material_rune_shard": 1
+        }
+      },
+      {
+        "itemId": "useable_mana_potion",
+        "materials": {
+          "material_rune_shard": 1,
+          "material_rune_dust": 1
+        }
+      },
+      {
+        "itemId": "useable_stamina_potion",
+        "materials": {
+          "material_heart_stone": 1,
+          "material_iron_silk": 1
+        }
+      },
+      {
+        "itemId": "useable_critical_potion",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_metallic_feather": 1,
+          "material_troll_skull": 1
+        }
+      }
+    ],
+    "blacksmith": [
+      {
+        "itemId": "weapon_soldiers_longsword",
+        "materials": {
+          "material_heart_stone": 2,
+          "material_iron_silk": 2
+        }
+      },
+      {
+        "itemId": "weapon_brutal_battleaxe",
+        "materials": {
+          "material_heart_stone": 3,
+          "material_metallic_feather": 1,
+          "material_troll_skull": 1
+        }
+      },
+      {
+        "itemId": "weapon_arcane_orb",
+        "materials": {
+          "material_runic_sigil": 2,
+          "material_rune_dust": 2,
+          "material_metallic_feather": 1
+        }
+      },
+      {
+        "itemId": "armor_iron_visor",
+        "materials": {
+          "material_heart_stone": 1,
+          "material_iron_silk": 2
+        }
+      },
+      {
+        "itemId": "armor_guardian_cuirass",
+        "materials": {
+          "material_heart_stone": 2,
+          "material_iron_silk": 3,
+          "material_troll_skull": 1
+        }
+      },
+      {
+        "itemId": "armor_tempest_greaves",
+        "materials": {
+          "material_heart_stone": 1,
+          "material_runic_sigil": 1,
+          "material_metallic_feather": 2
+        }
+      }
+    ]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -13,7 +13,17 @@ const { getEquipmentCatalog } = require("./systems/equipmentService");
 const { purchaseItem } = require("./systems/shopService");
 const { getInventory, setEquipment } = require("./systems/inventoryService");
 const { getChallengeStatus, runChallengeFight, startChallenge } = require("./systems/challengeGA");
-const { getJobStatus, selectJob, startJobWork, stopJobWork, ensureJobIdle, clearJobLog } = require("./systems/jobService");
+const {
+  getJobStatus,
+  selectJob,
+  startJobWork,
+  stopJobWork,
+  ensureJobIdle,
+  clearJobLog,
+  setBlacksmithTask,
+  addBlacksmithQueueItem,
+  removeBlacksmithQueueItem,
+} = require("./systems/jobService");
 const {
   getAdventureStatus,
   startAdventure,
@@ -246,6 +256,54 @@ app.post("/characters/:characterId/job/log/clear", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(400).json({ error: err.message || "failed to clear job log" });
+  }
+});
+
+app.post("/characters/:characterId/job/blacksmith/task", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId, task } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId || !task) {
+    return res.status(400).json({ error: "playerId, characterId and task required" });
+  }
+  try {
+    const status = await setBlacksmithTask(pid, characterId, task);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to update task" });
+  }
+});
+
+app.post("/characters/:characterId/job/blacksmith/salvage/add", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId, itemId } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId || !itemId) {
+    return res.status(400).json({ error: "playerId, characterId and itemId required" });
+  }
+  try {
+    const status = await addBlacksmithQueueItem(pid, characterId, itemId);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to add item to queue" });
+  }
+});
+
+app.post("/characters/:characterId/job/blacksmith/salvage/remove", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId, itemId } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId || !itemId) {
+    return res.status(400).json({ error: "playerId, characterId and itemId required" });
+  }
+  try {
+    const status = await removeBlacksmithQueueItem(pid, characterId, itemId);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to remove item from queue" });
   }
 });
 

--- a/models/Character.js
+++ b/models/Character.js
@@ -55,7 +55,7 @@ const jobGeneratedMaterialSchema = new mongoose.Schema(
 const jobLogEntrySchema = new mongoose.Schema(
   {
     timestamp: { type: Date, default: Date.now },
-    type: { type: String, enum: ['crafted', 'failed'], required: true },
+    type: { type: String, enum: ['crafted', 'failed', 'salvaged'], required: true },
     itemId: { type: String, default: null },
     itemName: { type: String, default: null },
     rarity: { type: String, default: null },
@@ -65,6 +65,18 @@ const jobLogEntrySchema = new mongoose.Schema(
     missing: { type: [jobMissingSchema], default: undefined },
     materials: { type: materialsSchema, default: () => ({}) },
     generatedMaterials: { type: [jobGeneratedMaterialSchema], default: undefined },
+    producedMaterials: { type: [jobGeneratedMaterialSchema], default: undefined },
+    itemBonus: {
+      type: new mongoose.Schema(
+        {
+          stat: { type: String, default: null },
+          amount: { type: Number, default: 0 },
+          instanceId: { type: String, default: null },
+        },
+        { _id: false }
+      ),
+      default: undefined,
+    },
     generationAttempted: { type: Boolean, default: false },
     generationSucceeded: { type: Boolean, default: false },
     generationChance: { type: Number, default: null },
@@ -72,6 +84,14 @@ const jobLogEntrySchema = new mongoose.Schema(
     generationMultiplier: { type: Number, default: null },
     generationRoll: { type: Number, default: null },
     generationAttribute: { type: String, default: null },
+  },
+  { _id: false }
+);
+
+const jobBlacksmithSchema = new mongoose.Schema(
+  {
+    task: { type: String, enum: ['craft', 'salvage'], default: 'craft' },
+    salvageQueue: { type: [String], default: [] },
   },
   { _id: false }
 );
@@ -89,8 +109,18 @@ const jobSchema = new mongoose.Schema(
     statGains: { type: flexibleNumberMapSchema, default: () => ({}) },
     totalsByItem: { type: flexibleNumberMapSchema, default: () => ({}) },
     log: { type: [jobLogEntrySchema], default: [] },
+    blacksmith: { type: jobBlacksmithSchema, default: undefined },
   },
   { _id: false }
+);
+
+const customItemSchema = new mongoose.Schema(
+  {
+    baseItemId: { type: String, required: true },
+    attributeBonuses: { type: flexibleNumberMapSchema, default: undefined },
+    createdAt: { type: Date, default: Date.now },
+  },
+  { _id: false, minimize: false }
 );
 
 const characterSchema = new mongoose.Schema(
@@ -108,6 +138,7 @@ const characterSchema = new mongoose.Schema(
     gold: { type: Number, default: 0 },
     items: { type: [String], default: [] },
     materials: { type: materialsSchema, default: () => ({}) },
+    customItems: { type: Map, of: customItemSchema, default: undefined },
     job: { type: jobSchema, default: () => ({}) },
   },
   { timestamps: true }

--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -3,6 +3,7 @@ const { getAction } = require('./rotationEngine');
 const { applyEffect, tick } = require('./effectsEngine');
 const { pushLog } = require('./log');
 const { USEABLE_SLOTS } = require('../models/utils');
+const { resolveItemSync } = require('./customItemService');
 
 const EQUIPMENT_SLOTS = ['weapon', 'helmet', 'chest', 'legs', 'feet', 'hands'];
 const MAX_RESIST = 0.75;
@@ -39,11 +40,8 @@ function resolveEquipment(character, equipmentMap) {
   const resolved = {};
   EQUIPMENT_SLOTS.forEach(slot => {
     const itemId = character.equipment && character.equipment[slot];
-    if (itemId && equipmentMap && equipmentMap.has(itemId)) {
-      resolved[slot] = equipmentMap.get(itemId);
-    } else {
-      resolved[slot] = null;
-    }
+    const item = itemId ? resolveItemSync(character, itemId, equipmentMap) : null;
+    resolved[slot] = item || null;
   });
   return resolved;
 }
@@ -52,11 +50,8 @@ function resolveUseables(character, equipmentMap) {
   const resolved = {};
   USEABLE_SLOTS.forEach(slot => {
     const itemId = character.useables && character.useables[slot];
-    if (itemId && equipmentMap && equipmentMap.has(itemId)) {
-      resolved[slot] = equipmentMap.get(itemId);
-    } else {
-      resolved[slot] = null;
-    }
+    const item = itemId ? resolveItemSync(character, itemId, equipmentMap) : null;
+    resolved[slot] = item || null;
   });
   return resolved;
 }

--- a/systems/customItemService.js
+++ b/systems/customItemService.js
@@ -1,0 +1,143 @@
+const crypto = require('crypto');
+const { getEquipmentMap } = require('./equipmentService');
+
+const CUSTOM_ITEM_PREFIX = 'custom:';
+
+function isCustomItemId(id) {
+  return typeof id === 'string' && id.startsWith(CUSTOM_ITEM_PREFIX);
+}
+
+function getCustomId(id) {
+  if (!isCustomItemId(id)) return null;
+  return id.slice(CUSTOM_ITEM_PREFIX.length);
+}
+
+function ensureCustomContainer(characterDoc) {
+  if (!characterDoc) return;
+  if (!characterDoc.customItems) {
+    characterDoc.customItems = {};
+    return;
+  }
+  if (
+    !(characterDoc.customItems instanceof Map)
+    && typeof characterDoc.customItems !== 'object'
+  ) {
+    characterDoc.customItems = {};
+  }
+}
+
+function generateCustomItemId(characterDoc) {
+  const base = crypto.randomUUID ? crypto.randomUUID() : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+  let id = base;
+  const container = characterDoc && characterDoc.customItems;
+  const hasId = candidate => {
+    if (!container) return false;
+    if (container instanceof Map) {
+      return container.has(candidate);
+    }
+    return !!container[candidate];
+  };
+  while (hasId(id)) {
+    id = `${base}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+  return `${CUSTOM_ITEM_PREFIX}${id}`;
+}
+
+function getCustomDefinition(characterDoc, itemId) {
+  if (!characterDoc) return null;
+  const key = getCustomId(itemId);
+  if (!key) return null;
+  if (characterDoc.customItems instanceof Map) {
+    return characterDoc.customItems.get(key) || null;
+  }
+  const container = characterDoc.customItems || {};
+  const entry = container[key];
+  if (!entry || typeof entry !== 'object') return null;
+  return entry;
+}
+
+function storeCustomDefinition(characterDoc, customId, definition) {
+  ensureCustomContainer(characterDoc);
+  if (characterDoc.customItems instanceof Map) {
+    characterDoc.customItems.set(customId.slice(CUSTOM_ITEM_PREFIX.length), definition);
+  } else {
+    characterDoc.customItems[customId.slice(CUSTOM_ITEM_PREFIX.length)] = definition;
+  }
+}
+
+function deleteCustomDefinition(characterDoc, itemId) {
+  if (!characterDoc) return;
+  const key = getCustomId(itemId);
+  if (!key) return;
+  if (characterDoc.customItems instanceof Map) {
+    characterDoc.customItems.delete(key);
+  } else if (characterDoc.customItems && typeof characterDoc.customItems === 'object') {
+    delete characterDoc.customItems[key];
+  }
+}
+
+function applyCustomBonuses(baseItem, definition, itemId) {
+  if (!baseItem) return null;
+  const clone = JSON.parse(JSON.stringify(baseItem));
+  clone.id = itemId || baseItem.id;
+  if (definition && definition.attributeBonuses) {
+    const bonuses = definition.attributeBonuses;
+    clone.attributeBonuses = { ...(clone.attributeBonuses || {}) };
+    Object.entries(bonuses).forEach(([stat, value]) => {
+      const numeric = Number(value);
+      if (Number.isFinite(numeric) && numeric !== 0) {
+        clone.attributeBonuses[stat] = (clone.attributeBonuses[stat] || 0) + numeric;
+      }
+    });
+  }
+  if (definition && definition.nameSuffix && clone.name) {
+    clone.name = `${clone.name} ${definition.nameSuffix}`;
+  }
+  return clone;
+}
+
+async function resolveItem(character, itemId, equipmentMap = null) {
+  if (!itemId) return null;
+  if (!isCustomItemId(itemId)) {
+    const map = equipmentMap || (await getEquipmentMap());
+    return map.get(itemId) || null;
+  }
+  const definition = getCustomDefinition(character, itemId);
+  if (!definition) {
+    return null;
+  }
+  const map = equipmentMap || (await getEquipmentMap());
+  const base = map.get(definition.baseItemId);
+  if (!base) {
+    return null;
+  }
+  return applyCustomBonuses(base, definition, itemId);
+}
+
+function resolveItemSync(character, itemId, equipmentMap) {
+  if (!itemId) return null;
+  if (!isCustomItemId(itemId)) {
+    return equipmentMap && equipmentMap.get ? equipmentMap.get(itemId) || null : null;
+  }
+  const definition = getCustomDefinition(character, itemId);
+  if (!definition || !equipmentMap) {
+    return null;
+  }
+  const base = equipmentMap.get(definition.baseItemId);
+  if (!base) {
+    return null;
+  }
+  return applyCustomBonuses(base, definition, itemId);
+}
+
+module.exports = {
+  CUSTOM_ITEM_PREFIX,
+  isCustomItemId,
+  getCustomDefinition,
+  storeCustomDefinition,
+  deleteCustomDefinition,
+  applyCustomBonuses,
+  generateCustomItemId,
+  resolveItem,
+  resolveItemSync,
+};

--- a/systems/dungeonGA.js
+++ b/systems/dungeonGA.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { ensureEquipmentShape, EQUIPMENT_SLOTS, STATS } = require('../models/utils');
 const { compute } = require('./derivedStats');
 const { runDungeonCombat } = require('./combatEngine');
+const { resolveItemSync } = require('./customItemService');
 
 const CONFIG_FILE = path.join(__dirname, '..', 'data', 'dungeonConfig.json');
 
@@ -994,7 +995,7 @@ function computePartyProfile(party, equipmentMap) {
     const resolved = {};
     EQUIPMENT_SLOTS.forEach(slot => {
       const id = equipment[slot];
-      const item = id ? equipmentMap.get(id) : null;
+      const item = id ? resolveItemSync(character, id, equipmentMap) : null;
       const cost = item && typeof item.cost === 'number' ? item.cost : 0;
       resolved[slot] = item || null;
       totalGear += cost;
@@ -1188,7 +1189,7 @@ function buildBossPreview(character, equipmentMap, metrics) {
   const resolved = {};
   EQUIPMENT_SLOTS.forEach(slot => {
     const id = equipment[slot];
-    resolved[slot] = id && equipmentMap.has(id) ? equipmentMap.get(id) : null;
+    resolved[slot] = id ? resolveItemSync(character, id, equipmentMap) : null;
   });
   const derived = compute(character, resolved);
   const negationDetails = character && character.bossNegation ? applyBossNegationToDerived(derived, character.bossNegation) : null;

--- a/ui/style.css
+++ b/ui/style.css
@@ -1717,3 +1717,225 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   0%, 100% { box-shadow:0 0 0 0 rgba(0,0,0,0.4); transform:translateY(0); }
   50% { box-shadow:0 0 0 6px rgba(0,0,0,0.2); transform:translateY(-1px); }
 }
+
+.blacksmith-section {
+  margin-top:24px;
+  padding:16px;
+  border:1px solid #1f1f1f;
+  border-radius:10px;
+  background:#0e0e0e;
+  box-shadow:0 6px 16px rgba(0,0,0,0.35);
+}
+
+.blacksmith-task-header {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  flex-wrap:wrap;
+  margin-bottom:12px;
+}
+
+.blacksmith-task-header h4 {
+  margin:0;
+  font-size:1.2rem;
+}
+
+.blacksmith-task-buttons {
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+}
+
+.blacksmith-task-button {
+  background:#1c2531;
+  color:#d7e8ff;
+  border:1px solid #2f4057;
+  padding:6px 14px;
+  border-radius:6px;
+  font-weight:600;
+  transition:background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  cursor:pointer;
+}
+
+.blacksmith-task-button:hover,
+.blacksmith-task-button:focus {
+  background:#263445;
+  border-color:#3f5575;
+}
+
+.blacksmith-task-button.active {
+  background:linear-gradient(135deg,#3b82f6,#2563eb);
+  border-color:#1d4ed8;
+  color:#f8fafc;
+  cursor:default;
+  transform:translateY(-1px);
+  box-shadow:0 4px 12px rgba(37,99,235,0.35);
+}
+
+.blacksmith-task-button.active:hover,
+.blacksmith-task-button.active:focus {
+  background:linear-gradient(135deg,#3b82f6,#2563eb);
+  border-color:#1d4ed8;
+}
+
+.blacksmith-task-button:disabled {
+  opacity:0.85;
+}
+
+.blacksmith-note {
+  margin:0 0 18px;
+  font-size:0.95rem;
+  color:#cbd5f5;
+}
+
+.blacksmith-columns {
+  display:grid;
+  gap:18px;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+}
+
+.blacksmith-column {
+  background:#11151d;
+  border:1px solid #1f2b3d;
+  border-radius:10px;
+  padding:14px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  min-height:120px;
+  transition:border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.blacksmith-column.active {
+  border-color:#3b82f6;
+  box-shadow:0 0 0 1px rgba(59,130,246,0.35);
+}
+
+.blacksmith-column h5 {
+  margin:0;
+  font-size:1rem;
+  font-weight:600;
+  color:#e3e9ff;
+}
+
+.blacksmith-empty {
+  margin:0;
+  color:#8b9bbd;
+  font-size:0.9rem;
+}
+
+.blacksmith-item-list {
+  display:grid;
+  gap:12px;
+}
+
+.blacksmith-item-card {
+  background:#151b27;
+  border:1px solid #253044;
+  border-radius:8px;
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  transition:border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.blacksmith-item-card:hover,
+.blacksmith-item-card:focus-within {
+  border-color:#3b82f6;
+  box-shadow:0 4px 12px rgba(59,130,246,0.25);
+}
+
+.blacksmith-item-header {
+  display:flex;
+  justify-content:space-between;
+  gap:8px;
+  align-items:baseline;
+}
+
+.blacksmith-item-name {
+  font-weight:600;
+  font-size:1rem;
+  color:#f1f5ff;
+}
+
+.blacksmith-item-rarity {
+  font-size:0.85rem;
+  color:#9fb7ff;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
+}
+
+.blacksmith-item-meta {
+  font-size:0.85rem;
+  color:#a6b4d4;
+}
+
+.blacksmith-item-variant {
+  font-size:0.8rem;
+  color:#94a3c7;
+}
+
+.blacksmith-item-stats {
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.blacksmith-item-stat {
+  display:flex;
+  justify-content:space-between;
+  gap:12px;
+  font-size:0.85rem;
+  color:#d0dcff;
+}
+
+.blacksmith-item-stat .label {
+  font-weight:600;
+  color:#94b4ff;
+}
+
+.blacksmith-item-stat .value {
+  flex:1;
+  text-align:right;
+  color:#e4ecff;
+}
+
+.blacksmith-item-actions {
+  display:flex;
+  justify-content:flex-end;
+}
+
+.blacksmith-item-action {
+  padding:6px 12px;
+  border-radius:6px;
+  border:1px solid #2e3d52;
+  background:#1f2a3a;
+  color:#d4e4ff;
+  font-weight:600;
+  cursor:pointer;
+  transition:background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.blacksmith-item-action:hover,
+.blacksmith-item-action:focus {
+  background:#2b3b50;
+  border-color:#3f5575;
+  transform:translateY(-1px);
+}
+
+.blacksmith-item-action.remove {
+  background:#3a1f2a;
+  border-color:#5a2538;
+  color:#f8d7e1;
+}
+
+.blacksmith-item-action.remove:hover,
+.blacksmith-item-action.remove:focus {
+  background:#4c2836;
+  border-color:#7a3246;
+}


### PR DESCRIPTION
## Summary
- add front-end helpers for blacksmith jobs, including salvage queue controls and task switching
- style the new blacksmith panels and item cards in the job dialog
- ensure dungeon simulations resolve custom gear correctly while loading job recipes from the dedicated JSON file

## Testing
- not run (UI and service changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cf38fc3ce88320805a02e5d414bb38