### PR TITLE
Restyle world mode with monochrome theme

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -2920,12 +2920,14 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-weight: 600;
-  color: #f5f5f5;
-  background: linear-gradient(135deg, #1f3b4d, #2c5364);
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #000;
+  background: #fff;
+  border: 2px solid #000;
+  box-shadow: 6px 6px 0 #000;
   padding: 8px 12px;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
 }
 
 #world-title {
@@ -2939,26 +2941,32 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 #world-canvas {
   width: 100%;
   max-width: 640px;
-  background: #12202b;
-  border-radius: 8px;
-  border: 2px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  background: #fff;
+  border: 2px solid #000;
+  box-shadow: 6px 6px 0 #000;
 }
 
 .world-message {
   min-height: 1.5em;
+  border: 2px solid #000;
+  background: #fff;
+  color: #000;
+  padding: 6px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 .world-sidebar {
   width: 240px;
-  background: rgba(12, 24, 32, 0.85);
-  color: #e0f1ff;
-  border-radius: 10px;
+  background: #fff;
+  color: #000;
+  border: 2px solid #000;
+  box-shadow: 6px 6px 0 #000;
   padding: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   display: flex;
   flex-direction: column;
   gap: 16px;
+  text-transform: uppercase;
 }
 
 .world-sidebar h3 {
@@ -2976,31 +2984,33 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 
 .world-player-list li {
-  background: rgba(17, 34, 46, 0.9);
-  border-radius: 6px;
+  background: #fff;
+  border: 2px solid #000;
   padding: 6px 8px;
   font-size: 0.95rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: #d6f4ff;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 .world-player-list li.you {
-  background: rgba(46, 151, 255, 0.35);
+  background: #000;
   color: #fff;
-  font-weight: 600;
 }
 
 .world-player-list .player-coords {
   font-size: 0.8rem;
-  opacity: 0.85;
+  font-weight: bold;
 }
 
 .world-controls p {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- update the world tab layout to use the site's monochrome retro palette
- adjust world sidebar, header, canvas, and messaging elements to reuse high-contrast borders and shadows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded760c268832095d46d165df47815