### PR TITLE
Fix adventure event processing after completion

### DIFF
--- a/systems/adventureService.js
+++ b/systems/adventureService.js
@@ -215,7 +215,7 @@ function createBaseState(characterId, config) {
 
 function isStateActive(state) {
   if (!state || !state.active) return false;
-  if (state.endsAt && Date.now() >= state.endsAt) return false;
+  if (state.completedAt != null && state.completedAt <= Date.now()) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- keep adventures marked active until completion has been finalized so overdue events can be processed and logged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3550184048320bf3934118339786a