### PR TITLE
Improve dungeon matchmaking transparency and recovery

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,12 @@ const {
   isAdventureActive,
   streamAdventureCombat,
 } = require("./systems/adventureService");
-const { queueDungeon, cancelDungeon, readyForDungeon } = require("./systems/dungeonService");
+const {
+  queueDungeon,
+  cancelDungeon,
+  readyForDungeon,
+  getDungeonStatus,
+} = require("./systems/dungeonService");
 const app = express();
 const connectDB = require("./db");
 
@@ -430,6 +435,20 @@ app.get("/dungeon/queue", async (req, res) => {
     send({ type: "error", message: err.message || "dungeon failed" });
   }
   res.end();
+});
+
+app.get("/dungeon/status", (req, res) => {
+  const characterId = parseInt(req.query.characterId, 10);
+  if (!characterId) {
+    return res.status(400).json({ error: "characterId required" });
+  }
+  try {
+    const status = getDungeonStatus(characterId);
+    res.json(status);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "failed to load dungeon status" });
+  }
 });
 
 app.post("/dungeon/cancel", (req, res) => {


### PR DESCRIPTION
## Summary
- add resume-aware queue handling, queued events, and disband safeguards to the dungeon service
- expose a `/dungeon/status` endpoint so clients can query queue state without reconnecting
- update the dungeon UI to resume existing queues, surface clearer status messages, and keep leave controls accessible after errors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0a48a171c83209eb6b5003bf22d81