### PR TITLE
Fix dungeon advance preview and ready state handling

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -7019,6 +7019,15 @@ function startDungeonQueue(
       return;
     }
     if (data.type === 'ready') {
+      const eventPhase = data.phase || null;
+      if (
+        dungeonState &&
+        dungeonState.phase &&
+        eventPhase &&
+        eventPhase !== dungeonState.phase
+      ) {
+        return;
+      }
       updateDungeonReady(data.ready || 0, data.total || dungeonState.size, data.readyIds);
       return;
     }


### PR DESCRIPTION
## Summary
- pre-generate the next dungeon boss after victories so the decision screen previews the upcoming challenge
- reuse the prepared boss data when advancing instead of regenerating it on demand
- guard dungeon ready updates so phase-mismatched events no longer auto-lock a player's decision button

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d23f891b648320a4a91964f0bb510b