### PR TITLE
Fix world builder export to match world mode schema

### DIFF
--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -37,6 +37,25 @@
             <span>Encounter Enemy Count</span>
             <input id="world-enemy-count" type="number" min="1" value="6" />
           </label>
+          <label class="field-inline">
+            <span>Encounter Tiles</span>
+            <input id="world-encounter-tiles" type="text" placeholder="e.g. 2" />
+          </label>
+          <label class="field-inline">
+            <span>Encounter Chance</span>
+            <input
+              id="world-encounter-chance"
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              value="0.22"
+            />
+          </label>
+          <label class="field-inline">
+            <span>Encounter Cooldown (ms)</span>
+            <input id="world-encounter-cooldown" type="number" min="0" value="2000" />
+          </label>
         </section>
         <section class="panel palette-panel">
           <h2>Tile Palette</h2>


### PR DESCRIPTION
## Summary
- add encounter tile, chance, and cooldown controls to the world builder settings panel
- sanitize encounter configuration, always include a primary zone tile map, and wrap the generated JSON in an array for world mode compatibility
- allow loading existing array-based JSON while keeping the output textarea in sync with the sanitized export

## Testing
- not run (MongoDB connection required for npm start)


------
https://chatgpt.com/codex/tasks/task_e_68df611aa2e08320bb5a6dd6021bb847