### PR TITLE
Fix salvage quantity handler scope

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -2842,6 +2842,7 @@ function createBlacksmithItemCard(entry, { type, container }) {
   controls.className = 'blacksmith-item-controls';
 
   let quantityInput = null;
+  let enforceQuantityBounds = () => {};
   if (type === 'inventory') {
     const quantityField = document.createElement('div');
     quantityField.className = 'blacksmith-quantity-field';
@@ -2862,7 +2863,10 @@ function createBlacksmithItemCard(entry, { type, container }) {
       quantityInput.value = '0';
       quantityInput.disabled = true;
     }
-    const enforceQuantityBounds = () => {
+    enforceQuantityBounds = () => {
+      if (!quantityInput) {
+        return;
+      }
       const raw = parseInt(quantityInput.value, 10);
       if (!Number.isFinite(raw)) {
         return;


### PR DESCRIPTION
## Summary
- expose the salvage quantity bounds helper outside the quantity field block so click handlers can access it
- keep the guard logic to clamp requested salvage amounts within the available inventory count

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d064fb2df0832086775368e7b334a7