### PR TITLE
Prevent recursive retaliation loops

### DIFF
--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -636,8 +636,10 @@ function processDamageRetaliationStores(victim, attacker, amount, now, log) {
   if (!victim || !Array.isArray(victim.damageRetaliationStores) || victim.damageRetaliationStores.length === 0) {
     return;
   }
+  const stores = victim.damageRetaliationStores.slice();
   const remaining = [];
-  victim.damageRetaliationStores.forEach(entry => {
+  victim.damageRetaliationStores = remaining;
+  stores.forEach(entry => {
     if (!entry) return;
     const expiresAt = Number.isFinite(entry.expiresAt) ? entry.expiresAt : Infinity;
     const expired = Number.isFinite(now) && now >= expiresAt;
@@ -662,7 +664,6 @@ function processDamageRetaliationStores(victim, attacker, amount, now, log) {
       remaining.push(entry);
     }
   });
-  victim.damageRetaliationStores = remaining;
 }
 
 function handleDamageTaken(victim, attacker, damageType, amount, now, log) {


### PR DESCRIPTION
## Summary
- rebuild damage retaliation processing to work on a snapshot and reassign the active list before iterating
- ensure triggered retaliation stores are removed before retaliating to stop infinite handleDamageTaken recursion

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d545b339ec8320bf3ac6e717060d3e