### PR TITLE
Persist blacksmith mode selection

### DIFF
--- a/models/Character.js
+++ b/models/Character.js
@@ -93,6 +93,7 @@ const jobBlacksmithSchema = new mongoose.Schema(
   {
     task: { type: String, enum: ['craft', 'salvage'], default: 'craft' },
     salvageQueue: { type: [String], default: [] },
+    modeId: { type: String, default: 'forge' },
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary
- persist the currently selected blacksmith work mode directly on the job state so it survives reloads
- normalize blacksmith mode/task synchronization when changing shifts, clocking in, and building the job status payload

## Testing
- node -e "require('./systems/jobService')"

------
https://chatgpt.com/codex/tasks/task_e_68cf8b88e6648320bec349c3d8fa0458