### PR TITLE
Add account-wide stash system

### DIFF
--- a/models/Player.js
+++ b/models/Player.js
@@ -1,10 +1,25 @@
 const mongoose = require('mongoose');
 
+const stashEquipmentSchema = new mongoose.Schema({}, { _id: false, strict: false });
+
+const stashMaterialsSchema = new mongoose.Schema({}, { _id: false, strict: false });
+
+const stashSchema = new mongoose.Schema(
+  {
+    gold: { type: Number, default: 0 },
+    equipmentSlots: { type: Number, default: 5 },
+    equipment: { type: stashEquipmentSchema, default: () => ({}) },
+    materials: { type: stashMaterialsSchema, default: () => ({}) },
+  },
+  { _id: false }
+);
+
 const playerSchema = new mongoose.Schema(
   {
     playerId: { type: Number, unique: true, index: true, required: true },
     name: { type: String, required: true },
     characterId: { type: Number, default: null },
+    stash: { type: stashSchema, default: () => ({}) },
   },
   { timestamps: true }
 );

--- a/models/utils.js
+++ b/models/utils.js
@@ -2,6 +2,7 @@ const EQUIPMENT_SLOTS = ['weapon', 'helmet', 'chest', 'legs', 'feet', 'hands'];
 const USEABLE_SLOTS = ['useable1', 'useable2'];
 const STATS = ['strength', 'stamina', 'agility', 'intellect', 'wisdom'];
 const ITEM_AUGMENT_SEPARATOR = '::bs::';
+const DEFAULT_STASH_EQUIPMENT_SLOTS = 5;
 
 function normalizeDate(value) {
   if (!value) return null;
@@ -56,6 +57,49 @@ function ensureMaterialShape(materials = {}) {
     });
   }
   return shaped;
+}
+
+function ensureCountMap(map = {}) {
+  const shaped = {};
+  if (!map || typeof map !== 'object') {
+    return shaped;
+  }
+  const assignIfValid = (id, value) => {
+    if (id == null) return;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      shaped[id] = Math.floor(numeric);
+    }
+  };
+  if (map instanceof Map) {
+    map.forEach((value, key) => assignIfValid(key, value));
+  } else {
+    Object.entries(map).forEach(([id, value]) => assignIfValid(id, value));
+  }
+  return shaped;
+}
+
+function ensureStashEquipmentShape(equipment = {}) {
+  return ensureCountMap(equipment);
+}
+
+function ensureStashShape(stash = {}) {
+  if (!stash || typeof stash !== 'object') {
+    return {
+      gold: 0,
+      equipmentSlots: DEFAULT_STASH_EQUIPMENT_SLOTS,
+      equipment: {},
+      materials: {},
+    };
+  }
+  const gold = Number(stash.gold);
+  const slots = Number(stash.equipmentSlots);
+  return {
+    gold: Number.isFinite(gold) ? gold : 0,
+    equipmentSlots: Number.isFinite(slots) && slots > 0 ? Math.floor(slots) : DEFAULT_STASH_EQUIPMENT_SLOTS,
+    equipment: ensureStashEquipmentShape(stash.equipment),
+    materials: ensureMaterialShape(stash.materials),
+  };
 }
 
 function readMaterialCount(materials, id) {
@@ -269,4 +313,8 @@ module.exports = {
   matchesItemId,
   findItemIndex,
   countItems,
+  ensureStashShape,
+  ensureStashEquipmentShape,
+  ensureCountMap,
+  DEFAULT_STASH_EQUIPMENT_SLOTS,
 };

--- a/systems/dungeonGA.js
+++ b/systems/dungeonGA.js
@@ -1329,12 +1329,23 @@ async function generateDungeonBoss(party, abilityMap, equipmentMap, options = {}
   context.party = party;
   let parentA = null;
   let parentB = null;
+  if (options.parentGenomes && typeof options.parentGenomes === 'object') {
+    const parents = options.parentGenomes;
+    if (parents.champion) {
+      parentA = normalizeGenome(clone(parents.champion), context);
+    }
+    if (parents.partner) {
+      parentB = normalizeGenome(clone(parents.partner), context);
+    }
+  }
   let finalChampion = null;
+  let finalPartner = parentB ? { genome: parentB } : null;
   for (let gen = 0; gen < context.generations; gen += 1) {
     const { champion, partner } = await findChampion(context, parentA, parentB, gen);
     finalChampion = champion;
     parentA = champion.genome;
     parentB = partner.genome;
+    finalPartner = partner;
   }
   const bossCharacter = buildBossCharacter(finalChampion.genome, context, 0);
   finalChampion.genome.name = bossCharacter.name;
@@ -1359,6 +1370,10 @@ async function generateDungeonBoss(party, abilityMap, equipmentMap, options = {}
     character: bossCharacter,
     preview,
     metrics,
+    genomes: {
+      champion: clone(finalChampion.genome),
+      partner: finalPartner && finalPartner.genome ? clone(finalPartner.genome) : null,
+    },
   };
 }
 

--- a/systems/stashService.js
+++ b/systems/stashService.js
@@ -1,0 +1,296 @@
+const PlayerModel = require('../models/Player');
+const CharacterModel = require('../models/Character');
+const {
+  EQUIPMENT_SLOTS,
+  ensureMaterialShape,
+  ensureStashShape,
+  ensureStashEquipmentShape,
+  DEFAULT_STASH_EQUIPMENT_SLOTS,
+  matchesItemId,
+  countItems,
+} = require('../models/utils');
+const { getEquipmentMap } = require('./equipmentService');
+const { getMaterialMap } = require('./materialService');
+
+const BASE_SLOT_COST = 250;
+const RARITY_ORDER = ['Common', 'Uncommon', 'Rare', 'Epic', 'Legendary'];
+
+function slotOrder(slot) {
+  const order = [...EQUIPMENT_SLOTS, 'useable'];
+  const idx = order.indexOf(slot);
+  return idx === -1 ? order.length : idx;
+}
+
+function sanitizeStashDocument(stashDoc) {
+  const shaped = ensureStashShape(stashDoc);
+  if (!shaped.equipmentSlots || shaped.equipmentSlots < DEFAULT_STASH_EQUIPMENT_SLOTS) {
+    shaped.equipmentSlots = DEFAULT_STASH_EQUIPMENT_SLOTS;
+  }
+  return shaped;
+}
+
+function ensureStash(playerDoc) {
+  if (!playerDoc.stash) {
+    playerDoc.stash = sanitizeStashDocument({});
+    playerDoc.markModified('stash');
+    return playerDoc.stash;
+  }
+  const sanitized = sanitizeStashDocument(playerDoc.stash);
+  playerDoc.stash.gold = sanitized.gold;
+  playerDoc.stash.equipmentSlots = sanitized.equipmentSlots;
+  playerDoc.stash.equipment = sanitized.equipment;
+  playerDoc.stash.materials = sanitized.materials;
+  playerDoc.markModified('stash');
+  return playerDoc.stash;
+}
+
+function getUniqueEquipmentCount(equipmentMap = {}) {
+  return Object.values(equipmentMap).filter(count => Number.isFinite(count) && count > 0).length;
+}
+
+function computeNextSlotCost(stash) {
+  const slots = Math.max(DEFAULT_STASH_EQUIPMENT_SLOTS, Math.floor(stash.equipmentSlots || DEFAULT_STASH_EQUIPMENT_SLOTS));
+  const purchased = Math.max(0, slots - DEFAULT_STASH_EQUIPMENT_SLOTS);
+  return BASE_SLOT_COST * Math.pow(2, purchased);
+}
+
+async function loadPlayerAndCharacter(playerId, characterId) {
+  const [playerDoc, characterDoc] = await Promise.all([
+    PlayerModel.findOne({ playerId }),
+    CharacterModel.findOne({ playerId, characterId }),
+  ]);
+  if (!playerDoc) {
+    throw new Error('player not found');
+  }
+  if (!characterDoc) {
+    throw new Error('character not found');
+  }
+  return { playerDoc, characterDoc };
+}
+
+function removeCharacterItems(characterDoc, itemId, count) {
+  if (!Number.isFinite(count) || count <= 0) {
+    return;
+  }
+  const available = countItems(characterDoc.items, itemId);
+  if (available < count) {
+    throw new Error('not enough copies of item');
+  }
+  let remaining = count;
+  const nextItems = [];
+  (Array.isArray(characterDoc.items) ? characterDoc.items : []).forEach(rawId => {
+    if (remaining > 0 && matchesItemId(rawId, itemId)) {
+      remaining -= 1;
+      return;
+    }
+    nextItems.push(rawId);
+  });
+  characterDoc.items = nextItems;
+  characterDoc.markModified('items');
+}
+
+function removeCharacterMaterials(characterDoc, materialId, amount) {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return;
+  }
+  const shaped = ensureMaterialShape(characterDoc.materials || {});
+  const current = shaped[materialId] || 0;
+  if (current < amount) {
+    throw new Error('not enough materials');
+  }
+  const next = current - amount;
+  if (next > 0) {
+    characterDoc.materials[materialId] = next;
+  } else {
+    delete characterDoc.materials[materialId];
+  }
+  characterDoc.markModified('materials');
+}
+
+function applyDepositToStash(stash, { items = [], materials = {}, gold = 0 }) {
+  if (!stash.equipment) {
+    stash.equipment = {};
+  }
+  if (!stash.materials) {
+    stash.materials = {};
+  }
+  if (Array.isArray(items)) {
+    items.forEach(({ itemId, count }) => {
+      if (!itemId) return;
+      const numeric = Number(count);
+      if (!Number.isFinite(numeric) || numeric <= 0) {
+        return;
+      }
+      const key = String(itemId);
+      stash.equipment[key] = (stash.equipment[key] || 0) + Math.floor(numeric);
+    });
+  }
+  const shapedMaterials = ensureMaterialShape(materials);
+  Object.entries(shapedMaterials).forEach(([materialId, amount]) => {
+    stash.materials[materialId] = (stash.materials[materialId] || 0) + amount;
+  });
+  const numericGold = Number(gold);
+  if (Number.isFinite(numericGold) && numericGold > 0) {
+    stash.gold = (stash.gold || 0) + numericGold;
+  }
+}
+
+async function depositToStash(playerId, characterId, payload = {}) {
+  if (!playerId || !characterId) {
+    throw new Error('playerId and characterId required');
+  }
+  const { playerDoc, characterDoc } = await loadPlayerAndCharacter(playerId, characterId);
+  const stash = ensureStash(playerDoc);
+
+  const normalizedItems = Array.isArray(payload.items) ? payload.items : [];
+  const normalizedMaterials = ensureMaterialShape(payload.materials || {});
+  const goldAmount = Number(payload.gold) || 0;
+
+  const pendingItems = normalizedItems
+    .map(entry => {
+      if (!entry || entry.itemId == null) return null;
+      const count = Number(entry.count);
+      if (!Number.isFinite(count) || count <= 0) return null;
+      return { itemId: String(entry.itemId), count: Math.floor(count) };
+    })
+    .filter(Boolean);
+
+  const equipmentAfter = { ...ensureStashEquipmentShape(stash.equipment) };
+  const uniqueBefore = getUniqueEquipmentCount(equipmentAfter);
+  let uniqueAfter = uniqueBefore;
+  pendingItems.forEach(({ itemId, count }) => {
+    if (!equipmentAfter[itemId]) {
+      uniqueAfter += 1;
+    }
+    equipmentAfter[itemId] = (equipmentAfter[itemId] || 0) + count;
+  });
+  if (uniqueAfter > stash.equipmentSlots) {
+    throw new Error('not enough stash equipment slots');
+  }
+
+  if (!characterDoc.materials) {
+    characterDoc.materials = {};
+  }
+
+  pendingItems.forEach(({ itemId, count }) => removeCharacterItems(characterDoc, itemId, count));
+  Object.entries(normalizedMaterials).forEach(([materialId, amount]) => {
+    removeCharacterMaterials(characterDoc, materialId, amount);
+  });
+
+  const numericGold = Number(goldAmount);
+  if (Number.isFinite(numericGold) && numericGold > 0) {
+    const availableGold = Number(characterDoc.gold) || 0;
+    if (availableGold < numericGold) {
+      throw new Error('not enough gold');
+    }
+    characterDoc.gold = availableGold - numericGold;
+  }
+
+  applyDepositToStash(stash, {
+    items: pendingItems,
+    materials: normalizedMaterials,
+    gold: numericGold,
+  });
+
+  playerDoc.markModified('stash');
+  await Promise.all([playerDoc.save(), characterDoc.save()]);
+}
+
+function buildStashView(stash, equipmentMap, materialMap) {
+  const normalized = sanitizeStashDocument(stash);
+  const equipmentEntries = [];
+  Object.entries(normalized.equipment).forEach(([itemId, count]) => {
+    if (!(count > 0)) return;
+    const item = equipmentMap.get(itemId);
+    if (!item) return;
+    const plain = JSON.parse(JSON.stringify(item));
+    equipmentEntries.push({ item: plain, count });
+  });
+  equipmentEntries.sort((a, b) => {
+    const slotA = a.item ? a.item.slot : null;
+    const slotB = b.item ? b.item.slot : null;
+    const orderA = slotOrder(slotA);
+    const orderB = slotOrder(slotB);
+    if (orderA !== orderB) return orderA - orderB;
+    const nameA = a.item && a.item.name ? a.item.name : '';
+    const nameB = b.item && b.item.name ? b.item.name : '';
+    return nameA.localeCompare(nameB);
+  });
+
+  const materialEntries = [];
+  Object.entries(normalized.materials).forEach(([materialId, amount]) => {
+    if (!(amount > 0)) return;
+    const material = materialMap.get(materialId);
+    if (!material) return;
+    const plain = JSON.parse(JSON.stringify(material));
+    materialEntries.push({ material: plain, count: amount });
+  });
+  materialEntries.sort((a, b) => {
+    const rarityA = a.material?.rarity || 'Common';
+    const rarityB = b.material?.rarity || 'Common';
+    const indexA = RARITY_ORDER.indexOf(rarityA);
+    const indexB = RARITY_ORDER.indexOf(rarityB);
+    if (indexA !== indexB) {
+      const safeA = indexA === -1 ? RARITY_ORDER.length : indexA;
+      const safeB = indexB === -1 ? RARITY_ORDER.length : indexB;
+      return safeA - safeB;
+    }
+    const nameA = a.material?.name || '';
+    const nameB = b.material?.name || '';
+    return nameA.localeCompare(nameB);
+  });
+
+  const equipmentCounts = ensureStashEquipmentShape(normalized.equipment);
+  const materialCounts = ensureMaterialShape(normalized.materials);
+
+  return {
+    gold: normalized.gold || 0,
+    equipmentSlots: normalized.equipmentSlots || DEFAULT_STASH_EQUIPMENT_SLOTS,
+    equipmentUsed: equipmentEntries.length,
+    nextSlotCost: computeNextSlotCost(normalized),
+    equipment: equipmentEntries,
+    equipmentCounts,
+    materials: materialEntries,
+    materialCounts,
+  };
+}
+
+async function getStash(playerId) {
+  const playerDoc = await PlayerModel.findOne({ playerId });
+  if (!playerDoc) {
+    throw new Error('player not found');
+  }
+  const stash = ensureStash(playerDoc);
+  const [equipmentMap, materialMap] = await Promise.all([getEquipmentMap(), getMaterialMap()]);
+  return buildStashView(stash, equipmentMap, materialMap);
+}
+
+async function expandStash(playerId) {
+  if (!playerId) {
+    throw new Error('playerId required');
+  }
+  const playerDoc = await PlayerModel.findOne({ playerId });
+  if (!playerDoc) {
+    throw new Error('player not found');
+  }
+  const stash = ensureStash(playerDoc);
+  const cost = computeNextSlotCost(stash);
+  if ((stash.gold || 0) < cost) {
+    throw new Error('not enough stash gold');
+  }
+  stash.gold -= cost;
+  stash.equipmentSlots = Math.max(DEFAULT_STASH_EQUIPMENT_SLOTS, Math.floor(stash.equipmentSlots || DEFAULT_STASH_EQUIPMENT_SLOTS)) + 1;
+  playerDoc.markModified('stash');
+  await playerDoc.save();
+  const [equipmentMap, materialMap] = await Promise.all([getEquipmentMap(), getMaterialMap()]);
+  return buildStashView(stash, equipmentMap, materialMap);
+}
+
+module.exports = {
+  depositToStash,
+  getStash,
+  expandStash,
+  buildStashView,
+  ensureStash,
+  computeNextSlotCost,
+};

--- a/ui/index.html
+++ b/ui/index.html
@@ -104,6 +104,7 @@
               Show Filters ▾
             </button>
             <div class="inventory-controls-actions">
+              <button id="inventory-stash-button" class="inventory-stash-button" type="button">View Stash</button>
               <button id="inventory-filter-reset" class="filter-reset" type="button">Reset Filters</button>
             </div>
           </div>
@@ -134,6 +135,7 @@
         </div>
         <div class="inventory-results-header">
           <div id="inventory-results-summary"></div>
+          <div id="inventory-stash-summary" class="inventory-stash-summary"></div>
         </div>
         <div class="inventory-layout">
           <div class="inventory-column">
@@ -265,6 +267,34 @@
         </div>
       </div>
     </section>
+  </div>
+  <div id="stash-dialog" class="stash-dialog-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="stash-dialog-title">
+    <div class="stash-dialog">
+      <div class="stash-dialog-header">
+        <h2 id="stash-dialog-title">Account Stash</h2>
+        <button type="button" id="stash-dialog-close">Close</button>
+      </div>
+      <div id="stash-dialog-message" class="message hidden"></div>
+      <div class="stash-dialog-summary" id="stash-dialog-summary"></div>
+      <div class="stash-dialog-actions">
+        <div class="stash-gold-transfer">
+          <label for="stash-gold-input">Deposit Gold</label>
+          <div class="stash-gold-field">
+            <input id="stash-gold-input" type="number" min="1" step="1" />
+            <button type="button" id="stash-deposit-gold">Deposit</button>
+          </div>
+        </div>
+        <button type="button" id="stash-expand" class="stash-expand-button">Unlock Slot</button>
+      </div>
+      <div class="stash-section">
+        <h3>Stored Equipment</h3>
+        <div id="stash-equipment-grid" class="stash-grid"></div>
+      </div>
+      <div class="stash-section">
+        <h3>Stored Materials</h3>
+        <div id="stash-material-grid" class="stash-grid stash-material-grid"></div>
+      </div>
+    </div>
   </div>
   <script src="tooltip.js"></script>
   <script src="main.js"></script>

--- a/ui/style.css
+++ b/ui/style.css
@@ -979,6 +979,52 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   color:#fff;
   cursor:default;
 }
+.dungeon-post-match {
+  border:2px solid #000;
+  padding:16px;
+  background:#fff;
+  box-shadow:6px 6px 0 #000;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+.dungeon-post-match h3 {
+  margin:0;
+  font-size:20px;
+  text-align:center;
+  letter-spacing:2px;
+}
+.dungeon-post-match .post-match-summary {
+  border:2px solid #000;
+  padding:8px;
+  text-align:center;
+  font-weight:bold;
+  background:#fff;
+}
+.dungeon-post-match .post-match-flavor {
+  margin:0;
+  text-align:center;
+  font-size:12px;
+}
+.dungeon-post-match .post-match-actions {
+  display:flex;
+  justify-content:center;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.dungeon-post-match .post-match-actions button {
+  min-width:140px;
+  font-weight:bold;
+  text-transform:uppercase;
+}
+.dungeon-post-match .post-match-status {
+  min-height:20px;
+  text-align:center;
+  font-weight:bold;
+  letter-spacing:1px;
+}
 .combatant-preview {
   display:flex;
   flex-direction:column;

--- a/ui/style.css
+++ b/ui/style.css
@@ -1398,6 +1398,35 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   flex:1 0 auto;
 }
 
+.inventory-card-stash {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  width:100%;
+  justify-content:flex-end;
+}
+
+.inventory-card-quantity-field {
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+
+.inventory-card-quantity-label {
+  font-size:11px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+}
+
+.inventory-card-quantity-input {
+  width:56px;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  padding:2px 4px;
+  font-family:'Courier New', monospace;
+}
+
 
 .shop-layout { display:flex; gap:16px; align-items:flex-start; flex-wrap:wrap; }
 #shop-controls { flex:0 0 260px; border:2px solid #000; background:#fff; padding:16px; display:flex; flex-direction:column; gap:16px; box-shadow:6px 6px 0 #000; }
@@ -1461,6 +1490,16 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   gap:12px;
 }
 
+.inventory-stash-button {
+  font-weight:bold;
+  text-transform:uppercase;
+  box-shadow:4px 4px 0 #000;
+  padding:8px 12px;
+  background:#fff;
+  color:#000;
+  border:2px solid #000;
+}
+
 .inventory-filter-toggle {
   font-weight:bold;
   text-transform:uppercase;
@@ -1522,6 +1561,21 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   font-weight:bold;
 }
 
+.inventory-stash-summary {
+  display:flex;
+  align-items:center;
+  gap:12px;
+  font-size:11px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+}
+
+.inventory-stash-summary span {
+  border:2px solid #000;
+  padding:4px 8px;
+  background:#fff;
+}
+
 @media (max-width: 900px) {
   .shop-layout { flex-direction:column; }
   #shop-controls { width:100%; }
@@ -1570,6 +1624,185 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .inventory-column .item-grid,
 .inventory-column .material-grid {
   flex:1;
+}
+
+.stash-dialog-overlay {
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  background:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:24px;
+  z-index:1200;
+}
+
+.stash-dialog {
+  width:100%;
+  max-width:820px;
+  border:2px solid #000;
+  background:#fff;
+  box-shadow:8px 8px 0 #000;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  padding:20px;
+}
+
+.stash-dialog-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  text-transform:uppercase;
+  letter-spacing:2px;
+}
+
+.stash-dialog-header h2 {
+  margin:0;
+  font-size:20px;
+}
+
+.stash-dialog-header button,
+.stash-expand-button,
+#stash-deposit-gold {
+  font-weight:bold;
+  text-transform:uppercase;
+  border:2px solid #000;
+  background:#fff;
+  color:#000;
+  padding:6px 12px;
+  box-shadow:4px 4px 0 #000;
+  cursor:pointer;
+}
+
+.stash-dialog-header button:disabled,
+.stash-expand-button:disabled,
+#stash-deposit-gold:disabled {
+  opacity:0.6;
+  cursor:not-allowed;
+}
+
+.stash-dialog-summary {
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+}
+
+.stash-summary-item {
+  flex:1 1 160px;
+  border:2px solid #000;
+  padding:12px;
+  background:repeating-linear-gradient(45deg, #fff 0px, #fff 6px, #f4f4f4 6px, #f4f4f4 12px);
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  min-width:160px;
+}
+
+.stash-summary-item .label {
+  font-size:11px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+}
+
+.stash-summary-item .value {
+  font-size:18px;
+  font-weight:bold;
+}
+
+.stash-dialog-actions {
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  align-items:flex-end;
+  justify-content:space-between;
+}
+
+.stash-gold-transfer {
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  font-size:12px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+}
+
+.stash-gold-field {
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+
+#stash-gold-input {
+  width:120px;
+  border:2px solid #000;
+  padding:6px 8px;
+  background:#fff;
+  color:#000;
+  font-family:'Courier New', monospace;
+}
+
+.stash-section h3 {
+  margin:0 0 8px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.stash-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(120px, 1fr));
+  gap:12px;
+}
+
+.stash-slot {
+  border:2px solid #000;
+  min-height:100px;
+  padding:12px;
+  background:#fff;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  text-align:center;
+  gap:6px;
+  position:relative;
+}
+
+.stash-slot.empty {
+  background:repeating-linear-gradient(135deg, #fff 0px, #fff 6px, #f2f2f2 6px, #f2f2f2 12px);
+}
+
+.stash-slot.filled {
+  background:#000;
+  color:#fff;
+}
+
+.stash-slot .stash-slot-name {
+  font-size:13px;
+  font-weight:bold;
+  letter-spacing:1px;
+}
+
+.stash-slot .stash-slot-count {
+  font-size:12px;
+  letter-spacing:1px;
+}
+
+.stash-slot .stash-slot-meta {
+  font-size:10px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+}
+
+.stash-material-grid {
+  grid-template-columns:repeat(auto-fill, minmax(140px, 1fr));
+}
+
+.stash-material-grid .stash-slot {
+  min-height:80px;
 }
 
 .equipment-panel {

--- a/ui/style.css
+++ b/ui/style.css
@@ -813,6 +813,47 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   text-transform:uppercase;
 }
 .dungeon-status { min-height:20px; }
+.dungeon-forging {
+  border:1px solid #000;
+  background:#fff;
+  box-shadow:4px 4px 0 #000;
+  padding:12px 16px;
+  margin-top:8px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  align-items:center;
+  text-align:center;
+  text-transform:uppercase;
+  font-weight:bold;
+  letter-spacing:0.5px;
+}
+.dungeon-forging-headline { font-size:0.85rem; }
+.dungeon-forging-bar {
+  position:relative;
+  width:100%;
+  max-width:280px;
+  height:14px;
+  border:1px solid #000;
+  background:#fff;
+  overflow:hidden;
+}
+.dungeon-forging-fill {
+  position:absolute;
+  inset:0;
+  background-image:repeating-linear-gradient(-45deg, #000 0, #000 6px, #fff 6px, #fff 12px);
+  animation:dungeon-forging-stripes 0.6s linear infinite;
+}
+.dungeon-forging-detail {
+  font-size:0.7rem;
+  text-transform:none;
+  font-weight:normal;
+  letter-spacing:0.3px;
+}
+@keyframes dungeon-forging-stripes {
+  from { background-position:0 0; }
+  to { background-position:12px 0; }
+}
 .dungeon-preview-panel {
   border:2px solid #000;
   padding:16px;


### PR DESCRIPTION
## Summary
- extend players with a shared stash model and implement service helpers for depositing items, materials and gold
- expose stash retrieval, deposit and slot expansion endpoints and include stash data in inventory payloads
- add inventory UI controls, modal grid view and styling to manage the stash with quantity-aware deposit buttons and slot purchase flow

## Testing
- npm run start *(fails: MongoDB connection unavailable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1aa47149c8320b8a2f030fc4e69ba