### PR TITLE
Fix adventure restart timing regression

### DIFF
--- a/systems/adventureService.js
+++ b/systems/adventureService.js
@@ -183,6 +183,15 @@ async function persistState(state) {
   if (!state || typeof state.characterId !== 'number') {
     throw new Error('invalid adventure state');
   }
+  const nullableNumbers = ['startedAt', 'endsAt', 'nextEventAt', 'completedAt'];
+  nullableNumbers.forEach(key => {
+    if (!Number.isFinite(state[key])) {
+      state[key] = null;
+    }
+  });
+  if (state.outcome == null) {
+    state.outcome = null;
+  }
   const payload = JSON.parse(JSON.stringify(state));
   payload.characterId = state.characterId;
   await AdventureStateModel.updateOne(
@@ -1163,6 +1172,7 @@ async function startAdventure(characterId, options = {}) {
     dayDurationMs,
     totalDays,
     nextEventAt,
+    completedAt: null,
     events: [],
     history: baseHistory,
     finalized: false,


### PR DESCRIPTION
## Summary
- normalize persisted adventure state fields so cleared timestamps are stored as null
- reset the persisted completedAt field when starting a new adventure to avoid stale values

## Testing
- node -e "require('./systems/adventureService')"

------
https://chatgpt.com/codex/tasks/task_e_68d3a58137c883209ba732d63a9dbca0