### PR TITLE
Add stamina-scaling Reckoning and Secondwind abilities

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -427,4 +427,44 @@
       }
     ]
   }
+  ,
+  {
+    "id": 25,
+    "name": "Reckoning",
+    "school": "physical",
+    "costType": "stamina",
+    "costValue": 20,
+    "cooldown": 15,
+    "scaling": ["stamina"],
+    "effects": [
+      {
+        "type": "ReckoningDamage",
+        "value": 12,
+        "scaling": { "stamina": 0.28 },
+        "damageType": "physical",
+        "logLabel": "reckoning"
+      }
+    ]
+  },
+  {
+    "id": 26,
+    "name": "Secondwind",
+    "school": "physical",
+    "costType": "stamina",
+    "costValue": 16,
+    "cooldown": 16,
+    "scaling": ["stamina"],
+    "effects": [
+      {
+        "type": "DamageResourceReturn",
+        "resource": "stamina",
+        "percent": 0.35,
+        "attackCountBase": 4,
+        "attackCountScaling": { "stamina": 0.12 },
+        "attackCountMax": 16,
+        "durationType": "selfAttackIntervals",
+        "logLabel": "Second Wind"
+      }
+    ]
+  }
 ]

--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -149,6 +149,7 @@ function createCombatant(character, equipmentMap) {
     damageGuards: [],
     damageReflections: [],
     damageHealShields: [],
+    damageResourceReturns: [],
     attackIntervalAdjustments: [],
     tookDamageSinceLastTurn: false,
     damageTakenLastTurn: false,


### PR DESCRIPTION
## Summary
- add Reckoning and Secondwind abilities with stamina-focused scaling
- extend combat and effect engines to handle missing-health damage and stamina recovery shields
- update UI descriptions to surface new effect behavior

## Testing
- node -e "require('./data/abilities.json'); console.log('abilities ok');"

------
https://chatgpt.com/codex/tasks/task_e_68d42e126fa083209ba8a7223e34977f