### PR TITLE
Fix world builder export types and add JSON import

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -122,6 +122,7 @@ body.world-builder {
 .mode-button,
 #add-zone,
 #generate-world,
+#load-world,
 #enemy-add-ability,
 #transport-clear,
 .enemy-template button {
@@ -403,6 +404,12 @@ body.world-builder {
   left:2px;
   font-weight:bold;
   font-size:11px;
+}
+
+.output-actions {
+  display:flex;
+  gap:8px;
+  margin-bottom:8px;
 }
 
 .output-panel textarea {

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -157,8 +157,15 @@
         </section>
         <section class="panel output-panel">
           <h2>Generated world.json</h2>
-          <button id="generate-world">Generate</button>
-          <textarea id="world-output" readonly placeholder="Generated JSON will appear here..."></textarea>
+          <div class="output-actions">
+            <button id="generate-world">Generate</button>
+            <button id="load-world">Load From JSON</button>
+          </div>
+          <textarea
+            id="world-output"
+            placeholder="Paste existing JSON here or generate to view output..."
+            spellcheck="false"
+          ></textarea>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- ensure the world builder exports numeric tile grids and sanitized encounter data
- add the ability to paste existing JSON into the builder for editing and keep the UI in sync
- adjust the builder page layout and styles for the new import action

## Testing
- node --check ui/world-builder.js

------
https://chatgpt.com/codex/tasks/task_e_68df5ca6aee88320be6a1c92426df29f