### PR TITLE
Add monochrome rarity frames to inventory and shop cards

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -206,6 +206,32 @@ function titleCase(value) {
     .trim();
 }
 
+function normalizeRarity(value) {
+  if (!value) return 'common';
+  const normalized = String(value).trim().toLowerCase();
+  switch (normalized) {
+    case 'uncommon':
+    case 'rare':
+    case 'epic':
+    case 'legendary':
+      return normalized;
+    case 'common':
+    default:
+      return 'common';
+  }
+}
+
+function applyCardRarity(card, rarity) {
+  if (!card) return 'common';
+  const normalized = normalizeRarity(rarity);
+  card.dataset.rarity = normalized;
+  card.classList.remove('rarity-uncommon', 'rarity-rare', 'rarity-epic', 'rarity-legendary');
+  if (normalized !== 'common') {
+    card.classList.add(`rarity-${normalized}`);
+  }
+  return normalized;
+}
+
 const SHOP_CATEGORY_DEFINITIONS = [
   { value: 'weapons', label: 'Weapons' },
   { value: 'armor', label: 'Armor' },
@@ -2511,6 +2537,7 @@ function createInventoryItemCard(entry, messageEl) {
   const { item, count } = entry;
   const card = document.createElement('div');
   card.className = 'shop-item-card inventory-item-card';
+  const normalizedRarity = applyCardRarity(card, item.rarity);
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -2520,7 +2547,7 @@ function createInventoryItemCard(entry, messageEl) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
-  rarity.textContent = item.rarity || 'Common';
+  rarity.textContent = titleCase(normalizedRarity);
   header.appendChild(rarity);
   card.appendChild(header);
 
@@ -2611,6 +2638,7 @@ function createInventoryMaterialCard(material, count) {
   if (!material) return null;
   const card = document.createElement('div');
   card.className = 'shop-item-card inventory-material-card';
+  const normalizedRarity = applyCardRarity(card, material.rarity);
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -2620,7 +2648,7 @@ function createInventoryMaterialCard(material, count) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
-  rarity.textContent = material.rarity || 'Common';
+  rarity.textContent = titleCase(normalizedRarity);
   header.appendChild(rarity);
   card.appendChild(header);
 
@@ -4230,6 +4258,7 @@ function createTag(text) {
 function buildShopItemCard(item, messageEl) {
   const card = document.createElement('div');
   card.className = 'shop-item-card';
+  const normalizedRarity = applyCardRarity(card, item.rarity);
 
   const header = document.createElement('div');
   header.className = 'card-header';
@@ -4239,7 +4268,7 @@ function buildShopItemCard(item, messageEl) {
   header.appendChild(name);
   const rarity = document.createElement('div');
   rarity.className = 'card-rarity';
-  rarity.textContent = item.rarity || 'Common';
+  rarity.textContent = titleCase(normalizedRarity);
   header.appendChild(rarity);
   card.appendChild(header);
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -1335,8 +1335,101 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 
 .inventory-item-card,
-.inventory-material-card {
+.inventory-material-card,
+.shop-item-card {
   position:relative;
+}
+
+.shop-item-card > *,
+.inventory-item-card > *,
+.inventory-material-card > * {
+  position:relative;
+  z-index:1;
+}
+
+.shop-item-card::after,
+.inventory-item-card::after,
+.inventory-material-card::after,
+.shop-item-card::before,
+.inventory-item-card::before,
+.inventory-material-card::before {
+  content:'';
+  position:absolute;
+  pointer-events:none;
+  opacity:0;
+  z-index:0;
+  border:2px solid transparent;
+}
+
+.shop-item-card::after,
+.inventory-item-card::after,
+.inventory-material-card::after {
+  inset:6px;
+}
+
+.shop-item-card::before,
+.inventory-item-card::before,
+.inventory-material-card::before {
+  inset:14px;
+}
+
+.shop-item-card.rarity-uncommon,
+.inventory-item-card.rarity-uncommon,
+.inventory-material-card.rarity-uncommon,
+.shop-item-card.rarity-epic,
+.inventory-item-card.rarity-epic,
+.inventory-material-card.rarity-epic {
+  padding:12px;
+}
+
+.shop-item-card.rarity-rare,
+.inventory-item-card.rarity-rare,
+.inventory-material-card.rarity-rare,
+.shop-item-card.rarity-legendary,
+.inventory-item-card.rarity-legendary,
+.inventory-material-card.rarity-legendary {
+  padding:18px;
+}
+
+.shop-item-card.rarity-uncommon::after,
+.inventory-item-card.rarity-uncommon::after,
+.inventory-material-card.rarity-uncommon::after,
+.shop-item-card.rarity-rare::after,
+.inventory-item-card.rarity-rare::after,
+.inventory-material-card.rarity-rare::after,
+.shop-item-card.rarity-epic::after,
+.inventory-item-card.rarity-epic::after,
+.inventory-material-card.rarity-epic::after,
+.shop-item-card.rarity-legendary::after,
+.inventory-item-card.rarity-legendary::after,
+.inventory-material-card.rarity-legendary::after {
+  opacity:1;
+  border-color:currentColor;
+}
+
+.shop-item-card.rarity-epic::after,
+.inventory-item-card.rarity-epic::after,
+.inventory-material-card.rarity-epic::after,
+.shop-item-card.rarity-legendary::after,
+.inventory-item-card.rarity-legendary::after,
+.inventory-material-card.rarity-legendary::after {
+  border-style:dotted;
+}
+
+.shop-item-card.rarity-rare::before,
+.inventory-item-card.rarity-rare::before,
+.inventory-material-card.rarity-rare::before,
+.shop-item-card.rarity-legendary::before,
+.inventory-item-card.rarity-legendary::before,
+.inventory-material-card.rarity-legendary::before {
+  opacity:1;
+  border-color:currentColor;
+}
+
+.shop-item-card.rarity-legendary::before,
+.inventory-item-card.rarity-legendary::before,
+.inventory-material-card.rarity-legendary::before {
+  border-style:dotted;
 }
 
 .inventory-card-meta {


### PR DESCRIPTION
## Summary
- add helper utilities to normalize rarities and tag item cards with rarity-specific classes
- draw monochrome inner borders and padding adjustments to distinguish rarity tiers on shop and inventory cards

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d617fd60888320ab7a7aa63e53d116