### PR TITLE
Fix ready-up regression in dungeon matches

### DIFF
--- a/systems/dungeonService.js
+++ b/systems/dungeonService.js
@@ -314,7 +314,7 @@ async function readyForDungeon(matchId, characterId) {
   match.lastReady = {
     ready: match.ready.size,
     total: match.entries.length,
-    readyIds,
+    readyIds: readyMembers,
   };
   match.entries.forEach(item => sendSafe(item, payload));
   if (match.ready.size >= match.entries.length) {


### PR DESCRIPTION
## Summary
- ensure dungeon matches persist the list of ready participants without referencing an undefined variable

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0bfa67cdc8320a741e41cef9c9d69