### PR TITLE
Refine world rendering and support configurable tile sprites

### DIFF
--- a/data/worlds.json
+++ b/data/worlds.json
@@ -4,9 +4,14 @@
     "name": "Verdant Glen",
     "tileSize": 32,
     "palette": {
-      "0": "#2f4858",
-      "1": "#8bd674",
-      "2": "#4c9c59"
+      "0": "#000000",
+      "1": "#ffffff",
+      "2": "#ffffff"
+    },
+    "tileConfig": {
+      "0": { "sprite": "/assets/world/stone.png", "fill": "#000000" },
+      "1": { "sprite": "/assets/world/path.png", "fill": "#ffffff" },
+      "2": { "sprite": "/assets/world/bush.png", "fill": "#ffffff" }
     },
     "tiles": [
       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -60,6 +60,37 @@ function normalizePalette(raw) {
   return palette;
 }
 
+function normalizeTileConfig(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+  const tileConfig = {};
+  Object.entries(raw).forEach(([key, value]) => {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    const sprite = typeof value.sprite === 'string' && value.sprite.trim() ? value.sprite.trim() : null;
+    let fill = null;
+    if (typeof value.fill === 'string') {
+      const rawFill = value.fill.trim().toLowerCase();
+      if (/^#(?:0{3}|f{3}|0{6}|f{6})$/.test(rawFill)) {
+        fill = rawFill.length === 4 ? (rawFill === '#000' ? '#000000' : '#ffffff') : rawFill;
+      }
+    }
+    if (!sprite && !fill) {
+      return;
+    }
+    tileConfig[String(key)] = {};
+    if (sprite) {
+      tileConfig[String(key)].sprite = sprite;
+    }
+    if (fill) {
+      tileConfig[String(key)].fill = fill;
+    }
+  });
+  return tileConfig;
+}
+
 function normalizeTemplates(rawTemplates) {
   if (!Array.isArray(rawTemplates) || !rawTemplates.length) {
     return [];
@@ -127,6 +158,7 @@ function normalizeWorld(entry) {
     width,
     height,
     palette: normalizePalette(entry.palette),
+    tileConfig: normalizeTileConfig(entry.tileConfig),
     spawn,
     moveCooldownMs: Number.isFinite(entry.moveCooldownMs) ? Math.max(60, Math.round(entry.moveCooldownMs)) : 180,
     encounters: normalizeEncounter(entry.encounters),
@@ -173,6 +205,7 @@ function sanitizeWorld(world) {
     tileSize: world.tileSize,
     tiles: world.tiles,
     palette: world.palette,
+    tileConfig: world.tileConfig,
     moveCooldownMs: world.moveCooldownMs,
   };
 }


### PR DESCRIPTION
## Summary
- restyle the world canvas to a monochrome presentation while drawing player markers and labels in black and white
- add tileConfig normalization and sprite loading so tiles can reference PNG assets from the world configuration
- update the default world definition with monochrome defaults and sample sprite mappings

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dec963cb948320b596ed283bcb90a8