### PR TITLE
Fix matchmaking update payload orientation

### DIFF
--- a/systems/matchmaking.js
+++ b/systems/matchmaking.js
@@ -108,9 +108,10 @@ function startMatch(a, b) {
           sendSafe(a, { type: 'start', you: event.a, opponent: event.b });
           sendSafe(b, { type: 'start', you: event.b, opponent: event.a });
         } else if (event.type === 'update') {
-          const payload = { type: 'update', you: event.a, opponent: event.b, log: event.log };
-          sendSafe(a, payload);
-          sendSafe(b, payload);
+          const payloadA = { type: 'update', you: event.a, opponent: event.b, log: event.log };
+          const payloadB = { type: 'update', you: event.b, opponent: event.a, log: event.log };
+          sendSafe(a, payloadA);
+          sendSafe(b, payloadB);
         }
       });
     })


### PR DESCRIPTION
## Summary
- ensure matchmaking combat update payloads send player and opponent data in the correct orientation for each client

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d04e3d5c4c83208f5750fcab11bfd6