### PR TITLE
Add blacksmith profession with salvage workflow

### DIFF
--- a/data/jobConfig.json
+++ b/data/jobConfig.json
@@ -19,116 +19,33 @@
       "name": "Craftsman",
       "attribute": "agility",
       "description": "Refines tools and contraptions to keep adventurers ahead of danger.",
-      "category": "Tools",
-      "items": [
-        {
-          "itemId": "useable_first_aid_kit",
-          "materials": {
-            "material_heart_stone": 2,
-            "material_iron_silk": 1
-          }
-        },
-        {
-          "itemId": "useable_toxins",
-          "materials": {
-            "material_rune_dust": 1,
-            "material_runic_sigil": 1,
-            "material_heart_stone": 1
-          }
-        },
-        {
-          "itemId": "useable_vanishing_powder",
-          "materials": {
-            "material_rune_dust": 2,
-            "material_metallic_feather": 1
-          }
-        },
-        {
-          "itemId": "useable_thieving_tools",
-          "materials": {
-            "material_iron_silk": 2,
-            "material_metallic_feather": 1
-          }
-        }
-      ]
+      "category": "Tools"
     },
     {
       "id": "enchanter",
       "name": "Enchanter",
       "attribute": "intellect",
       "description": "Infuses scrolls with arcane force for precise battlefield control.",
-      "category": "Scrolls",
-      "items": [
-        {
-          "itemId": "useable_ice_scroll",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_iron_silk": 1,
-            "material_rune_dust": 1
-          }
-        },
-        {
-          "itemId": "useable_fire_scroll",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_rune_shard": 1,
-            "material_metallic_feather": 1
-          }
-        },
-        {
-          "itemId": "useable_mana_scroll",
-          "materials": {
-            "material_runic_sigil": 2,
-            "material_rune_dust": 1
-          }
-        },
-        {
-          "itemId": "useable_mana_steal_scroll",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_metallic_feather": 1,
-            "material_troll_skull": 1
-          }
-        }
-      ]
+      "category": "Scrolls"
     },
     {
       "id": "apothecary",
       "name": "Apothecary",
       "attribute": "wisdom",
       "description": "Distills restorative draughts and potent elixirs from rare reagents.",
-      "category": "Potions",
-      "items": [
-        {
-          "itemId": "useable_healing_potion",
-          "materials": {
-            "material_heart_stone": 1,
-            "material_rune_shard": 1
-          }
-        },
-        {
-          "itemId": "useable_mana_potion",
-          "materials": {
-            "material_rune_shard": 1,
-            "material_rune_dust": 1
-          }
-        },
-        {
-          "itemId": "useable_stamina_potion",
-          "materials": {
-            "material_heart_stone": 1,
-            "material_iron_silk": 1
-          }
-        },
-        {
-          "itemId": "useable_critical_potion",
-          "materials": {
-            "material_runic_sigil": 1,
-            "material_metallic_feather": 1,
-            "material_troll_skull": 1
-          }
-        }
-      ]
+      "category": "Potions"
+    },
+    {
+      "id": "blacksmith",
+      "name": "Blacksmith",
+      "attribute": "strength",
+      "description": "Breaks unwanted arms into raw stock and reforges legends at the anvil.",
+      "category": "Forge",
+      "type": "blacksmith",
+      "materialRecoveryEnabled": true,
+      "materialRecoveryChanceMultiplier": 1.5,
+      "statGainChance": 0.07,
+      "statGainAmount": 1
     }
   ]
 }

--- a/data/jobRecipes.json
+++ b/data/jobRecipes.json
@@ -1,0 +1,151 @@
+{
+  "recipes": {
+    "craftsman": [
+      {
+        "itemId": "useable_first_aid_kit",
+        "materials": {
+          "material_heart_stone": 2,
+          "material_iron_silk": 1
+        }
+      },
+      {
+        "itemId": "useable_toxins",
+        "materials": {
+          "material_rune_dust": 1,
+          "material_runic_sigil": 1,
+          "material_heart_stone": 1
+        }
+      },
+      {
+        "itemId": "useable_vanishing_powder",
+        "materials": {
+          "material_rune_dust": 2,
+          "material_metallic_feather": 1
+        }
+      },
+      {
+        "itemId": "useable_thieving_tools",
+        "materials": {
+          "material_iron_silk": 2,
+          "material_metallic_feather": 1
+        }
+      }
+    ],
+    "enchanter": [
+      {
+        "itemId": "useable_ice_scroll",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_iron_silk": 1,
+          "material_rune_dust": 1
+        }
+      },
+      {
+        "itemId": "useable_fire_scroll",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_rune_shard": 1,
+          "material_metallic_feather": 1
+        }
+      },
+      {
+        "itemId": "useable_mana_scroll",
+        "materials": {
+          "material_runic_sigil": 2,
+          "material_rune_dust": 1
+        }
+      },
+      {
+        "itemId": "useable_mana_steal_scroll",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_metallic_feather": 1,
+          "material_troll_skull": 1
+        }
+      }
+    ],
+    "apothecary": [
+      {
+        "itemId": "useable_healing_potion",
+        "materials": {
+          "material_heart_stone": 1,
+          "material_rune_shard": 1
+        }
+      },
+      {
+        "itemId": "useable_mana_potion",
+        "materials": {
+          "material_rune_shard": 1,
+          "material_rune_dust": 1
+        }
+      },
+      {
+        "itemId": "useable_stamina_potion",
+        "materials": {
+          "material_heart_stone": 1,
+          "material_iron_silk": 1
+        }
+      },
+      {
+        "itemId": "useable_critical_potion",
+        "materials": {
+          "material_runic_sigil": 1,
+          "material_metallic_feather": 1,
+          "material_troll_skull": 1
+        }
+      }
+    ],
+    "blacksmith": [
+      {
+        "itemId": "weapon_rusted_shortsword",
+        "materials": {
+          "material_heart_stone": 3,
+          "material_iron_silk": 1
+        },
+        "weight": 6
+      },
+      {
+        "itemId": "weapon_militia_spear",
+        "materials": {
+          "material_heart_stone": 2,
+          "material_rune_shard": 2
+        },
+        "weight": 5
+      },
+      {
+        "itemId": "weapon_brutal_battleaxe",
+        "materials": {
+          "material_iron_silk": 3,
+          "material_metallic_feather": 2
+        },
+        "weight": 3
+      },
+      {
+        "itemId": "armor_padded_hood",
+        "materials": {
+          "material_iron_silk": 2,
+          "material_rune_dust": 2
+        },
+        "weight": 5
+      },
+      {
+        "itemId": "armor_guardian_cuirass",
+        "materials": {
+          "material_heart_stone": 2,
+          "material_iron_silk": 2,
+          "material_metallic_feather": 2
+        },
+        "weight": 2
+      },
+      {
+        "itemId": "armor_tempest_greaves",
+        "materials": {
+          "material_runic_sigil": 2,
+          "material_metallic_feather": 2,
+          "material_troll_skull": 1
+        },
+        "weight": 1
+      }
+    ]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -13,7 +13,17 @@ const { getEquipmentCatalog } = require("./systems/equipmentService");
 const { purchaseItem } = require("./systems/shopService");
 const { getInventory, setEquipment } = require("./systems/inventoryService");
 const { getChallengeStatus, runChallengeFight, startChallenge } = require("./systems/challengeGA");
-const { getJobStatus, selectJob, startJobWork, stopJobWork, ensureJobIdle, clearJobLog } = require("./systems/jobService");
+const {
+  getJobStatus,
+  selectJob,
+  startJobWork,
+  stopJobWork,
+  ensureJobIdle,
+  clearJobLog,
+  setJobMode,
+  addToSalvageQueue,
+  removeFromSalvageQueue,
+} = require("./systems/jobService");
 const {
   getAdventureStatus,
   startAdventure,
@@ -230,6 +240,54 @@ app.post("/characters/:characterId/job/stop", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(400).json({ error: err.message || "failed to stop job" });
+  }
+});
+
+app.post("/characters/:characterId/job/mode", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId, mode } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId || !mode) {
+    return res.status(400).json({ error: "playerId, characterId and mode required" });
+  }
+  try {
+    const status = await setJobMode(pid, characterId, mode);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to update job mode" });
+  }
+});
+
+app.post("/characters/:characterId/job/salvage/add", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId, itemId } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId || !itemId) {
+    return res.status(400).json({ error: "playerId, characterId and itemId required" });
+  }
+  try {
+    const status = await addToSalvageQueue(pid, characterId, itemId);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to add item to salvage queue" });
+  }
+});
+
+app.post("/characters/:characterId/job/salvage/remove", async (req, res) => {
+  const characterId = parseInt(req.params.characterId, 10);
+  const { playerId, itemId } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!pid || !characterId || !itemId) {
+    return res.status(400).json({ error: "playerId, characterId and itemId required" });
+  }
+  try {
+    const status = await removeFromSalvageQueue(pid, characterId, itemId);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to remove item from salvage queue" });
   }
 });
 

--- a/models/Character.js
+++ b/models/Character.js
@@ -52,11 +52,20 @@ const jobGeneratedMaterialSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const jobRecoveredMaterialSchema = new mongoose.Schema(
+  {
+    materialId: { type: String, required: true },
+    amount: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
 const jobLogEntrySchema = new mongoose.Schema(
   {
     timestamp: { type: Date, default: Date.now },
-    type: { type: String, enum: ['crafted', 'failed'], required: true },
+    type: { type: String, enum: ['crafted', 'failed', 'salvaged'], required: true },
     itemId: { type: String, default: null },
+    variantId: { type: String, default: null },
     itemName: { type: String, default: null },
     rarity: { type: String, default: null },
     stat: { type: String, default: null },
@@ -72,6 +81,16 @@ const jobLogEntrySchema = new mongoose.Schema(
     generationMultiplier: { type: Number, default: null },
     generationRoll: { type: Number, default: null },
     generationAttribute: { type: String, default: null },
+    recoveredMaterials: { type: [jobRecoveredMaterialSchema], default: undefined },
+    bonusAttributes: { type: new mongoose.Schema({}, { _id: false, strict: false }), default: undefined },
+  },
+  { _id: false }
+);
+
+const blacksmithStateSchema = new mongoose.Schema(
+  {
+    mode: { type: String, enum: ['craft', 'salvage'], default: 'craft' },
+    salvageQueue: { type: [String], default: [] },
   },
   { _id: false }
 );
@@ -89,6 +108,7 @@ const jobSchema = new mongoose.Schema(
     statGains: { type: flexibleNumberMapSchema, default: () => ({}) },
     totalsByItem: { type: flexibleNumberMapSchema, default: () => ({}) },
     log: { type: [jobLogEntrySchema], default: [] },
+    blacksmith: { type: blacksmithStateSchema, default: undefined },
   },
   { _id: false }
 );

--- a/systems/adventureService.js
+++ b/systems/adventureService.js
@@ -5,6 +5,9 @@ const {
   STATS,
   readMaterialCount,
   writeMaterialCount,
+  findItemIndex,
+  countItems,
+  matchesItemId,
 } = require('../models/utils');
 const { readJSON } = require('../store/jsonStore');
 const {
@@ -824,13 +827,13 @@ async function resolveAdventureEvent(state, config, bundle, eventDef, timestamp)
       let modifiedUseables = false;
       let itemsModified = false;
       consumedByPlayer.forEach(entry => {
-        const idx = bundle.characterDoc.items.indexOf(entry.itemId);
+        const idx = findItemIndex(bundle.characterDoc.items, entry.itemId);
         if (idx !== -1) {
           bundle.characterDoc.items.splice(idx, 1);
           itemsModified = true;
         }
-        if (bundle.characterDoc.useables[entry.slot] === entry.itemId) {
-          const remaining = bundle.characterDoc.items.filter(id => id === entry.itemId).length;
+        if (matchesItemId(bundle.characterDoc.useables[entry.slot], entry.itemId)) {
+          const remaining = countItems(bundle.characterDoc.items, entry.itemId);
           if (remaining <= 0) {
             bundle.characterDoc.useables[entry.slot] = null;
             modifiedUseables = true;

--- a/systems/challengeGA.js
+++ b/systems/challengeGA.js
@@ -7,6 +7,9 @@ const {
   ensureEquipmentShape,
   EQUIPMENT_SLOTS,
   STATS,
+  findItemIndex,
+  countItems,
+  matchesItemId,
 } = require('../models/utils');
 const { getAbilities } = require('./abilityService');
 const { getEquipmentMap } = require('./equipmentService');
@@ -1326,13 +1329,13 @@ async function runChallengeFight(characterId, send) {
     let modifiedUseables = false;
     let itemsModified = false;
     consumedByPlayer.forEach(entry => {
-      const idx = prep.characterDoc.items.indexOf(entry.itemId);
+      const idx = findItemIndex(prep.characterDoc.items, entry.itemId);
       if (idx !== -1) {
         prep.characterDoc.items.splice(idx, 1);
         itemsModified = true;
       }
-      if (prep.characterDoc.useables[entry.slot] === entry.itemId) {
-        const remaining = prep.characterDoc.items.filter(id => id === entry.itemId).length;
+      if (matchesItemId(prep.characterDoc.useables[entry.slot], entry.itemId)) {
+        const remaining = countItems(prep.characterDoc.items, entry.itemId);
         if (remaining <= 0) {
           prep.characterDoc.useables[entry.slot] = null;
           modifiedUseables = true;

--- a/systems/dungeonService.js
+++ b/systems/dungeonService.js
@@ -1,5 +1,5 @@
 const CharacterModel = require('../models/Character');
-const { serializeCharacter } = require('../models/utils');
+const { serializeCharacter, findItemIndex, countItems, matchesItemId } = require('../models/utils');
 const { getAbilities } = require('./abilityService');
 const { getEquipmentMap } = require('./equipmentService');
 const { generateDungeonBoss } = require('./dungeonGA');
@@ -92,13 +92,13 @@ function applyUseableConsumption(entry, consumedMap, characterDoc) {
     characterDoc.items = [];
   }
   consumed.forEach(useable => {
-    const idx = characterDoc.items.indexOf(useable.itemId);
+    const idx = findItemIndex(characterDoc.items, useable.itemId);
     if (idx !== -1) {
       characterDoc.items.splice(idx, 1);
       itemsModified = true;
     }
-    if (characterDoc.useables[useable.slot] === useable.itemId) {
-      const remaining = characterDoc.items.filter(id => id === useable.itemId).length;
+    if (matchesItemId(characterDoc.useables[useable.slot], useable.itemId)) {
+      const remaining = countItems(characterDoc.items, useable.itemId);
       if (remaining <= 0) {
         characterDoc.useables[useable.slot] = null;
         modifiedUseables = true;

--- a/systems/equipmentService.js
+++ b/systems/equipmentService.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { readJSON } = require('../store/jsonStore');
 const Item = require('../domain/item');
 const { getMaterialCatalog } = require('./materialService');
+const { parseItemInstanceId, combineAttributeBonuses } = require('../models/utils');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const EQUIPMENT_FILE = path.join(DATA_DIR, 'equipment.json');
@@ -33,6 +34,47 @@ function createItem(entry) {
   return Object.freeze(item);
 }
 
+function createAugmentedItem(baseItem, parsed) {
+  if (!baseItem || !parsed || !parsed.itemId) {
+    return null;
+  }
+  const bonuses = parsed.bonuses || {};
+  if (!Object.keys(bonuses).length) {
+    return null;
+  }
+  const attributeBonuses = combineAttributeBonuses(baseItem.attributeBonuses || {}, bonuses);
+  const augmented = {
+    ...baseItem,
+    id: parsed.rawId,
+    attributeBonuses,
+    blacksmithBonuses: bonuses,
+  };
+  return Object.freeze(augmented);
+}
+
+function resolveDynamicItem(catalog, id) {
+  if (!id || !catalog) return null;
+  if (!catalog.dynamicItems) {
+    catalog.dynamicItems = new Map();
+  }
+  if (catalog.dynamicItems.has(id)) {
+    return catalog.dynamicItems.get(id);
+  }
+  const parsed = parseItemInstanceId(id);
+  if (!parsed.isAugmented || !parsed.itemId) {
+    return null;
+  }
+  const base = catalog.byId.get(parsed.itemId);
+  if (!base) {
+    return null;
+  }
+  const augmented = createAugmentedItem(base, parsed);
+  if (augmented) {
+    catalog.dynamicItems.set(id, augmented);
+  }
+  return augmented;
+}
+
 async function loadCatalog() {
   if (!cache) {
     const raw = await readJSON(EQUIPMENT_FILE);
@@ -41,7 +83,7 @@ async function loadCatalog() {
     const useables = Array.isArray(raw.useables) ? raw.useables.map(createItem) : [];
     const items = [...weapons, ...armor, ...useables];
     const byId = new Map(items.map(item => [item.id, item]));
-    cache = { weapons, armor, useables, byId };
+    cache = { weapons, armor, useables, byId, dynamicItems: new Map() };
   }
   return cache;
 }
@@ -58,7 +100,24 @@ async function getEquipmentCatalog() {
 
 async function getEquipmentMap() {
   const catalog = await loadCatalog();
-  return catalog.byId;
+  if (!catalog.lookup) {
+    const lookup = new Map(catalog.byId);
+    const originalGet = lookup.get.bind(lookup);
+    lookup.get = id => {
+      if (!id) return null;
+      const base = originalGet(id);
+      if (base) {
+        return base;
+      }
+      return resolveDynamicItem(catalog, id);
+    };
+    lookup.has = id => {
+      if (!id) return false;
+      return !!lookup.get(id);
+    };
+    catalog.lookup = lookup;
+  }
+  return catalog.lookup;
 }
 
 async function getItemById(id) {

--- a/systems/matchmaking.js
+++ b/systems/matchmaking.js
@@ -1,5 +1,5 @@
 const CharacterModel = require('../models/Character');
-const { serializeCharacter } = require('../models/utils');
+const { serializeCharacter, findItemIndex, countItems, matchesItemId } = require('../models/utils');
 const { getAbilities } = require('./abilityService');
 const { getEquipmentMap } = require('./equipmentService');
 const { runCombat } = require('./combatEngine');
@@ -142,13 +142,13 @@ function startMatch(a, b) {
           characterDoc.items = [];
         }
         consumed.forEach(entry => {
-          const idx = characterDoc.items.indexOf(entry.itemId);
+          const idx = findItemIndex(characterDoc.items, entry.itemId);
           if (idx !== -1) {
             characterDoc.items.splice(idx, 1);
             itemsModified = true;
           }
-          if (characterDoc.useables[entry.slot] === entry.itemId) {
-            const remaining = characterDoc.items.filter(id => id === entry.itemId).length;
+          if (matchesItemId(characterDoc.useables[entry.slot], entry.itemId)) {
+            const remaining = countItems(characterDoc.items, entry.itemId);
             if (remaining <= 0) {
               characterDoc.useables[entry.slot] = null;
               modifiedUseables = true;

--- a/ui/style.css
+++ b/ui/style.css
@@ -1443,6 +1443,165 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   letter-spacing:1px;
   color:#222;
 }
+.blacksmith-mode-panel {
+  margin:12px 0 0;
+  padding:10px 12px;
+  border:2px solid #000;
+  background:#fff;
+  display:flex;
+  align-items:center;
+  gap:10px;
+  flex-wrap:wrap;
+  box-shadow:3px 3px 0 #000;
+}
+.blacksmith-mode-label {
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:2px;
+  font-weight:bold;
+}
+.blacksmith-mode-button {
+  font-family:'Courier New', monospace;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  padding:6px 14px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:3px 3px 0 #000;
+  cursor:pointer;
+  transition:background 0.2s ease, color 0.2s ease, transform 0.1s ease;
+}
+.blacksmith-mode-button:not([disabled]):hover,
+.blacksmith-mode-button:not([disabled]):focus {
+  background:#000;
+  color:#fff;
+  transform:translate(-1px, -1px);
+}
+.blacksmith-mode-button.active {
+  background:#000;
+  color:#fff;
+  cursor:default;
+}
+.blacksmith-mode-button[disabled]:not(.active) {
+  background:#f1f1f1;
+  color:#777;
+  border-color:#777;
+  box-shadow:3px 3px 0 #999;
+  cursor:not-allowed;
+}
+.blacksmith-workspace {
+  margin:18px 0;
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+  gap:16px;
+}
+.blacksmith-column {
+  border:3px solid #000;
+  background:#fff;
+  color:#000;
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  box-shadow:6px 6px 0 #000;
+}
+.blacksmith-column h4 {
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:15px;
+}
+.blacksmith-column .job-empty-text {
+  border-color:rgba(0,0,0,0.4);
+  background:rgba(0,0,0,0.05);
+  color:#000;
+}
+.blacksmith-item-card {
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  padding:10px 12px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  box-shadow:3px 3px 0 #000;
+  transition:transform 0.12s ease, box-shadow 0.12s ease;
+}
+.blacksmith-item-card:hover,
+.blacksmith-item-card:focus-within {
+  transform:translate(-2px, -2px);
+  box-shadow:5px 5px 0 #000;
+}
+.blacksmith-item-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:8px;
+}
+.blacksmith-item-header .name {
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:13px;
+}
+.blacksmith-item-header .rarity {
+  font-size:10px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  border:1px solid #000;
+  padding:2px 6px;
+  background:#000;
+  color:#fff;
+}
+.blacksmith-item-meta {
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-family:'Courier New', monospace;
+  color:#111;
+}
+.blacksmith-tags {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+}
+.blacksmith-tags .tag {
+  border:1px dashed #000;
+  padding:2px 6px;
+  font-size:10px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  background:#fff;
+  color:#000;
+}
+.blacksmith-item-action {
+  align-self:flex-start;
+  font-family:'Courier New', monospace;
+  font-weight:bold;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  padding:4px 12px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  box-shadow:3px 3px 0 #000;
+  transition:background 0.2s ease, color 0.2s ease, transform 0.1s ease;
+}
+.blacksmith-item-action:not([disabled]):hover,
+.blacksmith-item-action:not([disabled]):focus {
+  background:#000;
+  color:#fff;
+  transform:translate(-1px, -1px);
+}
+.blacksmith-item-action[disabled] {
+  background:#f2f2f2;
+  color:#777;
+  border-color:#777;
+  box-shadow:3px 3px 0 #999;
+  cursor:not-allowed;
+}
 .job-stats-grid {
   display:grid;
   grid-template-columns:repeat(auto-fit, minmax(190px,1fr));
@@ -1590,6 +1749,25 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .job-log-entry.log-crafted .job-log-detail .value,
 .job-log-entry.log-crafted .job-log-footer {
   color:#000;
+}
+.job-log-entry.log-salvaged {
+  background:repeating-linear-gradient(135deg, #fff 0px, #fff 12px, #f7f7f7 12px, #f7f7f7 24px);
+  color:#000;
+  border:2px dashed #000;
+  box-shadow:4px 4px 0 #000;
+}
+.job-log-entry.log-salvaged .job-log-rarity,
+.job-log-entry.log-salvaged .job-log-detail .label,
+.job-log-entry.log-salvaged .job-log-detail .value,
+.job-log-entry.log-salvaged .job-log-footer {
+  color:#000;
+}
+.job-log-entry.log-salvaged .job-log-detail .value {
+  font-weight:bold;
+}
+.job-log-entry.log-salvaged .job-log-badge {
+  border-style:dashed;
+  background:#fff;
 }
 .job-log-entry.log-failed {
   background:#000;


### PR DESCRIPTION
## Summary
- move job recipes into data/jobRecipes.json and register the new strength-scaled blacksmith profession
- extend persistence, equipment lookup, and job processing to support salvage queue management, gear crafting bonuses, and salvage logging
- expose REST endpoints for blacksmith mode/queue changes and build matching UI with monochrome styling plus dedicated salvage log cards

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfd1f0283c83208caf1ff168ed3aa9