### PR TITLE
Add monochrome rarity framing to item cards

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -2511,6 +2511,8 @@ function createInventoryItemCard(entry, messageEl) {
   const { item, count } = entry;
   const card = document.createElement('div');
   card.className = 'shop-item-card inventory-item-card';
+  const rarityKey = item.rarity ? String(item.rarity).toLowerCase() : 'common';
+  card.dataset.rarity = rarityKey;
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -2520,6 +2522,7 @@ function createInventoryItemCard(entry, messageEl) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
+  rarity.dataset.rarity = rarityKey;
   rarity.textContent = item.rarity || 'Common';
   header.appendChild(rarity);
   card.appendChild(header);
@@ -2611,6 +2614,8 @@ function createInventoryMaterialCard(material, count) {
   if (!material) return null;
   const card = document.createElement('div');
   card.className = 'shop-item-card inventory-material-card';
+  const rarityKey = material.rarity ? String(material.rarity).toLowerCase() : 'common';
+  card.dataset.rarity = rarityKey;
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -2620,6 +2625,7 @@ function createInventoryMaterialCard(material, count) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
+  rarity.dataset.rarity = rarityKey;
   rarity.textContent = material.rarity || 'Common';
   header.appendChild(rarity);
   card.appendChild(header);
@@ -4230,6 +4236,8 @@ function createTag(text) {
 function buildShopItemCard(item, messageEl) {
   const card = document.createElement('div');
   card.className = 'shop-item-card';
+  const rarityKey = item.rarity ? String(item.rarity).toLowerCase() : 'common';
+  card.dataset.rarity = rarityKey;
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -4239,6 +4247,7 @@ function buildShopItemCard(item, messageEl) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
+  rarity.dataset.rarity = rarityKey;
   rarity.textContent = item.rarity || 'Common';
   header.appendChild(rarity);
   card.appendChild(header);

--- a/ui/style.css
+++ b/ui/style.css
@@ -1337,6 +1337,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .inventory-item-card,
 .inventory-material-card {
   position:relative;
+  overflow:hidden;
 }
 
 .inventory-card-meta {
@@ -1432,7 +1433,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .shop-subsection-title { display:flex; justify-content:space-between; align-items:center; text-transform:uppercase; font-weight:bold; letter-spacing:1px; }
 .shop-subsection-count { font-size:12px; }
 .shop-card-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); gap:12px; }
-.shop-item-card { border:2px solid #000; background:#fff; box-shadow:4px 4px 0 #000; padding:10px; display:flex; flex-direction:column; gap:8px; min-height:0; }
+.shop-item-card { border:2px solid #000; background:#fff; box-shadow:4px 4px 0 #000; padding:10px; display:flex; flex-direction:column; gap:8px; min-height:0; position:relative; overflow:hidden; }
 .shop-item-card .card-header { display:flex; justify-content:space-between; align-items:flex-start; text-transform:uppercase; font-weight:bold; letter-spacing:1px; gap:8px; }
 .shop-item-card .card-name { flex:1; font-size:14px; line-height:1.2; }
 .shop-item-card .card-rarity { border:2px solid #000; padding:2px 6px; font-size:11px; }
@@ -1443,6 +1444,180 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 .shop-item-card .card-cost { font-size:12px; }
 .shop-item-card button { font-weight:bold; text-transform:uppercase; box-shadow:3px 3px 0 #000; padding:6px 10px; }
 .shop-empty { padding:24px; text-align:center; text-transform:uppercase; letter-spacing:1px; font-weight:bold; border:2px dashed #000; }
+
+.shop-item-card[data-rarity]::before,
+.shop-item-card[data-rarity]::after,
+.inventory-item-card[data-rarity]::before,
+.inventory-item-card[data-rarity]::after,
+.inventory-material-card[data-rarity]::before,
+.inventory-material-card[data-rarity]::after {
+  pointer-events:none;
+  content:'';
+  position:absolute;
+}
+
+.shop-item-card[data-rarity='uncommon'],
+.inventory-item-card:not(.equipped)[data-rarity='uncommon'],
+.inventory-material-card[data-rarity='uncommon'] {
+  box-shadow:4px 4px 0 #000, inset 0 0 0 2px #000;
+}
+
+.shop-item-card[data-rarity='uncommon']::after,
+.inventory-item-card:not(.equipped)[data-rarity='uncommon']::after,
+.inventory-material-card[data-rarity='uncommon']::after {
+  inset:10px;
+  border:1px solid #000;
+}
+
+.shop-item-card[data-rarity='rare'],
+.inventory-item-card:not(.equipped)[data-rarity='rare'],
+.inventory-material-card[data-rarity='rare'] {
+  box-shadow:4px 4px 0 #000, inset 0 0 0 3px #000;
+}
+
+.shop-item-card[data-rarity='rare']::before,
+.inventory-item-card:not(.equipped)[data-rarity='rare']::before,
+.inventory-material-card[data-rarity='rare']::before,
+.shop-item-card[data-rarity='rare']::after,
+.inventory-item-card:not(.equipped)[data-rarity='rare']::after,
+.inventory-material-card[data-rarity='rare']::after {
+  left:0;
+  width:100%;
+  height:14px;
+  background:
+    linear-gradient(135deg, transparent 0 45%, #000 45% 55%, transparent 55% 100%),
+    linear-gradient(225deg, transparent 0 45%, #000 45% 55%, transparent 55% 100%);
+  background-repeat:no-repeat;
+  background-size:50% 100%;
+}
+
+.shop-item-card[data-rarity='rare']::before,
+.inventory-item-card:not(.equipped)[data-rarity='rare']::before,
+.inventory-material-card[data-rarity='rare']::before {
+  top:0;
+}
+
+.shop-item-card[data-rarity='rare']::after,
+.inventory-item-card:not(.equipped)[data-rarity='rare']::after,
+.inventory-material-card[data-rarity='rare']::after {
+  bottom:0;
+}
+
+.shop-item-card[data-rarity='epic'],
+.inventory-item-card[data-rarity='epic'],
+.inventory-material-card[data-rarity='epic'] {
+  background:#000;
+  color:#fff;
+  border-color:#000;
+  box-shadow:4px 4px 0 #000, inset 0 0 0 2px #fff, inset 0 0 0 5px #000;
+}
+
+.shop-item-card[data-rarity='epic']::after,
+.inventory-item-card[data-rarity='epic']::after,
+.inventory-material-card[data-rarity='epic']::after {
+  inset:14px;
+  border:2px solid #fff;
+}
+
+.shop-item-card[data-rarity='legendary'],
+.inventory-item-card:not(.equipped)[data-rarity='legendary'],
+.inventory-material-card[data-rarity='legendary'] {
+  box-shadow:4px 4px 0 #000, inset 0 0 0 2px #000, inset 0 0 0 12px #fff, inset 0 0 0 14px #000;
+}
+
+.shop-item-card[data-rarity='legendary']::before,
+.inventory-item-card:not(.equipped)[data-rarity='legendary']::before,
+.inventory-material-card[data-rarity='legendary']::before {
+  top:50%;
+  left:50%;
+  transform:translate(-50%, -50%) rotate(45deg);
+  width:min(70%, 140px);
+  height:min(70%, 140px);
+  border:2px solid #000;
+  background:transparent;
+}
+
+.shop-item-card[data-rarity='legendary']::after,
+.inventory-item-card:not(.equipped)[data-rarity='legendary']::after,
+.inventory-material-card[data-rarity='legendary']::after {
+  display:none;
+}
+
+.inventory-item-card.equipped[data-rarity='uncommon']::after {
+  inset:10px;
+  border:1px solid #fff;
+}
+
+.inventory-item-card.equipped[data-rarity='rare']::before,
+.inventory-item-card.equipped[data-rarity='rare']::after {
+  left:0;
+  width:100%;
+  height:14px;
+  background:
+    linear-gradient(135deg, transparent 0 45%, #fff 45% 55%, transparent 55% 100%),
+    linear-gradient(225deg, transparent 0 45%, #fff 45% 55%, transparent 55% 100%);
+  background-repeat:no-repeat;
+  background-size:50% 100%;
+}
+
+.inventory-item-card.equipped[data-rarity='rare']::before {
+  top:0;
+}
+
+.inventory-item-card.equipped[data-rarity='rare']::after {
+  bottom:0;
+}
+
+.inventory-item-card.equipped[data-rarity='legendary'] {
+  box-shadow:4px 4px 0 #000, 0 0 0 2px #fff inset, inset 0 0 0 12px #fff, inset 0 0 0 14px #000;
+}
+
+.inventory-item-card.equipped[data-rarity='legendary']::before {
+  top:50%;
+  left:50%;
+  transform:translate(-50%, -50%) rotate(45deg);
+  width:min(70%, 140px);
+  height:min(70%, 140px);
+  border:2px solid #fff;
+  background:transparent;
+}
+
+.shop-item-card[data-rarity='epic'] .card-rarity,
+.inventory-item-card[data-rarity='epic'] .card-rarity,
+.inventory-material-card[data-rarity='epic'] .card-rarity,
+.shop-item-card[data-rarity='legendary'] .card-rarity,
+.inventory-item-card:not(.equipped)[data-rarity='legendary'] .card-rarity,
+.inventory-material-card[data-rarity='legendary'] .card-rarity {
+  background:#000;
+  color:#fff;
+  border-color:#fff;
+}
+
+.shop-item-card[data-rarity='epic'] .card-tags .card-tag,
+.inventory-item-card[data-rarity='epic'] .card-tags .card-tag,
+.inventory-material-card[data-rarity='epic'] .card-tags .card-tag {
+  border-color:#fff;
+  color:#fff;
+  background:transparent;
+}
+
+.shop-item-card[data-rarity='epic'] .card-description,
+.shop-item-card[data-rarity='epic'] .card-cost,
+.shop-item-card[data-rarity='epic'] .card-footer,
+.shop-item-card[data-rarity='epic'] .card-name,
+.shop-item-card[data-rarity='epic'] .card-tags,
+.inventory-item-card[data-rarity='epic'] .card-description,
+.inventory-item-card[data-rarity='epic'] .card-cost,
+.inventory-item-card[data-rarity='epic'] .card-footer,
+.inventory-item-card[data-rarity='epic'] .card-name,
+.inventory-item-card[data-rarity='epic'] .card-tags,
+.inventory-material-card[data-rarity='epic'] .card-description,
+.inventory-material-card[data-rarity='epic'] .card-cost,
+.inventory-material-card[data-rarity='epic'] .card-footer,
+.inventory-material-card[data-rarity='epic'] .card-name,
+.inventory-material-card[data-rarity='epic'] .card-tags {
+  color:#fff;
+}
 
 .inventory-controls {
   border:2px solid #000;


### PR DESCRIPTION
## Summary
- tag shop and inventory item cards with normalized rarity data attributes
- restyle rarity tiers with black-and-white borders and overlays for both shop and inventory views, including equipped items

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d5fbc5bd648320a7e638c940ac2fcf