### PR TITLE
Fix Restage stored damage and basic attack type issues

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -209,6 +209,8 @@
         "type": "NextAbilityDamage",
         "value": 10,
         "scaling": { "agility": 0.75 },
+        "appliesTo": "any",
+        "matchLastDamageType": false,
         "matchLastResult": true,
         "target": "self"
       }

--- a/systems/derivedStats.js
+++ b/systems/derivedStats.js
@@ -191,7 +191,9 @@ function compute(character, equipped = {}) {
   let maxMeleeAttack = attributes.strength * 2 + 4;
   let minMagicAttack = attributes.intellect * 2;
   let maxMagicAttack = attributes.intellect * 2 + 4;
-  let basicAttackEffectType = character.basicType === 'melee' ? 'PhysicalDamage' : 'MagicDamage';
+  const normalizedBasicType =
+    character.basicType === 'magic' ? 'magic' : character.basicType === 'melee' ? 'melee' : null;
+  let basicAttackEffectType = normalizedBasicType === 'magic' ? 'MagicDamage' : 'PhysicalDamage';
   let weaponDamageType = null;
 
   if (weapon) {
@@ -199,13 +201,17 @@ function compute(character, equipped = {}) {
     if (weapon.damageType === 'magical') {
       minMagicAttack = minDamage;
       maxMagicAttack = maxDamage;
-      basicAttackEffectType = 'MagicDamage';
       weaponDamageType = 'magical';
+      if (!normalizedBasicType) {
+        basicAttackEffectType = 'MagicDamage';
+      }
     } else {
       minMeleeAttack = minDamage;
       maxMeleeAttack = maxDamage;
-      basicAttackEffectType = 'PhysicalDamage';
       weaponDamageType = 'physical';
+      if (!normalizedBasicType) {
+        basicAttackEffectType = 'PhysicalDamage';
+      }
     }
   }
 

--- a/systems/effectsEngine.js
+++ b/systems/effectsEngine.js
@@ -1177,11 +1177,15 @@ function applyEffect(source, target, effect, now, log, context = {}) {
       }
       const interval = Number.isFinite(effect.interval) && effect.interval > 0 ? effect.interval : 1;
       const rawDuration = Number.isFinite(effect.duration) && effect.duration >= 0 ? effect.duration : null;
-      const explicitTicks =
-        Number.isFinite(effect.ticks) && effect.ticks > 0 ? Math.floor(effect.ticks) : null;
+      const explicitTicksRaw =
+        Number.isFinite(effect.ticks) && effect.ticks > 0 ? effect.ticks : null;
+      const explicitTicks = explicitTicksRaw != null ? Math.max(1, Math.floor(explicitTicksRaw)) : null;
       let totalDuration = rawDuration;
-      if (totalDuration == null && explicitTicks != null) {
+      if ((totalDuration == null || totalDuration <= 0) && explicitTicks != null) {
         totalDuration = interval * explicitTicks;
+      }
+      if (totalDuration != null && totalDuration < interval) {
+        totalDuration = interval;
       }
       let ticksRemaining = explicitTicks;
       if (ticksRemaining == null && totalDuration != null && interval > 0) {


### PR DESCRIPTION
## Summary
- let Restage's stored damage apply to any subsequent action regardless of damage type
- respect the player's chosen basic attack school and clarify basic attack information in the rotation planner and visualization
- ensure resource-over-time effects last long enough for at least one tick and display accurate durations

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d464a8c9a08320ada8db0e260bc44e