### PR TITLE
Add monochrome rarity frames to item cards

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -2510,7 +2510,9 @@ function createInventoryItemCard(entry, messageEl) {
   if (!entry || !entry.item) return null;
   const { item, count } = entry;
   const card = document.createElement('div');
-  card.className = 'shop-item-card inventory-item-card';
+  card.className = 'shop-item-card inventory-item-card rarity-card';
+  const rarityKey = (item.rarity || 'Common').toLowerCase();
+  card.dataset.rarity = rarityKey;
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -2520,7 +2522,7 @@ function createInventoryItemCard(entry, messageEl) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
-  rarity.textContent = item.rarity || 'Common';
+  rarity.textContent = titleCase(item.rarity || 'Common');
   header.appendChild(rarity);
   card.appendChild(header);
 
@@ -2610,7 +2612,9 @@ function createInventoryItemCard(entry, messageEl) {
 function createInventoryMaterialCard(material, count) {
   if (!material) return null;
   const card = document.createElement('div');
-  card.className = 'shop-item-card inventory-material-card';
+  card.className = 'shop-item-card inventory-material-card rarity-card';
+  const rarityKey = (material.rarity || 'Common').toLowerCase();
+  card.dataset.rarity = rarityKey;
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -2620,7 +2624,7 @@ function createInventoryMaterialCard(material, count) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
-  rarity.textContent = material.rarity || 'Common';
+  rarity.textContent = titleCase(material.rarity || 'Common');
   header.appendChild(rarity);
   card.appendChild(header);
 
@@ -4229,7 +4233,9 @@ function createTag(text) {
 
 function buildShopItemCard(item, messageEl) {
   const card = document.createElement('div');
-  card.className = 'shop-item-card';
+  card.className = 'shop-item-card rarity-card';
+  const rarityKey = (item.rarity || 'Common').toLowerCase();
+  card.dataset.rarity = rarityKey;
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -4239,7 +4245,7 @@ function buildShopItemCard(item, messageEl) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
-  rarity.textContent = item.rarity || 'Common';
+  rarity.textContent = titleCase(item.rarity || 'Common');
   header.appendChild(rarity);
   card.appendChild(header);
 
@@ -8050,12 +8056,11 @@ function launchAdventureReplay(event) {
 function createAdventureItemCard(item) {
   if (!item) return null;
   const card = document.createElement('div');
-  card.className = 'event-card item-card';
+  card.className = 'event-card item-card rarity-card';
   card.tabIndex = 0;
   card.setAttribute('role', 'button');
-  if (item.rarity) {
-    card.dataset.rarity = String(item.rarity).toLowerCase();
-  }
+  const rarityKey = (item.rarity || 'Common').toLowerCase();
+  card.dataset.rarity = rarityKey;
   const title = document.createElement('div');
   title.className = 'card-title';
   title.textContent = 'Item Found';
@@ -8081,12 +8086,11 @@ function createAdventureItemCard(item) {
 function createAdventureMaterialCard(material) {
   if (!material) return null;
   const card = document.createElement('div');
-  card.className = 'event-card item-card';
+  card.className = 'event-card item-card rarity-card';
   card.tabIndex = 0;
   card.setAttribute('role', 'button');
-  if (material.rarity) {
-    card.dataset.rarity = String(material.rarity).toLowerCase();
-  }
+  const rarityKey = (material.rarity || 'Common').toLowerCase();
+  card.dataset.rarity = rarityKey;
   const title = document.createElement('div');
   title.className = 'card-title';
   title.textContent = 'Material Found';

--- a/ui/style.css
+++ b/ui/style.css
@@ -1359,7 +1359,9 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   align-self:flex-start;
 }
 
+
 .inventory-item-card.equipped {
+  --rarity-accent:#fff;
   background:#000;
   color:#fff;
   border-color:#fff;
@@ -1370,16 +1372,15 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   color:#f2f2f2;
 }
 
-.inventory-item-card.equipped .card-rarity,
 .inventory-item-card.equipped .card-tag {
-  border-color:#fff;
-  color:#fff;
+  border-color:var(--rarity-accent);
+  color:var(--rarity-accent);
 }
 
 .inventory-item-card.equipped .inventory-card-status,
 .inventory-item-card.equipped .inventory-card-count {
-  border-color:#fff;
-  color:#fff;
+  border-color:var(--rarity-accent);
+  color:var(--rarity-accent);
 }
 
 .inventory-item-card.equipped button {
@@ -1435,7 +1436,86 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .shop-item-card { border:2px solid #000; background:#fff; box-shadow:4px 4px 0 #000; padding:10px; display:flex; flex-direction:column; gap:8px; min-height:0; }
 .shop-item-card .card-header { display:flex; justify-content:space-between; align-items:flex-start; text-transform:uppercase; font-weight:bold; letter-spacing:1px; gap:8px; }
 .shop-item-card .card-name { flex:1; font-size:14px; line-height:1.2; }
-.shop-item-card .card-rarity { border:2px solid #000; padding:2px 6px; font-size:11px; }
+.rarity-card { position:relative; --rarity-accent:#000; }
+.rarity-card::before,
+.rarity-card::after { content:none; }
+.rarity-card[data-rarity]::before,
+.rarity-card[data-rarity]::after {
+  position:absolute;
+  pointer-events:none;
+}
+.shop-item-card .card-rarity {
+  border:2px solid var(--rarity-accent);
+  color:var(--rarity-accent);
+  padding:2px 6px;
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  font-weight:bold;
+}
+.rarity-card[data-rarity='uncommon']::after {
+  content:'';
+  inset:4px;
+  border:2px solid var(--rarity-accent);
+}
+.rarity-card[data-rarity='rare']::after {
+  content:'';
+  inset:4px;
+  border:2px solid var(--rarity-accent);
+}
+.rarity-card[data-rarity='rare']::before {
+  content:'';
+  inset:0;
+  background:
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top left/16px 2px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top left/2px 16px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top right/16px 2px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top right/2px 16px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom left/16px 2px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom left/2px 16px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom right/16px 2px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom right/2px 16px no-repeat;
+}
+.rarity-card[data-rarity='epic']::after {
+  content:'';
+  inset:4px;
+  border:3px double var(--rarity-accent);
+}
+.rarity-card[data-rarity='epic']::before {
+  content:'';
+  inset:0;
+  background:
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top left/18px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top left/3px 18px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top right/18px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top right/3px 18px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom left/18px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom left/3px 18px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom right/18px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom right/3px 18px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) center/100% 2px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) center/2px 100% no-repeat;
+}
+.rarity-card[data-rarity='legendary']::after {
+  content:'';
+  inset:4px;
+  border:4px double var(--rarity-accent);
+}
+.rarity-card[data-rarity='legendary']::before {
+  content:'';
+  inset:0;
+  background:
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top left/20px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top left/3px 20px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top right/20px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) top right/3px 20px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom left/20px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom left/3px 20px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom right/20px 3px no-repeat,
+    linear-gradient(var(--rarity-accent), var(--rarity-accent)) bottom right/3px 20px no-repeat,
+    linear-gradient(45deg, transparent calc(50% - 1px), var(--rarity-accent) calc(50% - 1px) calc(50% + 1px), transparent calc(50% + 1px)),
+    linear-gradient(135deg, transparent calc(50% - 1px), var(--rarity-accent) calc(50% - 1px) calc(50% + 1px), transparent calc(50% + 1px));
+}
 .shop-item-card .card-tags { display:flex; flex-wrap:wrap; gap:4px; font-size:10px; text-transform:uppercase; letter-spacing:1px; }
 .shop-item-card .card-tag { border:1px solid #000; padding:2px 6px; }
 .shop-item-card .card-description { font-size:12px; color:#333; }


### PR DESCRIPTION
## Summary
- add a shared rarity-card frame to shop, inventory, and adventure item cards
- render rarity-specific monochrome outlines and corner patterns for uncommon through legendary tiers
- unify rarity badge styling and equipped state colors so the frames invert correctly when equipped

## Testing
- npm start *(fails: requires MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fe25ec408320948a71c2f4ebb73e