### PR TITLE
Persist job shift selections

### DIFF
--- a/models/Character.js
+++ b/models/Character.js
@@ -34,6 +34,7 @@ const attributesSchema = new mongoose.Schema(
 const materialsSchema = new mongoose.Schema({}, { _id: false, strict: false });
 
 const flexibleNumberMapSchema = new mongoose.Schema({}, { _id: false, strict: false });
+const shiftSelectionSchema = new mongoose.Schema({}, { _id: false, strict: false, minimize: false });
 
 const jobMissingSchema = new mongoose.Schema(
   {
@@ -109,6 +110,7 @@ const jobSchema = new mongoose.Schema(
     statGains: { type: flexibleNumberMapSchema, default: () => ({}) },
     totalsByItem: { type: flexibleNumberMapSchema, default: () => ({}) },
     log: { type: [jobLogEntrySchema], default: [] },
+    shiftSelections: { type: shiftSelectionSchema, default: undefined },
     blacksmith: { type: jobBlacksmithSchema, default: undefined },
   },
   { _id: false }


### PR DESCRIPTION
## Summary
- add a shiftSelections schema to the job model so selected work modes persist across reloads
- ensure blacksmith mode choices survive closing and reopening the job dialog, allowing salvage work to continue

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf891717748320ab298dc51973b69c