### PR TITLE
Implement world matchmaking and cooperative encounter flow

### DIFF
--- a/systems/combatEngine.js
+++ b/systems/combatEngine.js
@@ -879,6 +879,8 @@ async function runDungeonCombat(
     options = onUpdateOrOptions;
   }
 
+  const mode = typeof options.mode === 'string' && options.mode ? options.mode : 'dungeon';
+
   const party = Array.isArray(partyChars)
     ? partyChars.map(character => createCombatant(character, equipmentMap))
     : [];
@@ -946,7 +948,7 @@ async function runDungeonCombat(
   if (onUpdate) {
     onUpdate({
       type: 'start',
-      mode: 'dungeon',
+      mode,
       party: party.map(state),
       boss: state(boss),
       log: [],
@@ -1081,7 +1083,7 @@ async function runDungeonCombat(
     if (onUpdate) {
       onUpdate({
         type: 'update',
-        mode: 'dungeon',
+        mode,
         party: party.map(state),
         boss: state(boss),
         log: newLogs,

--- a/systems/worldMatchmakingService.js
+++ b/systems/worldMatchmakingService.js
@@ -1,0 +1,344 @@
+const CharacterModel = require('../models/Character');
+const { serializeCharacter } = require('../models/utils');
+const { processJobForCharacter, ensureJobIdleForDoc } = require('./jobService');
+const { ensureBattlefieldIdle } = require('./battlefieldService');
+const { ensureAdventureIdle } = require('./adventureService');
+const { listWorlds, createWorldInstance } = require('./worldService');
+
+function uuid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+const worldQueueCache = new Map();
+const waitingEntries = new Map();
+const activeMatches = new Map();
+const participantMatches = new Map();
+const worldInfoCache = new Map();
+
+function getQueuesForWorld(worldId) {
+  if (!worldQueueCache.has(worldId)) {
+    worldQueueCache.set(worldId, {
+      1: [],
+      2: [],
+      3: [],
+      4: [],
+      5: [],
+    });
+  }
+  return worldQueueCache.get(worldId);
+}
+
+function sendSafe(entry, payload) {
+  if (!entry || typeof entry.send !== 'function') return;
+  try {
+    entry.send(payload);
+  } catch (err) {
+    /* ignore send failures */
+  }
+}
+
+function removeFromQueue(entry) {
+  if (!entry) return;
+  const queues = getQueuesForWorld(entry.worldId);
+  const queue = queues[entry.size];
+  if (!queue) return;
+  const idx = queue.indexOf(entry);
+  if (idx !== -1) {
+    queue.splice(idx, 1);
+  }
+}
+
+function finalizeEntry(entry) {
+  if (!entry || entry.completed) return;
+  entry.completed = true;
+  waitingEntries.delete(entry.character.id);
+  participantMatches.delete(entry.character.id);
+}
+
+function cancelEntry(entry, reason = 'World queue cancelled.') {
+  if (!entry || entry.completed) return;
+  if (entry.status === 'queued') {
+    removeFromQueue(entry);
+    sendSafe(entry, { type: 'cancelled', message: reason });
+    finalizeEntry(entry);
+    return;
+  }
+  if (entry.status === 'matched') {
+    const match = participantMatches.get(entry.character.id);
+    if (match) {
+      cancelMatch(match, reason);
+    } else {
+      sendSafe(entry, { type: 'cancelled', message: reason });
+      finalizeEntry(entry);
+    }
+  }
+}
+
+function buildPartyPreview(entries) {
+  return entries
+    .map(item => {
+      if (!item || !item.character) return null;
+      return {
+        id: item.character.id,
+        name: item.character.name,
+        level: item.character.level,
+        basicType: item.character.basicType,
+      };
+    })
+    .filter(Boolean);
+}
+
+function readySnapshot(match) {
+  return Array.from(match.ready.values()).sort((a, b) => a - b);
+}
+
+function sendMatchState(match) {
+  if (!match) return;
+  const party = buildPartyPreview(match.entries);
+  const readyIds = readySnapshot(match);
+  const payload = {
+    type: 'matched',
+    matchId: match.id,
+    worldId: match.worldId,
+    worldName: match.worldName || null,
+    size: match.entries.length,
+    party,
+    ready: match.ready.size,
+    readyIds,
+    phase: match.started ? 'starting' : 'ready',
+  };
+  match.entries.forEach(entry => sendSafe(entry, payload));
+}
+
+function sendReadyUpdate(match) {
+  if (!match) return;
+  const readyIds = readySnapshot(match);
+  const payload = {
+    type: 'ready',
+    matchId: match.id,
+    ready: match.ready.size,
+    total: match.entries.length,
+    readyIds,
+  };
+  match.entries.forEach(entry => sendSafe(entry, payload));
+}
+
+function cancelMatch(match, reason = 'World queue cancelled.') {
+  if (!match || match.cancelled) return;
+  match.cancelled = true;
+  match.entries.forEach(entry => {
+    if (!entry || entry.completed) return;
+    sendSafe(entry, { type: 'cancelled', message: reason });
+    finalizeEntry(entry);
+  });
+  activeMatches.delete(match.id);
+}
+
+async function loadCharacter(characterId) {
+  const doc = await CharacterModel.findOne({ characterId });
+  if (!doc) {
+    throw new Error('character not found');
+  }
+  const { changed } = await processJobForCharacter(doc);
+  if (changed) {
+    await doc.save();
+  }
+  ensureJobIdleForDoc(doc);
+  if (!Array.isArray(doc.rotation) || doc.rotation.length < 3) {
+    throw new Error('character rotation invalid');
+  }
+  return serializeCharacter(doc);
+}
+
+async function resolveWorldInfo(worldId) {
+  if (worldInfoCache.has(worldId)) {
+    return worldInfoCache.get(worldId);
+  }
+  const worlds = await listWorlds();
+  const info = worlds.find(item => item && item.id === worldId);
+  if (!info) {
+    throw new Error('world not found');
+  }
+  worldInfoCache.set(worldId, info);
+  return info;
+}
+
+function takeNextQueuedEntry(queue) {
+  while (queue.length) {
+    const entry = queue.shift();
+    if (!entry || entry.completed) {
+      continue;
+    }
+    if (entry.status === 'queued') {
+      return entry;
+    }
+  }
+  return null;
+}
+
+async function startWorldForMatch(match) {
+  if (!match || match.started || match.cancelled) return;
+  match.started = true;
+  let instanceInfo = null;
+  try {
+    const participantIds = match.entries.map(entry => entry.character.id);
+    instanceInfo = await createWorldInstance(match.worldId, participantIds);
+    match.instanceId = instanceInfo.instanceId;
+  } catch (err) {
+    console.error('world instance creation failed', err);
+    cancelMatch(match, err.message || 'Failed to create world instance.');
+    return;
+  }
+  const startPayload = {
+    type: 'start',
+    matchId: match.id,
+    worldId: match.worldId,
+    worldName: match.worldName || null,
+    instanceId: instanceInfo.instanceId,
+    world: instanceInfo.world || null,
+    party: buildPartyPreview(match.entries),
+  };
+  match.entries.forEach(entry => {
+    sendSafe(entry, startPayload);
+    finalizeEntry(entry);
+  });
+  activeMatches.delete(match.id);
+}
+
+function tryStartMatch(worldId, size) {
+  const queues = getQueuesForWorld(worldId);
+  const queue = queues[size];
+  if (!Array.isArray(queue) || queue.length < size) {
+    return;
+  }
+  while (true) {
+    const group = [];
+    while (group.length < size) {
+      const next = takeNextQueuedEntry(queue);
+      if (!next) {
+        group.length = 0;
+        return;
+      }
+      group.push(next);
+    }
+    const matchId = uuid();
+    const match = {
+      id: matchId,
+      worldId,
+      worldName: group[0] && group[0].worldName ? group[0].worldName : null,
+      entries: group,
+      ready: new Set(),
+      started: false,
+    };
+    group.forEach(entry => {
+      entry.status = 'matched';
+      entry.matchId = matchId;
+      participantMatches.set(entry.character.id, match);
+    });
+    activeMatches.set(matchId, match);
+    sendMatchState(match);
+    sendReadyUpdate(match);
+    if (queue.length < size) {
+      return;
+    }
+  }
+}
+
+async function queueForWorld(worldId, size, characterId, send) {
+  const normalizedSize = Number.isFinite(size) ? Math.max(1, Math.min(5, Math.round(size))) : 1;
+  await ensureBattlefieldIdle(characterId);
+  await ensureAdventureIdle(characterId);
+  const character = await loadCharacter(characterId);
+  if (waitingEntries.has(character.id)) {
+    throw new Error('character already queued');
+  }
+  const info = await resolveWorldInfo(worldId);
+  const entry = {
+    id: uuid(),
+    worldId,
+    worldName: info.name,
+    size: normalizedSize,
+    character,
+    status: 'queued',
+    send,
+    completed: false,
+  };
+  waitingEntries.set(character.id, entry);
+  const queues = getQueuesForWorld(worldId);
+  queues[normalizedSize].push(entry);
+  sendSafe(entry, {
+    type: 'queued',
+    worldId,
+    worldName: info.name,
+    size: normalizedSize,
+  });
+  tryStartMatch(worldId, normalizedSize);
+  return entry;
+}
+
+async function readyWorldMatch(matchId, characterId) {
+  const match = activeMatches.get(matchId);
+  if (!match || match.cancelled) {
+    throw new Error('match not found');
+  }
+  const entry = match.entries.find(item => item.character.id === characterId);
+  if (!entry) {
+    throw new Error('participant not found');
+  }
+  if (entry.ready) {
+    return { ready: match.ready.size, total: match.entries.length, readyIds: readySnapshot(match) };
+  }
+  entry.ready = true;
+  match.ready.add(characterId);
+  sendReadyUpdate(match);
+  if (match.ready.size >= match.entries.length) {
+    await startWorldForMatch(match);
+  }
+  return { ready: match.ready.size, total: match.entries.length, readyIds: readySnapshot(match) };
+}
+
+function cancelWorldQueue(characterId) {
+  const entry = waitingEntries.get(characterId);
+  if (!entry) {
+    return false;
+  }
+  cancelEntry(entry, 'World queue left.');
+  return true;
+}
+
+function getWorldQueueStatus(characterId) {
+  const entry = waitingEntries.get(characterId);
+  if (!entry || entry.completed) {
+    return null;
+  }
+  if (entry.status === 'queued') {
+    return {
+      status: 'queued',
+      worldId: entry.worldId,
+      worldName: entry.worldName || null,
+      size: entry.size,
+    };
+  }
+  const match = participantMatches.get(characterId);
+  if (!match) {
+    return null;
+  }
+  return {
+    status: match.started ? 'starting' : 'matched',
+    matchId: match.id,
+    worldId: match.worldId,
+    worldName: match.worldName || null,
+    size: match.entries.length,
+    ready: match.ready.size,
+    readyIds: readySnapshot(match),
+    party: buildPartyPreview(match.entries),
+    instanceId: match.instanceId || null,
+  };
+}
+
+module.exports = {
+  queueForWorld,
+  cancelWorldQueue,
+  readyWorldMatch,
+  getWorldQueueStatus,
+};

--- a/ui/index.html
+++ b/ui/index.html
@@ -53,6 +53,30 @@
             <div id="world-message" class="world-message message hidden"></div>
           </div>
           <aside class="world-sidebar">
+            <div class="world-sidebar-section world-lobby">
+              <h3>World Party</h3>
+              <label for="world-select" class="input-label">World</label>
+              <select id="world-select" class="world-select" aria-label="Select world"></select>
+              <label for="world-party-size" class="input-label">Party Size</label>
+              <select id="world-party-size" class="world-select" aria-label="Select party size">
+                <option value="1">Solo (1)</option>
+                <option value="2">Duo (2)</option>
+                <option value="3">Trio (3)</option>
+                <option value="4">Squad (4)</option>
+                <option value="5">Full party (5)</option>
+              </select>
+              <div class="world-lobby-buttons">
+                <button id="world-queue-btn" type="button">Find Party</button>
+                <button id="world-leave-btn" type="button" class="hidden">Leave Queue</button>
+                <button id="world-ready-btn" type="button" class="hidden">Ready Up</button>
+              </div>
+              <div id="world-lobby-status" class="message hidden"></div>
+              <div id="world-ready-panel" class="world-ready-panel hidden">
+                <h4>Party Members</h4>
+                <ul id="world-ready-party"></ul>
+                <div id="world-ready-status" class="world-ready-status"></div>
+              </div>
+            </div>
             <div class="world-sidebar-section">
               <h3>Adventurers Nearby</h3>
               <ul id="world-player-list" class="world-player-list"></ul>

--- a/ui/style.css
+++ b/ui/style.css
@@ -2969,6 +2969,104 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   text-transform: uppercase;
 }
 
+.world-lobby label.input-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  margin-top: 6px;
+  margin-bottom: 4px;
+}
+
+.world-lobby .world-select {
+  width: 100%;
+  padding: 6px 8px;
+  border: 2px solid #000;
+  border-radius: 0;
+  background: #fff;
+  font-size: 0.85rem;
+  text-transform: none;
+}
+
+.world-lobby-buttons {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.world-lobby-buttons button {
+  flex: 1;
+  padding: 6px 8px;
+  border: 2px solid #000;
+  background: #000;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 1px;
+  cursor: pointer;
+}
+
+.world-lobby-buttons button.hidden {
+  display: none;
+}
+
+.world-lobby-buttons button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.world-ready-panel {
+  margin-top: 10px;
+  border: 2px solid #000;
+  padding: 8px;
+  background: #fff;
+  text-transform: none;
+}
+
+.world-ready-panel.hidden {
+  display: none;
+}
+
+.world-ready-panel h4 {
+  margin: 0 0 6px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.world-ready-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.world-ready-panel li {
+  border: 2px solid #000;
+  padding: 4px 6px;
+  background: #f5f5f5;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.world-ready-panel li.ready {
+  background: #d7f5de;
+}
+
+.world-ready-panel li.you {
+  background: #000;
+  color: #fff;
+}
+
+.world-ready-status {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
 .world-sidebar h3 {
   margin: 0 0 6px;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add a world matchmaking service that forms 1-5 player parties, manages ready-up flow, and provisions world instances
- update world endpoints and services to run per-instance state, broadcast shared encounters, and stream cooperative combat results
- enhance the world tab UI with queue controls, party status messaging, and dungeon-style battle dialog plus matching styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dedcd2b0c88320ae4c799c45ff8a24