### PR TITLE
Add blacksmith shift modes with salvage auto-stop

### DIFF
--- a/data/jobConfig.json
+++ b/data/jobConfig.json
@@ -43,7 +43,24 @@
       "category": "Forging",
       "behavior": "blacksmith",
       "materialRecoveryEnabled": true,
-      "materialRecoveryChanceMultiplier": 1.5
+      "materialRecoveryChanceMultiplier": 1.5,
+      "shiftModes": [
+        {
+          "id": "forge",
+          "label": "Forge Gear",
+          "description": "Forge new weapons and armor while the crew is on duty.",
+          "task": "craft",
+          "default": true
+        },
+        {
+          "id": "salvage",
+          "label": "Salvage Gear",
+          "description": "Break down queued gear into raw materials until every piece is dismantled.",
+          "task": "salvage",
+          "requiresQueue": true,
+          "autoStopOnQueueEmpty": true
+        }
+      ]
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -212,14 +212,19 @@ app.post("/characters/:characterId/job/select", async (req, res) => {
 
 app.post("/characters/:characterId/job/start", async (req, res) => {
   const characterId = parseInt(req.params.characterId, 10);
-  const { playerId } = req.body || {};
+  const { playerId, modeId: rawModeId, mode: rawMode } = req.body || {};
   const pid = parseInt(playerId, 10);
   if (!pid || !characterId) {
     return res.status(400).json({ error: "playerId and characterId required" });
   }
   try {
     await ensureAdventureIdle(characterId);
-    const status = await startJobWork(pid, characterId);
+    const modeId = typeof rawModeId === "string" && rawModeId.trim()
+      ? rawModeId.trim().toLowerCase()
+      : typeof rawMode === "string" && rawMode.trim()
+        ? rawMode.trim().toLowerCase()
+        : null;
+    const status = await startJobWork(pid, characterId, { modeId });
     res.json(status);
   } catch (err) {
     console.error(err);
@@ -261,13 +266,18 @@ app.post("/characters/:characterId/job/log/clear", async (req, res) => {
 
 app.post("/characters/:characterId/job/blacksmith/task", async (req, res) => {
   const characterId = parseInt(req.params.characterId, 10);
-  const { playerId, task } = req.body || {};
+  const { playerId, task, mode } = req.body || {};
   const pid = parseInt(playerId, 10);
-  if (!pid || !characterId || !task) {
-    return res.status(400).json({ error: "playerId, characterId and task required" });
+  const selection = typeof mode === "string" && mode.trim()
+    ? mode
+    : typeof task === "string" && task.trim()
+      ? task
+      : "";
+  if (!pid || !characterId || !selection) {
+    return res.status(400).json({ error: "playerId, characterId and mode required" });
   }
   try {
-    const status = await setBlacksmithTask(pid, characterId, task);
+    const status = await setBlacksmithTask(pid, characterId, selection);
     res.json(status);
   } catch (err) {
     console.error(err);

--- a/ui/style.css
+++ b/ui/style.css
@@ -1421,6 +1421,58 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   color:#111;
   text-transform:none;
 }
+.job-shift-mode {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.job-shift-mode-label {
+  font-size:11px;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  color:#111;
+}
+.job-shift-mode-options {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+.job-shift-mode-button {
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  font-weight:bold;
+  text-transform:uppercase;
+  padding:6px 14px;
+  box-shadow:3px 3px 0 #000;
+  cursor:pointer;
+  transition:transform 0.15s ease;
+}
+.job-shift-mode-button:hover,
+.job-shift-mode-button:focus {
+  transform:translate(-1px,-1px);
+  box-shadow:4px 4px 0 #000;
+}
+.job-shift-mode-button.active {
+  background:#000;
+  color:#fff;
+  cursor:default;
+  transform:translate(-1px,-1px);
+  box-shadow:4px 4px 0 #000;
+}
+.job-shift-mode-button:disabled {
+  opacity:0.7;
+  cursor:not-allowed;
+  transform:none;
+  box-shadow:3px 3px 0 #000;
+}
+.job-shift-mode-description {
+  margin:0;
+  font-size:12px;
+  line-height:1.4;
+  color:#333;
+}
 .job-shift-action {
   align-self:flex-start;
   font-weight:bold;


### PR DESCRIPTION
## Summary
- add shift mode definitions to the blacksmith job and wire them through the job service
- update job processing to honour the selected mode and auto-stop salvaging when the queue empties
- refresh the job UI so players choose forge vs salvage when clocking in, including new styling for the selector

## Testing
- node -e "require('./systems/jobService')"
- npm start *(fails: Missing MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68cf72b63ad8832093eda4d89f856510