### PR TITLE
Serve assets directory statically

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ const connectDB = require("./db");
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, "ui")));
+app.use("/assets", express.static(path.join(__dirname, "assets")));
 
 // Render provides the port as process.env.PORT
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- expose the assets directory under /assets so sprite files can be served

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded23e18ec83209404b4ea60e6f488