### PR TITLE
Respect explicit job mode selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/systems/jobService.js
+++ b/systems/jobService.js
@@ -1781,8 +1781,8 @@ async function setJobWorkingState(playerId, characterId, shouldWork, options = {
     ? options.modeId.trim().toLowerCase()
     : null;
   const hasExplicitModeRequest = !!modeIdRaw;
-  let requestedModeId = modeIdRaw;
-  if (jobDef.isBlacksmith) {
+  let requestedModeId = hasExplicitModeRequest ? modeIdRaw : null;
+  if (jobDef.isBlacksmith && !hasExplicitModeRequest) {
     const selectionMap = jobState.shiftSelections && typeof jobState.shiftSelections === 'object'
       ? jobState.shiftSelections
       : null;
@@ -1791,10 +1791,8 @@ async function setJobWorkingState(playerId, characterId, shouldWork, options = {
       : null;
     const storedModeId = storedSelectionRaw ? storedSelectionRaw.trim().toLowerCase() : null;
     if (storedModeId) {
-      if (!requestedModeId || storedModeId !== requestedModeId) {
-        requestedModeId = storedModeId;
-      }
-    } else if (!requestedModeId && jobState.blacksmith && typeof jobState.blacksmith === 'object') {
+      requestedModeId = storedModeId;
+    } else if (jobState.blacksmith && typeof jobState.blacksmith === 'object') {
       const stateModeId = normalizeBlacksmithModeId(jobState.blacksmith.modeId);
       if (stateModeId) {
         requestedModeId = stateModeId;

--- a/tests/jobService.start.test.js
+++ b/tests/jobService.start.test.js
@@ -1,0 +1,119 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+class FakeCharacterDoc {
+  constructor(data) {
+    Object.assign(this, JSON.parse(JSON.stringify(data)));
+    this._modified = new Set();
+    this._saveCount = 0;
+  }
+
+  markModified(field) {
+    if (field) {
+      this._modified.add(field);
+    }
+  }
+
+  async save() {
+    this._saveCount += 1;
+    return this;
+  }
+
+  toObject() {
+    const {
+      markModified,
+      save,
+      toObject,
+      _modified,
+      _saveCount,
+      ...rest
+    } = this;
+    return JSON.parse(JSON.stringify(rest));
+  }
+}
+
+const docs = new Map();
+
+function setFakeCharacterDoc(doc) {
+  const key = `${doc.playerId}:${doc.characterId}`;
+  docs.set(key, doc);
+}
+
+const characterModelPath = require.resolve('../models/Character');
+require.cache[characterModelPath] = {
+  id: characterModelPath,
+  filename: characterModelPath,
+  loaded: true,
+  exports: {
+    async findOne(query = {}) {
+      const playerId = Number(query.playerId ?? query.playerID);
+      const characterId = Number(query.characterId ?? query.characterID);
+      if (!Number.isFinite(playerId) || !Number.isFinite(characterId)) {
+        return null;
+      }
+      const key = `${playerId}:${characterId}`;
+      return docs.get(key) || null;
+    },
+  },
+};
+
+const { startJobWork } = require('../systems/jobService');
+
+function buildBaseCharacter() {
+  return new FakeCharacterDoc({
+    playerId: 1,
+    characterId: 10,
+    name: 'Test Blacksmith',
+    basicType: 'melee',
+    attributes: { strength: 10, stamina: 5, agility: 5, intellect: 1, wisdom: 1 },
+    level: 1,
+    xp: 0,
+    rotation: [],
+    equipment: {},
+    useables: {},
+    gold: 0,
+    items: [],
+    materials: {},
+    job: {
+      jobId: 'blacksmith',
+      startedAt: null,
+      lastProcessedAt: null,
+      isWorking: false,
+      workingSince: null,
+      totalAttempts: 0,
+      totalCrafted: 0,
+      totalStatGain: 0,
+      statGains: {},
+      totalsByItem: {},
+      log: [],
+      shiftSelections: { blacksmith: 'forge' },
+      blacksmith: { task: 'craft', salvageQueue: [], modeId: 'forge' },
+    },
+  });
+}
+
+test('POST /characters/:id/job/start honors explicit modeId selection changes', async () => {
+  docs.clear();
+  const doc = buildBaseCharacter();
+  setFakeCharacterDoc(doc);
+
+  const salvageStatus = await startJobWork(1, 10, { modeId: 'salvage' });
+
+  assert.equal(doc.job.shiftSelections.blacksmith, 'salvage');
+  assert.equal(doc.job.blacksmith.modeId, 'salvage');
+  assert.equal(doc.job.blacksmith.task, 'salvage');
+  assert.ok(salvageStatus?.activeJob);
+  assert.equal(salvageStatus.activeJob.activeShiftModeId, 'salvage');
+  assert.equal(salvageStatus.activeJob.blacksmith.modeId, 'salvage');
+  assert.equal(salvageStatus.activeJob.blacksmith.task, 'salvage');
+
+  const forgeStatus = await startJobWork(1, 10, { modeId: 'forge' });
+
+  assert.equal(doc.job.shiftSelections.blacksmith, 'forge');
+  assert.equal(doc.job.blacksmith.modeId, 'forge');
+  assert.equal(doc.job.blacksmith.task, 'craft');
+  assert.ok(forgeStatus?.activeJob);
+  assert.equal(forgeStatus.activeJob.activeShiftModeId, 'forge');
+  assert.equal(forgeStatus.activeJob.blacksmith.modeId, 'forge');
+  assert.equal(forgeStatus.activeJob.blacksmith.task, 'craft');
+});


### PR DESCRIPTION
## Summary
- ensure blacksmith job start requests only fall back to stored mode when no modeId is provided
- keep honoring explicit mode switches by updating shift selections and blacksmith state accordingly
- add a node test covering POST /characters/:id/job/start toggling between forge and salvage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfa744a5588320a0d60bc26bdbf4d4