### PR TITLE
Improve world tab mobile layout

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -2980,10 +2980,10 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 }
 
 #world-canvas {
-  width: 100%;
-  max-width: 960px;
+  width: min(100%, 960px);
+  max-width: 100%;
   height: auto;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 1 / 1;
   background: #fff;
   border: 2px solid #000;
   box-shadow: 6px 6px 0 #000;
@@ -3299,6 +3299,75 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   }
 
   .world-dpad {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  body.world-tab-active {
+    background: #fff;
+  }
+
+  body.world-tab-active #game {
+    max-width: none;
+    margin: 0;
+    width: 100%;
+  }
+
+  body.world-tab-active #tabs {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: #fff;
+  }
+
+  body.world-tab-active #content {
+    border: none;
+    padding: 0;
+  }
+
+  body.world-tab-active #world {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  body.world-tab-active .world-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 12px;
+  }
+
+  body.world-tab-active .world-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  body.world-tab-active .world-screen {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  body.world-tab-active #world-canvas {
+    width: 100%;
+    max-width: none;
+  }
+
+  body.world-tab-active .world-dpad-wrapper {
+    margin-top: auto;
+  }
+
+  body.world-tab-active .world-dpad {
+    max-width: 360px;
+  }
+
+  body.world-tab-active .world-sidebar {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- ensure the World tab applies a mobile-focused layout when active, expanding the canvas and repositioning controls
- adjust world rendering to keep a centered 16x16 tile view that follows the player regardless of map size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68def855094c8320be1f4ef7e956b296