### PR TITLE
Add dungeon continuation decision flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const {
   queueDungeon,
   cancelDungeon,
   readyForDungeon,
+  readyForDungeonDecision,
   getDungeonStatus,
 } = require("./systems/dungeonService");
 const app = express();
@@ -475,6 +476,20 @@ app.post("/dungeon/ready", async (req, res) => {
     res.json(status);
   } catch (err) {
     res.status(400).json({ error: err.message || "failed to ready" });
+  }
+});
+
+app.post("/dungeon/decision", async (req, res) => {
+  const matchId = req.body && req.body.matchId;
+  const characterId = parseInt((req.body && req.body.characterId) || 0, 10);
+  if (!matchId || !characterId) {
+    return res.status(400).json({ error: "matchId and characterId required" });
+  }
+  try {
+    const status = await readyForDungeonDecision(matchId, characterId);
+    res.json(status);
+  } catch (err) {
+    res.status(400).json({ error: err.message || "failed to continue" });
   }
 });
 

--- a/systems/dungeonGA.js
+++ b/systems/dungeonGA.js
@@ -1327,14 +1327,21 @@ async function generateDungeonBoss(party, abilityMap, equipmentMap, options = {}
   const config = await loadDungeonConfig();
   const context = buildDungeonContext(party, abilityMap, equipmentMap, options, config);
   context.party = party;
-  let parentA = null;
-  let parentB = null;
+  const seeds = Array.isArray(options.seedGenomes)
+    ? options.seedGenomes.filter(Boolean)
+    : options.seedGenome
+    ? [options.seedGenome]
+    : [];
+  let parentA = seeds[0] ? normalizeGenome(seeds[0], context) : null;
+  let parentB = seeds[1] ? normalizeGenome(seeds[1], context) : null;
   let finalChampion = null;
+  let finalPartner = null;
   for (let gen = 0; gen < context.generations; gen += 1) {
     const { champion, partner } = await findChampion(context, parentA, parentB, gen);
     finalChampion = champion;
     parentA = champion.genome;
     parentB = partner.genome;
+    finalPartner = partner;
   }
   const bossCharacter = buildBossCharacter(finalChampion.genome, context, 0);
   finalChampion.genome.name = bossCharacter.name;
@@ -1359,6 +1366,11 @@ async function generateDungeonBoss(party, abilityMap, equipmentMap, options = {}
     character: bossCharacter,
     preview,
     metrics,
+    genome: normalizeGenome(finalChampion.genome, context),
+    partnerGenome:
+      finalPartner && finalPartner.genome
+        ? normalizeGenome(finalPartner.genome, context)
+        : null,
   };
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -864,6 +864,61 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:16px;
   font-family:'Courier New', monospace;
 }
+.dungeon-decision-panel {
+  border:2px solid #000;
+  padding:16px;
+  background:#fff;
+  box-shadow:4px 4px 0 #000;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  font-family:'Courier New', monospace;
+}
+.dungeon-decision-panel .decision-title {
+  margin:0;
+  font-size:20px;
+  text-transform:uppercase;
+  letter-spacing:3px;
+  text-align:center;
+}
+.dungeon-decision-panel .decision-round {
+  align-self:center;
+  border:2px solid #000;
+  padding:4px 10px;
+  font-size:12px;
+  text-transform:uppercase;
+  background:#000;
+  color:#fff;
+  letter-spacing:1px;
+}
+.dungeon-decision-panel .decision-detail {
+  font-size:13px;
+  text-align:center;
+  text-transform:none;
+  letter-spacing:0.5px;
+}
+.dungeon-decision-panel .decision-reward {
+  font-size:12px;
+  text-align:center;
+  border:2px dashed #000;
+  padding:6px 8px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.decision-columns {
+  margin-top:4px;
+}
+.decision-actions {
+  border-top:2px solid #000;
+  padding-top:12px;
+}
+.decision-actions .dungeon-ready-button {
+  min-width:140px;
+}
+.dungeon-decision-panel .ready-column-title {
+  background:#000;
+  color:#fff;
+}
 .dungeon-preview-panel h3 {
   margin:0;
   font-size:18px;


### PR DESCRIPTION
## Summary
- seed dungeon boss generation with prior genomes so advancing can escalate foes
- add a post-battle decision phase with `/dungeon/decision` endpoint for retry/advance coordination
- refresh the dungeon UI with a monochrome decision panel that shows party readiness and retry/advance buttons

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d211d26f1c8320973d860929905488