### PR TITLE
Improve blacksmith salvage queue batching

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,13 +261,15 @@ app.post("/characters/:characterId/job/mode", async (req, res) => {
 
 app.post("/characters/:characterId/job/salvage/add", async (req, res) => {
   const characterId = parseInt(req.params.characterId, 10);
-  const { playerId, itemId } = req.body || {};
+  const { playerId, itemId, count } = req.body || {};
   const pid = parseInt(playerId, 10);
   if (!pid || !characterId || !itemId) {
     return res.status(400).json({ error: "playerId, characterId and itemId required" });
   }
+  const parsedCount = parseInt(count, 10);
+  const normalizedCount = Number.isFinite(parsedCount) && parsedCount > 0 ? parsedCount : 1;
   try {
-    const status = await addToSalvageQueue(pid, characterId, itemId);
+    const status = await addToSalvageQueue(pid, characterId, itemId, normalizedCount);
     res.json(status);
   } catch (err) {
     console.error(err);

--- a/ui/style.css
+++ b/ui/style.css
@@ -1771,6 +1771,47 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-family:'Courier New', monospace;
   color:#111;
 }
+.blacksmith-item-controls {
+  display:flex;
+  align-items:center;
+  flex-wrap:wrap;
+  gap:10px;
+}
+.blacksmith-quantity-field {
+  display:flex;
+  align-items:center;
+  gap:6px;
+  font-family:'Courier New', monospace;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-size:10px;
+}
+.blacksmith-quantity-label {
+  font-weight:bold;
+}
+.blacksmith-quantity-input {
+  width:56px;
+  padding:4px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  font-family:'Courier New', monospace;
+  font-size:12px;
+  text-align:center;
+  box-shadow:inset 2px 2px 0 #000;
+}
+.blacksmith-quantity-input:focus {
+  outline:none;
+  border-color:#000;
+  box-shadow:inset 2px 2px 0 #000, 0 0 0 2px rgba(0,0,0,0.2);
+}
+.blacksmith-quantity-input[disabled] {
+  background:#f5f5f5;
+  color:#777;
+  border-color:#777;
+  box-shadow:inset 2px 2px 0 #999;
+  cursor:not-allowed;
+}
 .blacksmith-tags {
   display:flex;
   flex-wrap:wrap;


### PR DESCRIPTION
## Summary
- allow the client to pick a quantity when queuing blacksmith salvage items
- handle count-aware add requests on the server while respecting equipped gear limits
- style the new quantity controls to match the monochrome retro theme

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0621745ec8320a38217d3c355aa41