### PR TITLE
Add agility-scaling Sanguine Strike ability with conditional cost

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -396,5 +396,35 @@
         "target": "enemy"
       }
     ]
+  },
+  {
+    "id": 24,
+    "name": "Sanguine Strike",
+    "school": "physical",
+    "costType": "stamina",
+    "costValue": 25,
+    "cooldown": 15,
+    "scaling": ["agility"],
+    "conditionalCost": {
+      "type": "WaiveIfNoDamageLastTurn",
+      "resources": ["stamina"]
+    },
+    "effects": [
+      {
+        "type": "PhysicalDamage",
+        "value": 8,
+        "scaling": { "agility": 0.65 },
+        "critEffects": [
+          {
+            "type": "Bleed",
+            "percentPerBonus": 0.01,
+            "duration": 6,
+            "interval": 2,
+            "damageType": "bleed",
+            "logLabel": "bleed damage"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -150,6 +150,10 @@ function createCombatant(character, equipmentMap) {
     damageReflections: [],
     damageHealShields: [],
     attackIntervalAdjustments: [],
+    tookDamageSinceLastTurn: false,
+    damageTakenLastTurn: false,
+    lastDamageTakenTime: null,
+    lastTurnDamageTime: null,
   };
   if (negationDetails) {
     combatant.negation = { ...negationDetails };
@@ -189,6 +193,12 @@ function executeCombatAction(actor, target, now, abilityMap, log) {
     summary.logs = [];
     return summary;
   }
+
+  actor.damageTakenLastTurn = !!actor.tookDamageSinceLastTurn;
+  if (Number.isFinite(actor.lastDamageTakenTime)) {
+    actor.lastTurnDamageTime = actor.lastDamageTakenTime;
+  }
+  actor.tookDamageSinceLastTurn = false;
 
   if ((actor.stunnedAttacksRemaining || 0) > 0) {
     const remainingBefore = Number.isFinite(actor.stunnedAttacksRemaining)
@@ -572,6 +582,10 @@ function tryUseCombatantItem(combatant, enemy, now, log, context = {}) {
 
 function handleDamageTaken(victim, attacker, damageType, amount, now, log) {
   if (!victim || !Number.isFinite(amount) || amount <= 0) return;
+  victim.tookDamageSinceLastTurn = true;
+  if (Number.isFinite(now)) {
+    victim.lastDamageTakenTime = now;
+  }
   const context = {
     event: 'damageTaken',
     damageType,


### PR DESCRIPTION
## Summary
- add the Sanguine Strike agility-based ability definition with a conditional stamina cost and critical bleed effect
- extend ability, combat, and rotation systems to support conditional costs and track last-turn damage for the new skill
- implement bleed follow-up handling in the effects engine and surface the new behaviour in the UI with updated tooltips

## Testing
- node -e "require('./systems/effectsEngine'); console.log('effects ok');"
- node - <<'NODE'
const { getAbilities } = require('./systems/abilityService');
getAbilities().then(list => {
  const ability = list.find(a => a.name === 'Sanguine Strike');
  console.log('ability found:', !!ability);
  if (ability) {
    console.log('conditionalCosts:', ability.conditionalCosts);
    console.log('effects:', ability.effects.map(e => e.type));
  }
}).catch(err => {
  console.error('failed to load abilities', err);
  process.exitCode = 1;
});
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d394307fec8320ad5817a33d6d4041