### PR TITLE
Add dungeon continuation menu and progression

### DIFF
--- a/systems/dungeonGA.js
+++ b/systems/dungeonGA.js
@@ -1329,12 +1329,23 @@ async function generateDungeonBoss(party, abilityMap, equipmentMap, options = {}
   context.party = party;
   let parentA = null;
   let parentB = null;
+  if (options.parentGenomes && typeof options.parentGenomes === 'object') {
+    const parents = options.parentGenomes;
+    if (parents.champion) {
+      parentA = normalizeGenome(clone(parents.champion), context);
+    }
+    if (parents.partner) {
+      parentB = normalizeGenome(clone(parents.partner), context);
+    }
+  }
   let finalChampion = null;
+  let finalPartner = parentB ? { genome: parentB } : null;
   for (let gen = 0; gen < context.generations; gen += 1) {
     const { champion, partner } = await findChampion(context, parentA, parentB, gen);
     finalChampion = champion;
     parentA = champion.genome;
     parentB = partner.genome;
+    finalPartner = partner;
   }
   const bossCharacter = buildBossCharacter(finalChampion.genome, context, 0);
   finalChampion.genome.name = bossCharacter.name;
@@ -1359,6 +1370,10 @@ async function generateDungeonBoss(party, abilityMap, equipmentMap, options = {}
     character: bossCharacter,
     preview,
     metrics,
+    genomes: {
+      champion: clone(finalChampion.genome),
+      partner: finalPartner && finalPartner.genome ? clone(finalPartner.genome) : null,
+    },
   };
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -979,6 +979,52 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   color:#fff;
   cursor:default;
 }
+.dungeon-post-match {
+  border:2px solid #000;
+  padding:16px;
+  background:#fff;
+  box-shadow:6px 6px 0 #000;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.dungeon-post-match h3 {
+  margin:0;
+  font-size:20px;
+  text-align:center;
+  letter-spacing:2px;
+}
+.dungeon-post-match .post-match-summary {
+  border:2px solid #000;
+  padding:8px;
+  text-align:center;
+  font-weight:bold;
+  background:#fff;
+}
+.dungeon-post-match .post-match-flavor {
+  margin:0;
+  text-align:center;
+  font-size:12px;
+}
+.dungeon-post-match .post-match-actions {
+  display:flex;
+  justify-content:center;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.dungeon-post-match .post-match-actions button {
+  min-width:140px;
+  font-weight:bold;
+  text-transform:uppercase;
+}
+.dungeon-post-match .post-match-status {
+  min-height:20px;
+  text-align:center;
+  font-weight:bold;
+  letter-spacing:1px;
+}
 .combatant-preview {
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- allow dungeon boss generation to reuse parent genomes when continuing
- track post-match continuation state on the server and expose a continue endpoint
- surface a retro-styled post-fight menu that lets parties retry or advance and wire it into the dungeon queue

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0dbfeab1c8320a9d8688b17653e6f