### PR TITLE
Add developer world builder utility page

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,10 @@ app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "ui", "index.html"));
 });
 
+app.get("/dev/world-builder", (req, res) => {
+  res.sendFile(path.join(__dirname, "ui", "world-builder.html"));
+});
+
 app.post("/register", async (req, res) => {
   const name = req.body.name && req.body.name.trim();
   if (!name) {

--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -1,0 +1,451 @@
+body.world-builder {
+  background:#fdfdfd;
+  color:#000;
+  font-family:'Courier New', monospace;
+  padding:24px;
+}
+
+.builder-header {
+  max-width:1100px;
+  margin:0 auto 24px auto;
+  border:2px solid #000;
+  padding:16px;
+  background:#fff;
+  box-shadow:6px 6px 0 #000;
+  text-transform:uppercase;
+}
+
+.builder-header h1 {
+  margin:0 0 8px 0;
+  font-size:28px;
+  letter-spacing:2px;
+}
+
+.builder-header p {
+  margin:0 0 12px 0;
+  letter-spacing:1px;
+}
+
+.builder-link {
+  color:#000;
+  text-decoration:none;
+  border-bottom:1px solid #000;
+}
+
+.builder-layout {
+  max-width:1100px;
+  margin:0 auto;
+  display:grid;
+  grid-template-columns:340px 1fr;
+  gap:16px;
+}
+
+.builder-column {
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.panel {
+  border:2px solid #000;
+  background:#fff;
+  padding:16px;
+  box-shadow:6px 6px 0 #000;
+}
+
+.panel h2 {
+  margin-top:0;
+  text-transform:uppercase;
+  letter-spacing:2px;
+  font-size:18px;
+}
+
+.field-label {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  margin-bottom:12px;
+  text-transform:uppercase;
+}
+
+.field-inline {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:8px;
+  margin-bottom:12px;
+  text-transform:uppercase;
+}
+
+.field-label input,
+.field-inline input,
+.field-label select {
+  border:1px solid #000;
+  padding:4px;
+  font-family:'Courier New', monospace;
+  background:#fdfdfd;
+  color:#000;
+}
+
+.tile-palette {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-bottom:12px;
+}
+
+.tile-token {
+  width:60px;
+  height:60px;
+  border:2px solid #000;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  flex-direction:column;
+  cursor:pointer;
+  text-transform:uppercase;
+  position:relative;
+}
+
+.tile-token.active {
+  outline:2px dashed #000;
+  outline-offset:3px;
+}
+
+.tile-token span {
+  font-size:12px;
+  letter-spacing:1px;
+}
+
+.tile-form button,
+.enemy-actions button,
+.mode-button,
+#add-zone,
+#generate-world,
+#enemy-add-ability,
+#transport-clear,
+.enemy-template button {
+  border:1px solid #000;
+  background:#fff;
+  padding:6px 10px;
+  font-family:'Courier New', monospace;
+  text-transform:uppercase;
+  cursor:pointer;
+  box-shadow:2px 2px 0 #000;
+}
+
+.mode-button.active {
+  background:#000;
+  color:#fff;
+}
+
+.enemy-form {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.enemy-grid {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.enemy-attributes,
+.enemy-economy,
+.enemy-rotation,
+.enemy-equipment {
+  border:1px solid #000;
+  padding:8px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  text-transform:uppercase;
+}
+
+.enemy-attributes label,
+.enemy-economy label {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:12px;
+}
+
+.rotation-picker {
+  display:flex;
+  gap:8px;
+}
+
+.rotation-list {
+  margin:0;
+  padding-left:18px;
+  font-size:13px;
+}
+
+.rotation-list li {
+  display:flex;
+  justify-content:space-between;
+  gap:8px;
+  margin-bottom:4px;
+}
+
+.rotation-list button {
+  border:1px solid #000;
+  background:#fff;
+  padding:0 6px;
+  font-family:'Courier New', monospace;
+  cursor:pointer;
+}
+
+.equipment-slots {
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:8px;
+  width:100%;
+}
+
+.equipment-slot {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:12px;
+}
+
+.enemy-actions {
+  display:flex;
+  gap:8px;
+}
+
+.enemy-template-list {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  margin-top:12px;
+}
+
+.enemy-template {
+  border:1px solid #000;
+  padding:8px;
+  background:#fdfdfd;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:12px;
+}
+
+.enemy-template.active {
+  background:#000;
+  color:#fff;
+}
+
+.enemy-template .actions {
+  display:flex;
+  gap:6px;
+}
+
+.zone-panel-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  margin-bottom:12px;
+}
+
+.zone-list {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.zone-item {
+  border:1px solid #000;
+  background:#fdfdfd;
+  padding:8px;
+  cursor:pointer;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+}
+
+.zone-item.active {
+  background:#000;
+  color:#fff;
+}
+
+.zone-editor {
+  min-height:480px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.zone-toolbar {
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  justify-content:space-between;
+  align-items:center;
+}
+
+.transport-controls label {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:12px;
+  text-transform:uppercase;
+}
+
+.enemy-mode-info {
+  text-transform:uppercase;
+  letter-spacing:1px;
+}
+
+.zone-details {
+  border:1px solid #000;
+  padding:8px;
+  min-height:72px;
+  background:#fdfdfd;
+  font-size:13px;
+  text-transform:uppercase;
+}
+
+.zone-details input {
+  border:1px solid #000;
+  padding:4px;
+  font-family:'Courier New', monospace;
+  background:#fff;
+  color:#000;
+}
+
+.zone-details h3 {
+  margin:8px 0 4px 0;
+  font-size:14px;
+  letter-spacing:1px;
+}
+
+.zone-subsection {
+  border-top:1px solid #000;
+  padding-top:8px;
+  margin-top:8px;
+}
+
+.zone-subsection ul {
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.zone-subsection li {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:8px;
+}
+
+.zone-subsection button {
+  border:1px solid #000;
+  background:#fff;
+  padding:2px 6px;
+  font-family:'Courier New', monospace;
+  cursor:pointer;
+  text-transform:uppercase;
+}
+
+.zone-grid-container {
+  border:1px solid #000;
+  background:#fdfdfd;
+  padding:12px;
+  overflow:auto;
+}
+
+.zone-grid {
+  display:grid;
+  gap:2px;
+}
+
+.zone-cell {
+  width:32px;
+  height:32px;
+  border:1px solid #000;
+  background:#fff;
+  font-size:10px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:relative;
+  cursor:pointer;
+}
+
+.zone-cell.has-enemy::after {
+  content:"E";
+  position:absolute;
+  bottom:2px;
+  right:2px;
+  font-weight:bold;
+  font-size:11px;
+}
+
+.zone-cell.has-transport::after {
+  content:"⇄";
+  position:absolute;
+  top:2px;
+  right:2px;
+  font-weight:bold;
+  font-size:11px;
+}
+
+.zone-cell.is-spawn::after {
+  content:"S";
+  position:absolute;
+  top:2px;
+  left:2px;
+  font-weight:bold;
+  font-size:11px;
+}
+
+.output-panel textarea {
+  width:100%;
+  min-height:200px;
+  border:1px solid #000;
+  padding:8px;
+  font-family:'Courier New', monospace;
+  background:#fdfdfd;
+  color:#000;
+}
+
+.builder-loading {
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:rgba(255,255,255,0.95);
+  color:#000;
+  font-family:'Courier New', monospace;
+}
+
+.loading-panel {
+  border:2px solid #000;
+  padding:16px 24px;
+  background:#fff;
+  box-shadow:6px 6px 0 #000;
+  text-transform:uppercase;
+}
+
+.hidden {
+  display:none !important;
+}
+
+@media (max-width: 1024px) {
+  .builder-layout {
+    grid-template-columns:1fr;
+  }
+  .builder-column-settings {
+    order:2;
+  }
+  .builder-column-main {
+    order:1;
+  }
+}

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>World Builder Utility</title>
+    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="/world-builder.css" />
+  </head>
+  <body class="world-builder">
+    <header class="builder-header">
+      <h1>World Mode Builder</h1>
+      <p>Create and export world configuration files for developers.</p>
+      <a class="builder-link" href="/">← Back to Game</a>
+    </header>
+    <main id="builder" class="builder-layout hidden">
+      <div class="builder-column builder-column-settings">
+        <section class="panel">
+          <h2>World Settings</h2>
+          <label class="field-label">
+            World ID
+            <input id="world-id" type="text" placeholder="unique_world_id" />
+          </label>
+          <label class="field-label">
+            World Name
+            <input id="world-name" type="text" placeholder="World Name" />
+          </label>
+          <label class="field-inline">
+            <span>Tile Size</span>
+            <input id="world-tile-size" type="number" min="8" value="32" />
+          </label>
+          <label class="field-inline">
+            <span>Move Cooldown (ms)</span>
+            <input id="world-move-cooldown" type="number" min="0" value="180" />
+          </label>
+          <label class="field-inline">
+            <span>Encounter Enemy Count</span>
+            <input id="world-enemy-count" type="number" min="1" value="6" />
+          </label>
+        </section>
+        <section class="panel palette-panel">
+          <h2>Tile Palette</h2>
+          <div id="tile-palette" class="tile-palette"></div>
+          <form id="tile-form" class="tile-form">
+            <div class="field-inline">
+              <span>ID</span>
+              <input id="tile-id" type="text" placeholder="e.g. 0" />
+            </div>
+            <div class="field-inline">
+              <span>Fill</span>
+              <input id="tile-fill" type="text" placeholder="#000000" />
+            </div>
+            <div class="field-inline">
+              <span>Sprite</span>
+              <input id="tile-sprite" type="text" placeholder="/assets/Sprite.png" />
+            </div>
+            <button type="submit">Add / Update Tile</button>
+          </form>
+        </section>
+        <section class="panel enemy-panel">
+          <h2>Enemy Templates</h2>
+          <form id="enemy-form" class="enemy-form">
+            <div class="enemy-grid">
+              <label class="field-label">
+                Template ID
+                <input id="enemy-id" type="text" placeholder="wild_sprig" required />
+              </label>
+              <label class="field-label">
+                Name
+                <input id="enemy-name" type="text" placeholder="Wild Sprig" required />
+              </label>
+              <label class="field-label">
+                Basic Type
+                <select id="enemy-basic-type">
+                  <option value="melee">Melee</option>
+                  <option value="magic">Magic</option>
+                </select>
+              </label>
+              <label class="field-label">
+                Level
+                <input id="enemy-level" type="number" min="1" value="1" required />
+              </label>
+              <fieldset class="enemy-attributes">
+                <legend>Attributes</legend>
+                <label>STR <input id="enemy-str" type="number" min="0" value="5" /></label>
+                <label>STA <input id="enemy-sta" type="number" min="0" value="5" /></label>
+                <label>AGI <input id="enemy-agi" type="number" min="0" value="5" /></label>
+                <label>INT <input id="enemy-int" type="number" min="0" value="2" /></label>
+                <label>WIS <input id="enemy-wis" type="number" min="0" value="2" /></label>
+              </fieldset>
+              <fieldset class="enemy-economy">
+                <legend>Rewards</legend>
+                <label>XP % <input id="enemy-xp" type="number" min="0" max="1" step="0.01" value="0.05" /></label>
+                <label>Gold <input id="enemy-gold" type="number" min="0" value="5" /></label>
+                <label>Spawn Chance <input id="enemy-spawn-chance" type="number" min="0" max="1" step="0.01" value="0.5" /></label>
+              </fieldset>
+              <fieldset class="enemy-rotation">
+                <legend>Rotation</legend>
+                <div class="rotation-picker">
+                  <select id="enemy-ability-select"></select>
+                  <button type="button" id="enemy-add-ability">Add Ability</button>
+                </div>
+                <ol id="enemy-rotation-list" class="rotation-list"></ol>
+              </fieldset>
+              <fieldset class="enemy-equipment">
+                <legend>Equipment</legend>
+                <div id="enemy-equipment-slots" class="equipment-slots"></div>
+              </fieldset>
+            </div>
+            <div class="enemy-actions">
+              <button type="submit" id="enemy-save">Save Template</button>
+              <button type="button" id="enemy-reset">Clear</button>
+            </div>
+          </form>
+          <div id="enemy-template-list" class="enemy-template-list"></div>
+        </section>
+      </div>
+      <div class="builder-column builder-column-main">
+        <section class="panel zone-panel">
+          <div class="zone-panel-header">
+            <h2>Zones</h2>
+            <button id="add-zone">Add Zone</button>
+          </div>
+          <div id="zone-list" class="zone-list"></div>
+        </section>
+        <section class="panel zone-editor">
+          <div class="zone-toolbar">
+            <div class="mode-switcher">
+              <span class="mode-label">Edit Mode:</span>
+              <button data-mode="tile" class="mode-button active">Tiles</button>
+              <button data-mode="enemy" class="mode-button">Enemies</button>
+              <button data-mode="transport" class="mode-button">Transports</button>
+              <button data-mode="spawn" class="mode-button">Spawn</button>
+            </div>
+            <div class="transport-controls hidden" id="transport-controls">
+              <label>
+                Target Zone
+                <select id="transport-zone-select"></select>
+              </label>
+              <label>
+                Target X
+                <input id="transport-target-x" type="number" min="0" />
+              </label>
+              <label>
+                Target Y
+                <input id="transport-target-y" type="number" min="0" />
+              </label>
+              <button type="button" id="transport-clear">Clear Target</button>
+            </div>
+            <div class="enemy-mode-info hidden" id="enemy-mode-info">
+              <span>Placement Target:</span>
+              <span id="enemy-placement-target">None Selected</span>
+            </div>
+          </div>
+          <div id="zone-details" class="zone-details"></div>
+          <div id="zone-grid" class="zone-grid-container"></div>
+        </section>
+        <section class="panel output-panel">
+          <h2>Generated world.json</h2>
+          <button id="generate-world">Generate</button>
+          <textarea id="world-output" readonly placeholder="Generated JSON will appear here..."></textarea>
+        </section>
+      </div>
+    </main>
+    <div id="builder-loading" class="builder-loading">
+      <div class="loading-panel">
+        <p>Loading catalogs...</p>
+      </div>
+    </div>
+    <script src="/world-builder.js" type="module"></script>
+  </body>
+</html>

--- a/ui/world-builder.js
+++ b/ui/world-builder.js
@@ -1,0 +1,955 @@
+const builderEl = document.getElementById('builder');
+const loadingEl = document.getElementById('builder-loading');
+
+const worldIdInput = document.getElementById('world-id');
+const worldNameInput = document.getElementById('world-name');
+const worldTileSizeInput = document.getElementById('world-tile-size');
+const worldMoveCooldownInput = document.getElementById('world-move-cooldown');
+const worldEnemyCountInput = document.getElementById('world-enemy-count');
+
+const tilePaletteEl = document.getElementById('tile-palette');
+const tileForm = document.getElementById('tile-form');
+const tileIdInput = document.getElementById('tile-id');
+const tileFillInput = document.getElementById('tile-fill');
+const tileSpriteInput = document.getElementById('tile-sprite');
+
+const addZoneButton = document.getElementById('add-zone');
+const zoneListEl = document.getElementById('zone-list');
+const zoneGridContainer = document.getElementById('zone-grid');
+const zoneDetailsEl = document.getElementById('zone-details');
+
+const modeButtons = Array.from(document.querySelectorAll('.mode-button'));
+const transportControls = document.getElementById('transport-controls');
+const transportZoneSelect = document.getElementById('transport-zone-select');
+const transportTargetXInput = document.getElementById('transport-target-x');
+const transportTargetYInput = document.getElementById('transport-target-y');
+const transportClearButton = document.getElementById('transport-clear');
+const enemyModeInfo = document.getElementById('enemy-mode-info');
+const enemyPlacementTargetEl = document.getElementById('enemy-placement-target');
+
+const enemyForm = document.getElementById('enemy-form');
+const enemyIdInput = document.getElementById('enemy-id');
+const enemyNameInput = document.getElementById('enemy-name');
+const enemyBasicTypeInput = document.getElementById('enemy-basic-type');
+const enemyLevelInput = document.getElementById('enemy-level');
+const enemyStrInput = document.getElementById('enemy-str');
+const enemyStaInput = document.getElementById('enemy-sta');
+const enemyAgiInput = document.getElementById('enemy-agi');
+const enemyIntInput = document.getElementById('enemy-int');
+const enemyWisInput = document.getElementById('enemy-wis');
+const enemyXpInput = document.getElementById('enemy-xp');
+const enemyGoldInput = document.getElementById('enemy-gold');
+const enemySpawnChanceInput = document.getElementById('enemy-spawn-chance');
+const enemyAbilitySelect = document.getElementById('enemy-ability-select');
+const enemyAddAbilityButton = document.getElementById('enemy-add-ability');
+const enemyRotationList = document.getElementById('enemy-rotation-list');
+const enemyEquipmentSlotsContainer = document.getElementById('enemy-equipment-slots');
+const enemyTemplateListEl = document.getElementById('enemy-template-list');
+const enemyResetButton = document.getElementById('enemy-reset');
+
+const generateWorldButton = document.getElementById('generate-world');
+const worldOutput = document.getElementById('world-output');
+
+const DEFAULT_TILES = [
+  { id: '0', fill: '#000000', sprite: '/assets/Sprite-0003.png' },
+  { id: '1', fill: '#ffffff', sprite: '/assets/Sprite-0001.png' },
+  { id: '2', fill: '#dcdcdc', sprite: '/assets/Sprite-0002.png' },
+];
+
+const EQUIPMENT_SLOT_LABELS = {
+  weapon: 'Weapon',
+  helmet: 'Helmet',
+  chest: 'Chest',
+  legs: 'Legs',
+  feet: 'Feet',
+  hands: 'Hands',
+  useable: 'Useable Item',
+  useable1: 'Useable Slot 1',
+  useable2: 'Useable Slot 2',
+};
+
+const PREFERRED_SLOTS = [
+  'weapon',
+  'helmet',
+  'chest',
+  'legs',
+  'feet',
+  'hands',
+  'useable',
+  'useable1',
+  'useable2',
+];
+
+const state = {
+  abilities: [],
+  equipmentBySlot: new Map(),
+  equipmentSlots: [],
+  world: {
+    id: '',
+    name: '',
+    tileSize: 32,
+    moveCooldownMs: 180,
+    enemyCount: 6,
+  },
+  palette: {},
+  tileConfig: {},
+  zones: [],
+  selectedZoneId: null,
+  selectedTileId: null,
+  editMode: 'tile',
+  transportPlacement: null,
+  enemyTemplates: [],
+  selectedEnemyTemplateId: null,
+  enemyFormRotation: [],
+  editingEnemyId: null,
+};
+
+function initializeDefaults() {
+  DEFAULT_TILES.forEach(tile => {
+    state.palette[tile.id] = tile.fill;
+    state.tileConfig[tile.id] = { sprite: tile.sprite, fill: tile.fill };
+  });
+  state.selectedTileId = DEFAULT_TILES[1]?.id || DEFAULT_TILES[0]?.id || null;
+  renderTilePalette();
+}
+
+function attachWorldListeners() {
+  worldIdInput.addEventListener('input', e => {
+    state.world.id = e.target.value.trim();
+  });
+  worldNameInput.addEventListener('input', e => {
+    state.world.name = e.target.value;
+  });
+  worldTileSizeInput.addEventListener('input', e => {
+    const value = parseInt(e.target.value, 10);
+    if (!Number.isNaN(value)) {
+      state.world.tileSize = value;
+    }
+  });
+  worldMoveCooldownInput.addEventListener('input', e => {
+    const value = parseInt(e.target.value, 10);
+    if (!Number.isNaN(value)) {
+      state.world.moveCooldownMs = value;
+    }
+  });
+  worldEnemyCountInput.addEventListener('input', e => {
+    const value = parseInt(e.target.value, 10);
+    if (!Number.isNaN(value) && value > 0) {
+      state.world.enemyCount = value;
+    }
+  });
+}
+
+function renderTilePalette() {
+  tilePaletteEl.innerHTML = '';
+  const tileEntries = Object.entries(state.tileConfig);
+  if (!tileEntries.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No tiles defined';
+    tilePaletteEl.appendChild(empty);
+    return;
+  }
+  tileEntries.forEach(([id, config]) => {
+    const token = document.createElement('button');
+    token.type = 'button';
+    token.className = 'tile-token';
+    if (state.selectedTileId === id) {
+      token.classList.add('active');
+    }
+    token.style.background = config.fill || '#ffffff';
+    token.innerHTML = `<strong>${id}</strong><span>${config.fill || ''}</span>`;
+    token.addEventListener('click', () => {
+      state.selectedTileId = id;
+      renderTilePalette();
+    });
+    tilePaletteEl.appendChild(token);
+  });
+}
+
+function handleTileFormSubmit(event) {
+  event.preventDefault();
+  const id = tileIdInput.value.trim();
+  const fill = tileFillInput.value.trim() || '#ffffff';
+  const sprite = tileSpriteInput.value.trim();
+  if (!id) {
+    alert('Tile ID is required.');
+    return;
+  }
+  state.palette[id] = fill;
+  state.tileConfig[id] = { sprite, fill };
+  if (!state.selectedTileId) {
+    state.selectedTileId = id;
+  }
+  renderTilePalette();
+  renderZoneEditor();
+  tileForm.reset();
+}
+
+tileForm.addEventListener('submit', handleTileFormSubmit);
+
+function createZoneId(base) {
+  const sanitized = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'zone';
+  let candidate = sanitized;
+  let suffix = 1;
+  const existing = new Set(state.zones.map(z => z.id));
+  while (existing.has(candidate)) {
+    suffix += 1;
+    candidate = `${sanitized}_${suffix}`;
+  }
+  return candidate;
+}
+
+function createZone(name, width, height) {
+  const id = createZoneId(name);
+  const defaultTile = state.selectedTileId || Object.keys(state.tileConfig)[0] || '0';
+  const tiles = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => defaultTile)
+  );
+  return {
+    id,
+    name,
+    width,
+    height,
+    tiles,
+    transports: [],
+    enemyPlacements: [],
+    spawn: null,
+  };
+}
+
+function addZone() {
+  const name = prompt('Zone name?');
+  if (!name) {
+    return;
+  }
+  const width = parseInt(prompt('Zone width (tiles)?'), 10);
+  const height = parseInt(prompt('Zone height (tiles)?'), 10);
+  if (!Number.isInteger(width) || width <= 0 || !Number.isInteger(height) || height <= 0) {
+    alert('Width and height must be positive integers.');
+    return;
+  }
+  const zone = createZone(name, width, height);
+  state.zones.push(zone);
+  state.selectedZoneId = zone.id;
+  renderZonesList();
+  renderZoneEditor();
+  updateTransportOptions();
+}
+
+addZoneButton.addEventListener('click', addZone);
+
+function renderZonesList() {
+  zoneListEl.innerHTML = '';
+  if (!state.zones.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No zones yet. Add one to begin.';
+    zoneListEl.appendChild(empty);
+    return;
+  }
+  state.zones.forEach(zone => {
+    const item = document.createElement('div');
+    item.className = 'zone-item';
+    if (zone.id === state.selectedZoneId) {
+      item.classList.add('active');
+    }
+    const label = document.createElement('span');
+    label.textContent = zone.name || zone.id;
+    const dims = document.createElement('span');
+    dims.textContent = `${zone.width}×${zone.height}`;
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = 'Delete';
+    removeBtn.addEventListener('click', ev => {
+      ev.stopPropagation();
+      if (confirm(`Delete zone "${zone.name}"?`)) {
+        state.zones = state.zones.filter(z => z.id !== zone.id);
+        if (state.selectedZoneId === zone.id) {
+          state.selectedZoneId = state.zones[0]?.id || null;
+        }
+        renderZonesList();
+        renderZoneEditor();
+        updateTransportOptions();
+      }
+    });
+    item.addEventListener('click', () => {
+      state.selectedZoneId = zone.id;
+      renderZonesList();
+      renderZoneEditor();
+      updateTransportOptions();
+    });
+    item.appendChild(label);
+    item.appendChild(dims);
+    item.appendChild(removeBtn);
+    zoneListEl.appendChild(item);
+  });
+}
+
+function getSelectedZone() {
+  return state.zones.find(z => z.id === state.selectedZoneId) || null;
+}
+
+function setEditMode(mode) {
+  state.editMode = mode;
+  modeButtons.forEach(button => {
+    if (button.dataset.mode === mode) {
+      button.classList.add('active');
+    } else {
+      button.classList.remove('active');
+    }
+  });
+  transportControls.classList.toggle('hidden', mode !== 'transport');
+  enemyModeInfo.classList.toggle('hidden', mode !== 'enemy');
+}
+
+modeButtons.forEach(button => {
+  button.addEventListener('click', () => {
+    setEditMode(button.dataset.mode);
+  });
+});
+
+function setTransportPlacement() {
+  const zoneId = transportZoneSelect.value || null;
+  const x = parseInt(transportTargetXInput.value, 10);
+  const y = parseInt(transportTargetYInput.value, 10);
+  if (zoneId && Number.isInteger(x) && Number.isInteger(y)) {
+    state.transportPlacement = { zoneId, x, y };
+  } else if (zoneId) {
+    state.transportPlacement = { zoneId, x: null, y: null };
+  } else {
+    state.transportPlacement = null;
+  }
+}
+
+transportZoneSelect.addEventListener('change', () => {
+  setTransportPlacement();
+});
+transportTargetXInput.addEventListener('input', () => {
+  setTransportPlacement();
+});
+transportTargetYInput.addEventListener('input', () => {
+  setTransportPlacement();
+});
+transportClearButton.addEventListener('click', () => {
+  transportZoneSelect.value = '';
+  transportTargetXInput.value = '';
+  transportTargetYInput.value = '';
+  state.transportPlacement = null;
+});
+
+function ensureTransportPlacement() {
+  const placement = state.transportPlacement;
+  if (!placement || !placement.zoneId) {
+    alert('Select a target zone and coordinates for the transport.');
+    return false;
+  }
+  if (placement.x == null || placement.y == null) {
+    alert('Provide target coordinates for the transport.');
+    return false;
+  }
+  return true;
+}
+
+function handleEnemyPlacement(zone, x, y) {
+  const templateId = state.selectedEnemyTemplateId;
+  if (!templateId) {
+    alert('Select an enemy template to place.');
+    return;
+  }
+  const existing = zone.enemyPlacements.find(p => p.x === x && p.y === y);
+  if (existing) {
+    if (existing.templateId === templateId) {
+      zone.enemyPlacements = zone.enemyPlacements.filter(p => !(p.x === x && p.y === y));
+    } else {
+      existing.templateId = templateId;
+    }
+  } else {
+    zone.enemyPlacements.push({ x, y, templateId });
+  }
+}
+
+function handleTransportPlacement(zone, x, y) {
+  if (!ensureTransportPlacement()) {
+    return;
+  }
+  const placement = state.transportPlacement;
+  if (placement.zoneId === zone.id && placement.x === x && placement.y === y) {
+    alert('Transport cannot target the same tile.');
+    return;
+  }
+  const existingIndex = zone.transports.findIndex(t => t.from.x === x && t.from.y === y);
+  const transport = {
+    from: { x, y },
+    toZoneId: placement.zoneId,
+    to: { x: placement.x, y: placement.y },
+  };
+  if (existingIndex >= 0) {
+    zone.transports.splice(existingIndex, 1, transport);
+  } else {
+    zone.transports.push(transport);
+  }
+}
+
+function handleSpawnPlacement(zone, x, y) {
+  zone.spawn = { x, y };
+}
+
+function handleZoneCellClick(event) {
+  const zone = getSelectedZone();
+  if (!zone) return;
+  const x = Number(event.currentTarget.dataset.x);
+  const y = Number(event.currentTarget.dataset.y);
+  switch (state.editMode) {
+    case 'tile':
+      if (!state.selectedTileId) {
+        alert('Select a tile from the palette first.');
+        return;
+      }
+      zone.tiles[y][x] = state.selectedTileId;
+      break;
+    case 'enemy':
+      handleEnemyPlacement(zone, x, y);
+      break;
+    case 'transport':
+      handleTransportPlacement(zone, x, y);
+      break;
+    case 'spawn':
+      handleSpawnPlacement(zone, x, y);
+      break;
+    default:
+      break;
+  }
+  renderZoneEditor();
+}
+
+function handleZoneCellContextMenu(event) {
+  event.preventDefault();
+  const zone = getSelectedZone();
+  if (!zone) return;
+  const x = Number(event.currentTarget.dataset.x);
+  const y = Number(event.currentTarget.dataset.y);
+  if (state.editMode === 'enemy') {
+    zone.enemyPlacements = zone.enemyPlacements.filter(p => !(p.x === x && p.y === y));
+  } else if (state.editMode === 'transport') {
+    zone.transports = zone.transports.filter(t => !(t.from.x === x && t.from.y === y));
+  } else if (state.editMode === 'spawn') {
+    if (zone.spawn && zone.spawn.x === x && zone.spawn.y === y) {
+      zone.spawn = null;
+    }
+  } else if (state.editMode === 'tile') {
+    const defaultTile = Object.keys(state.tileConfig)[0];
+    if (defaultTile) {
+      zone.tiles[y][x] = defaultTile;
+    }
+  }
+  renderZoneEditor();
+}
+
+function renderZoneGrid() {
+  zoneGridContainer.innerHTML = '';
+  const zone = getSelectedZone();
+  if (!zone) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Select a zone to edit.';
+    zoneGridContainer.appendChild(empty);
+    return;
+  }
+  const grid = document.createElement('div');
+  grid.className = 'zone-grid';
+  const cellSize = Math.max(16, Math.min(96, state.world.tileSize || 32));
+  grid.style.gridTemplateColumns = `repeat(${zone.width}, ${cellSize}px)`;
+  grid.style.gridTemplateRows = `repeat(${zone.height}, ${cellSize}px)`;
+  for (let y = 0; y < zone.height; y += 1) {
+    for (let x = 0; x < zone.width; x += 1) {
+      const cell = document.createElement('button');
+      cell.type = 'button';
+      cell.className = 'zone-cell';
+      cell.dataset.x = x;
+      cell.dataset.y = y;
+      const tileId = zone.tiles[y][x];
+      const tileConfig = state.tileConfig[tileId] || {};
+      cell.style.background = tileConfig.fill || '#ffffff';
+      cell.textContent = tileId;
+      if (zone.spawn && zone.spawn.x === x && zone.spawn.y === y) {
+        cell.classList.add('is-spawn');
+      }
+      if (zone.enemyPlacements.some(p => p.x === x && p.y === y)) {
+        cell.classList.add('has-enemy');
+      }
+      if (zone.transports.some(t => t.from.x === x && t.from.y === y)) {
+        cell.classList.add('has-transport');
+      }
+      cell.addEventListener('click', handleZoneCellClick);
+      cell.addEventListener('contextmenu', handleZoneCellContextMenu);
+      grid.appendChild(cell);
+    }
+  }
+  zoneGridContainer.appendChild(grid);
+}
+
+function removeEnemyPlacement(zoneId, index) {
+  const zone = state.zones.find(z => z.id === zoneId);
+  if (!zone) return;
+  zone.enemyPlacements.splice(index, 1);
+  renderZoneEditor();
+}
+
+function removeTransport(zoneId, index) {
+  const zone = state.zones.find(z => z.id === zoneId);
+  if (!zone) return;
+  zone.transports.splice(index, 1);
+  renderZoneEditor();
+}
+
+function renderZoneDetails() {
+  zoneDetailsEl.innerHTML = '';
+  const zone = getSelectedZone();
+  if (!zone) {
+    zoneDetailsEl.textContent = 'Select a zone to view details.';
+    return;
+  }
+  const nameLabel = document.createElement('label');
+  nameLabel.className = 'field-label';
+  nameLabel.textContent = 'Zone Name';
+  const nameInput = document.createElement('input');
+  nameInput.value = zone.name;
+  nameInput.addEventListener('input', e => {
+    zone.name = e.target.value;
+    renderZonesList();
+    updateTransportOptions();
+  });
+  nameLabel.appendChild(nameInput);
+  zoneDetailsEl.appendChild(nameLabel);
+
+  const info = document.createElement('p');
+  info.textContent = `Size: ${zone.width}×${zone.height}`;
+  zoneDetailsEl.appendChild(info);
+
+  const spawnInfo = document.createElement('p');
+  spawnInfo.textContent = `Spawn: ${zone.spawn ? `${zone.spawn.x}, ${zone.spawn.y}` : 'Not set'}`;
+  zoneDetailsEl.appendChild(spawnInfo);
+
+  const enemySection = document.createElement('div');
+  enemySection.className = 'zone-subsection';
+  const enemyTitle = document.createElement('h3');
+  enemyTitle.textContent = `Enemy Placements (${zone.enemyPlacements.length})`;
+  enemySection.appendChild(enemyTitle);
+  const enemyList = document.createElement('ul');
+  zone.enemyPlacements.forEach((placement, index) => {
+    const li = document.createElement('li');
+    const template = state.enemyTemplates.find(t => t.id === placement.templateId);
+    const label = template ? `${template.name} (${placement.templateId})` : placement.templateId;
+    li.textContent = `${label} at ${placement.x}, ${placement.y}`;
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => removeEnemyPlacement(zone.id, index));
+    li.appendChild(removeButton);
+    enemyList.appendChild(li);
+  });
+  if (!zone.enemyPlacements.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'None';
+    enemyList.appendChild(empty);
+  }
+  enemySection.appendChild(enemyList);
+  zoneDetailsEl.appendChild(enemySection);
+
+  const transportSection = document.createElement('div');
+  transportSection.className = 'zone-subsection';
+  const transportTitle = document.createElement('h3');
+  transportTitle.textContent = `Transports (${zone.transports.length})`;
+  transportSection.appendChild(transportTitle);
+  const transportList = document.createElement('ul');
+  zone.transports.forEach((transport, index) => {
+    const li = document.createElement('li');
+    const targetZone = state.zones.find(z => z.id === transport.toZoneId);
+    const targetName = targetZone ? targetZone.name || targetZone.id : transport.toZoneId;
+    li.textContent = `${transport.from.x},${transport.from.y} → ${targetName} (${transport.to.x},${transport.to.y})`;
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => removeTransport(zone.id, index));
+    li.appendChild(removeButton);
+    transportList.appendChild(li);
+  });
+  if (!zone.transports.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'None';
+    transportList.appendChild(empty);
+  }
+  transportSection.appendChild(transportList);
+  zoneDetailsEl.appendChild(transportSection);
+}
+
+function renderZoneEditor() {
+  renderZoneDetails();
+  renderZoneGrid();
+}
+
+function updateTransportOptions() {
+  const zone = getSelectedZone();
+  const currentId = zone?.id;
+  transportZoneSelect.innerHTML = '<option value="">Select zone</option>';
+  state.zones
+    .filter(z => z.id !== currentId)
+    .forEach(z => {
+      const option = document.createElement('option');
+      option.value = z.id;
+      option.textContent = z.name || z.id;
+      transportZoneSelect.appendChild(option);
+    });
+  if (state.transportPlacement && state.transportPlacement.zoneId) {
+    const exists = state.zones.some(z => z.id === state.transportPlacement.zoneId);
+    if (!exists || state.transportPlacement.zoneId === currentId) {
+      state.transportPlacement = null;
+      transportZoneSelect.value = '';
+      transportTargetXInput.value = '';
+      transportTargetYInput.value = '';
+    }
+  }
+}
+
+function populateAbilitySelect() {
+  enemyAbilitySelect.innerHTML = '';
+  state.abilities.forEach(ability => {
+    const option = document.createElement('option');
+    option.value = ability.id;
+    option.textContent = `${ability.id} – ${ability.name}`;
+    enemyAbilitySelect.appendChild(option);
+  });
+}
+
+function flattenEquipment(data) {
+  const bySlot = new Map();
+  Object.values(data).forEach(items => {
+    if (!Array.isArray(items)) return;
+    items.forEach(item => {
+      if (!item || !item.slot) return;
+      const slot = item.slot;
+      if (!bySlot.has(slot)) {
+        bySlot.set(slot, []);
+      }
+      bySlot.get(slot).push(item);
+    });
+  });
+  bySlot.forEach(list => {
+    list.sort((a, b) => a.name.localeCompare(b.name));
+  });
+  return bySlot;
+}
+
+function renderEquipmentSlots() {
+  enemyEquipmentSlotsContainer.innerHTML = '';
+  const created = new Set();
+  const createSlot = slotId => {
+    if (created.has(slotId)) return;
+    const label = EQUIPMENT_SLOT_LABELS[slotId] || slotId;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'equipment-slot';
+    const title = document.createElement('span');
+    title.textContent = label;
+    const select = document.createElement('select');
+    select.dataset.slot = slotId;
+    select.innerHTML = '<option value="">None</option>';
+    const items = state.equipmentBySlot.get(slotId) || [];
+    items.forEach(item => {
+      const option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = item.name;
+      select.appendChild(option);
+    });
+    wrapper.appendChild(title);
+    wrapper.appendChild(select);
+    enemyEquipmentSlotsContainer.appendChild(wrapper);
+    created.add(slotId);
+  };
+
+  PREFERRED_SLOTS.forEach(slot => {
+    if (state.equipmentBySlot.has(slot)) {
+      createSlot(slot);
+    }
+  });
+
+  state.equipmentBySlot.forEach((_, slot) => {
+    if (!created.has(slot)) {
+      createSlot(slot);
+    }
+  });
+}
+
+function updateEquipmentSelection(equipment) {
+  const selects = enemyEquipmentSlotsContainer.querySelectorAll('select[data-slot]');
+  selects.forEach(select => {
+    const slot = select.dataset.slot;
+    const value = equipment[slot] || '';
+    select.value = value;
+  });
+}
+
+function renderEnemyRotation() {
+  enemyRotationList.innerHTML = '';
+  if (!state.enemyFormRotation.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No abilities yet.';
+    enemyRotationList.appendChild(empty);
+    return;
+  }
+  state.enemyFormRotation.forEach((abilityId, index) => {
+    const ability = state.abilities.find(a => String(a.id) === String(abilityId));
+    const li = document.createElement('li');
+    const label = document.createElement('span');
+    label.textContent = ability ? `${ability.id} – ${ability.name}` : abilityId;
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.textContent = '✕';
+    removeButton.addEventListener('click', () => {
+      state.enemyFormRotation.splice(index, 1);
+      renderEnemyRotation();
+    });
+    li.appendChild(label);
+    li.appendChild(removeButton);
+    enemyRotationList.appendChild(li);
+  });
+}
+
+enemyAddAbilityButton.addEventListener('click', () => {
+  const abilityId = enemyAbilitySelect.value;
+  if (!abilityId) return;
+  state.enemyFormRotation.push(Number(abilityId));
+  renderEnemyRotation();
+});
+
+enemyResetButton.addEventListener('click', () => {
+  state.enemyFormRotation = [];
+  state.editingEnemyId = null;
+  enemyForm.reset();
+  renderEnemyRotation();
+  updateEquipmentSelection({});
+});
+
+function collectEquipmentFromForm() {
+  const equipment = {};
+  enemyEquipmentSlotsContainer
+    .querySelectorAll('select[data-slot]')
+    .forEach(select => {
+      if (select.value) {
+        equipment[select.dataset.slot] = select.value;
+      }
+    });
+  return equipment;
+}
+
+function handleEnemyFormSubmit(event) {
+  event.preventDefault();
+  const id = enemyIdInput.value.trim();
+  if (!id) {
+    alert('Enemy template requires an ID.');
+    return;
+  }
+  const template = {
+    id,
+    name: enemyNameInput.value.trim() || id,
+    basicType: enemyBasicTypeInput.value,
+    level: parseInt(enemyLevelInput.value, 10) || 1,
+    attributes: {
+      strength: parseInt(enemyStrInput.value, 10) || 0,
+      stamina: parseInt(enemyStaInput.value, 10) || 0,
+      agility: parseInt(enemyAgiInput.value, 10) || 0,
+      intellect: parseInt(enemyIntInput.value, 10) || 0,
+      wisdom: parseInt(enemyWisInput.value, 10) || 0,
+    },
+    rotation: state.enemyFormRotation.slice(),
+    equipment: collectEquipmentFromForm(),
+    xpPct: Number(enemyXpInput.value) || 0,
+    gold: parseInt(enemyGoldInput.value, 10) || 0,
+    spawnChance: Number(enemySpawnChanceInput.value) || 0,
+  };
+
+  const existingIndex = state.enemyTemplates.findIndex(t => t.id === id);
+  if (state.editingEnemyId && state.editingEnemyId !== id && existingIndex >= 0) {
+    alert('Another template already uses that ID.');
+    return;
+  }
+  if (existingIndex >= 0) {
+    state.enemyTemplates.splice(existingIndex, 1, template);
+  } else {
+    state.enemyTemplates.push(template);
+  }
+  state.editingEnemyId = null;
+  renderEnemyTemplateList();
+  renderZoneEditor();
+  updateEnemyModeInfo();
+}
+
+enemyForm.addEventListener('submit', handleEnemyFormSubmit);
+
+function loadEnemyTemplateIntoForm(template) {
+  enemyIdInput.value = template.id;
+  enemyNameInput.value = template.name;
+  enemyBasicTypeInput.value = template.basicType;
+  enemyLevelInput.value = template.level;
+  enemyStrInput.value = template.attributes.strength ?? 0;
+  enemyStaInput.value = template.attributes.stamina ?? 0;
+  enemyAgiInput.value = template.attributes.agility ?? 0;
+  enemyIntInput.value = template.attributes.intellect ?? 0;
+  enemyWisInput.value = template.attributes.wisdom ?? 0;
+  enemyXpInput.value = template.xpPct ?? 0;
+  enemyGoldInput.value = template.gold ?? 0;
+  enemySpawnChanceInput.value = template.spawnChance ?? 0;
+  state.enemyFormRotation = template.rotation ? template.rotation.slice() : [];
+  updateEquipmentSelection(template.equipment || {});
+  renderEnemyRotation();
+  state.editingEnemyId = template.id;
+}
+
+function setEnemyPlacementTarget(templateId) {
+  state.selectedEnemyTemplateId = templateId;
+  enemyPlacementTargetEl.textContent = templateId || 'None Selected';
+  renderEnemyTemplateList();
+  renderZoneEditor();
+}
+
+function renderEnemyTemplateList() {
+  enemyTemplateListEl.innerHTML = '';
+  if (!state.enemyTemplates.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No enemy templates yet.';
+    enemyTemplateListEl.appendChild(empty);
+    return;
+  }
+  state.enemyTemplates.forEach(template => {
+    const item = document.createElement('div');
+    item.className = 'enemy-template';
+    if (template.id === state.selectedEnemyTemplateId) {
+      item.classList.add('active');
+    }
+    const info = document.createElement('div');
+    info.innerHTML = `<strong>${template.name}</strong><br /><span>${template.id}</span>`;
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const selectButton = document.createElement('button');
+    selectButton.type = 'button';
+    selectButton.textContent = 'Select';
+    selectButton.addEventListener('click', () => setEnemyPlacementTarget(template.id));
+    actions.appendChild(selectButton);
+
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.textContent = 'Edit';
+    editButton.addEventListener('click', () => loadEnemyTemplateIntoForm(template));
+    actions.appendChild(editButton);
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.textContent = 'Delete';
+    removeButton.addEventListener('click', () => {
+      if (confirm(`Delete template "${template.name}"?`)) {
+        state.enemyTemplates = state.enemyTemplates.filter(t => t.id !== template.id);
+        if (state.selectedEnemyTemplateId === template.id) {
+          state.selectedEnemyTemplateId = null;
+          enemyPlacementTargetEl.textContent = 'None Selected';
+        }
+        renderEnemyTemplateList();
+        renderZoneEditor();
+      }
+    });
+    actions.appendChild(removeButton);
+
+    item.appendChild(info);
+    item.appendChild(actions);
+    enemyTemplateListEl.appendChild(item);
+  });
+}
+
+function updateEnemyModeInfo() {
+  enemyPlacementTargetEl.textContent = state.selectedEnemyTemplateId || 'None Selected';
+}
+
+function generateWorldJson() {
+  if (!state.zones.length) {
+    alert('Create at least one zone before generating.');
+    return;
+  }
+  const world = {
+    id: state.world.id || 'new_world',
+    name: state.world.name || 'New World',
+    tileSize: state.world.tileSize,
+    palette: state.palette,
+    tileConfig: state.tileConfig,
+    moveCooldownMs: state.world.moveCooldownMs,
+    encounters: {
+      enemyCount: state.world.enemyCount,
+      templates: state.enemyTemplates.map(template => ({
+        ...template,
+        rotation: Array.isArray(template.rotation)
+          ? template.rotation.slice()
+          : [],
+        equipment: { ...(template.equipment || {}) },
+      })),
+    },
+    zones: state.zones.map(zone => ({
+      id: zone.id,
+      name: zone.name,
+      width: zone.width,
+      height: zone.height,
+      tiles: zone.tiles,
+      spawn: zone.spawn,
+      transports: zone.transports,
+      enemyPlacements: zone.enemyPlacements,
+    })),
+  };
+  if (state.zones.length === 1) {
+    const zone = state.zones[0];
+    world.tiles = zone.tiles;
+    world.spawn = zone.spawn;
+  }
+  const output = JSON.stringify(world, null, 2);
+  worldOutput.value = output;
+}
+
+generateWorldButton.addEventListener('click', generateWorldJson);
+
+function showError(message) {
+  loadingEl.innerHTML = `
+    <div class="loading-panel">
+      <p>${message}</p>
+    </div>
+  `;
+}
+
+async function initialize() {
+  try {
+    initializeDefaults();
+    attachWorldListeners();
+    const [abilitiesResponse, equipmentResponse] = await Promise.all([
+      fetch('/abilities'),
+      fetch('/equipment'),
+    ]);
+    if (!abilitiesResponse.ok || !equipmentResponse.ok) {
+      throw new Error('Failed to load catalogs');
+    }
+    const abilities = await abilitiesResponse.json();
+    const equipment = await equipmentResponse.json();
+    state.abilities = Array.isArray(abilities) ? abilities : [];
+    state.equipmentBySlot = flattenEquipment(equipment || {});
+    populateAbilitySelect();
+    renderEquipmentSlots();
+    renderEnemyRotation();
+    renderEnemyTemplateList();
+    renderZonesList();
+    renderZoneEditor();
+    updateEnemyModeInfo();
+    updateTransportOptions();
+    builderEl.classList.remove('hidden');
+    loadingEl.classList.add('hidden');
+  } catch (err) {
+    console.error(err);
+    showError('Failed to load catalogs. Please refresh to try again.');
+  }
+}
+
+initialize();


### PR DESCRIPTION
## Summary
- add an express route at `/dev/world-builder` that serves a standalone developer tool
- build a retro-styled world builder UI that supports editing tiles, multi-zone layouts, transports, and enemy templates that reuse existing abilities/equipment
- display the generated world JSON for copying once the world configuration is complete

## Testing
- not run (requires MongoDB connection to start the server)


------
https://chatgpt.com/codex/tasks/task_e_68df4fefd5788320b0db73ad5a183c07