### PR TITLE
Add sprite and enemy catalog management to world builder

### DIFF
--- a/models/EnemyTemplate.js
+++ b/models/EnemyTemplate.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+
+const AttributeSchema = new mongoose.Schema(
+  {
+    strength: { type: Number, default: 0 },
+    stamina: { type: Number, default: 0 },
+    agility: { type: Number, default: 0 },
+    intellect: { type: Number, default: 0 },
+    wisdom: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
+const EnemyTemplateSchema = new mongoose.Schema(
+  {
+    templateId: { type: String, required: true, trim: true, unique: true },
+    name: { type: String, required: true, trim: true },
+    basicType: { type: String, default: 'melee', trim: true },
+    level: { type: Number, default: 1 },
+    attributes: { type: AttributeSchema, default: () => ({}) },
+    rotation: {
+      type: [mongoose.Schema.Types.Mixed],
+      default: [],
+    },
+    equipment: {
+      type: Map,
+      of: String,
+      default: () => ({}),
+    },
+    xpPct: { type: Number, default: 0 },
+    gold: { type: Number, default: 0 },
+    spawnChance: { type: Number, default: 0 },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model('EnemyTemplate', EnemyTemplateSchema);

--- a/models/SpritePalette.js
+++ b/models/SpritePalette.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+
+const PaletteTileSchema = new mongoose.Schema(
+  {
+    tileId: { type: String, required: true },
+    sprite: { type: String, required: true },
+    fill: { type: String, default: '#ffffff' },
+    walkable: { type: Boolean, default: true },
+  },
+  { _id: false }
+);
+
+const SpritePaletteSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    tiles: {
+      type: [PaletteTileSchema],
+      default: [],
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+SpritePaletteSchema.index({ name: 1 }, { unique: true });
+SpritePaletteSchema.index({ 'tiles.tileId': 1, name: 1 });
+
+module.exports = mongoose.model('SpritePalette', SpritePaletteSchema);

--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -5,6 +5,42 @@ body.world-builder {
   padding:24px;
 }
 
+.builder-wrapper {
+  max-width:1100px;
+  margin:0 auto;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.builder-tabs {
+  display:flex;
+  gap:8px;
+}
+
+.tab-button {
+  border:2px solid #000;
+  background:#fff;
+  padding:8px 16px;
+  text-transform:uppercase;
+  font-family:'Courier New', monospace;
+  cursor:pointer;
+  box-shadow:4px 4px 0 #000;
+}
+
+.tab-button.active {
+  background:#000;
+  color:#fff;
+}
+
+.builder-tab {
+  display:none;
+}
+
+.builder-tab.active {
+  display:block;
+}
+
 .builder-header {
   max-width:1100px;
   margin:0 auto 24px auto;
@@ -79,7 +115,8 @@ body.world-builder {
 
 .field-label input,
 .field-inline input,
-.field-label select {
+.field-label select,
+.field-label textarea {
   border:1px solid #000;
   padding:4px;
   font-family:'Courier New', monospace;
@@ -92,6 +129,36 @@ body.world-builder {
   flex-wrap:wrap;
   gap:8px;
   margin-bottom:12px;
+}
+
+.panel-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:12px;
+}
+
+.panel-actions {
+  display:flex;
+  gap:8px;
+  align-items:center;
+}
+
+.panel-link {
+  border:1px solid #000;
+  background:#fff;
+  padding:4px 8px;
+  text-transform:uppercase;
+  font-family:'Courier New', monospace;
+  cursor:pointer;
+  box-shadow:2px 2px 0 #000;
+}
+
+.panel-note {
+  font-size:12px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+  margin:8px 0 0;
 }
 
 .tile-token {
@@ -117,8 +184,9 @@ body.world-builder {
   letter-spacing:1px;
 }
 
-.tile-form button,
 .enemy-actions button,
+.sprite-actions button,
+.palette-tile button,
 .mode-button,
 #add-zone,
 #generate-world,
@@ -141,6 +209,12 @@ body.world-builder {
 }
 
 .enemy-form {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.sprite-form {
   display:flex;
   flex-direction:column;
   gap:12px;
@@ -222,6 +296,16 @@ body.world-builder {
   flex-direction:column;
   gap:8px;
   margin-top:12px;
+}
+
+.enemy-template-list--compact .enemy-template {
+  flex-direction:column;
+  align-items:flex-start;
+}
+
+.enemy-template-list--compact .enemy-template .actions {
+  width:100%;
+  justify-content:flex-start;
 }
 
 .enemy-template {
@@ -404,6 +488,133 @@ body.world-builder {
   left:2px;
   font-weight:bold;
   font-size:11px;
+}
+
+.zone-cell.not-walkable::before {
+  content:"✕";
+  position:absolute;
+  top:2px;
+  left:2px;
+  font-weight:bold;
+  font-size:11px;
+}
+
+.sprite-layout,
+.enemy-layout {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+  gap:16px;
+}
+
+.sprite-actions {
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+}
+
+.palette-tile-list {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.palette-tile {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  border:1px solid #000;
+  padding:8px;
+  background:#fdfdfd;
+  gap:12px;
+}
+
+.palette-tile button {
+  align-self:flex-start;
+}
+
+.palette-tile .actions {
+  display:flex;
+  gap:6px;
+  flex-wrap:wrap;
+}
+
+.palette-tile-info {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  font-size:12px;
+  text-transform:uppercase;
+}
+
+.palette-tile-swatch {
+  width:36px;
+  height:36px;
+  border:1px solid #000;
+  background:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  overflow:hidden;
+}
+
+.palette-tile-swatch img {
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  image-rendering:pixelated;
+}
+
+.sprite-asset-list {
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(72px, 1fr));
+  gap:8px;
+  max-height:360px;
+  overflow:auto;
+}
+
+.asset-tile {
+  border:1px solid #000;
+  background:#fff;
+  padding:6px;
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  box-shadow:2px 2px 0 #000;
+}
+
+.asset-tile.active {
+  background:#000;
+}
+
+.asset-tile.active img {
+  filter:invert(1);
+}
+
+.asset-tile img {
+  width:48px;
+  height:48px;
+  image-rendering:pixelated;
+}
+
+.sprite-preview {
+  border:1px solid #000;
+  min-height:120px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:#fdfdfd;
+  margin:8px 0;
+  flex-direction:column;
+  gap:8px;
+}
+
+.sprite-preview img {
+  width:96px;
+  height:96px;
+  image-rendering:pixelated;
+  border:1px solid #000;
+  background:#fff;
 }
 
 .output-actions {

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -13,186 +13,274 @@
       <p>Create and export world configuration files for developers.</p>
       <a class="builder-link" href="/">← Back to Game</a>
     </header>
-    <main id="builder" class="builder-layout hidden">
-      <div class="builder-column builder-column-settings">
-        <section class="panel">
-          <h2>World Settings</h2>
-          <label class="field-label">
-            World ID
-            <input id="world-id" type="text" placeholder="unique_world_id" />
-          </label>
-          <label class="field-label">
-            World Name
-            <input id="world-name" type="text" placeholder="World Name" />
-          </label>
-          <label class="field-inline">
-            <span>Tile Size</span>
-            <input id="world-tile-size" type="number" min="8" value="32" />
-          </label>
-          <label class="field-inline">
-            <span>Move Cooldown (ms)</span>
-            <input id="world-move-cooldown" type="number" min="0" value="180" />
-          </label>
-          <label class="field-inline">
-            <span>Encounter Enemy Count</span>
-            <input id="world-enemy-count" type="number" min="1" value="6" />
-          </label>
-          <label class="field-inline">
-            <span>Encounter Tiles</span>
-            <input id="world-encounter-tiles" type="text" placeholder="e.g. 2" />
-          </label>
-          <label class="field-inline">
-            <span>Encounter Chance</span>
-            <input
-              id="world-encounter-chance"
-              type="number"
-              min="0"
-              max="1"
-              step="0.01"
-              value="0.22"
-            />
-          </label>
-          <label class="field-inline">
-            <span>Encounter Cooldown (ms)</span>
-            <input id="world-encounter-cooldown" type="number" min="0" value="2000" />
-          </label>
-        </section>
-        <section class="panel palette-panel">
-          <h2>Tile Palette</h2>
-          <div id="tile-palette" class="tile-palette"></div>
-          <form id="tile-form" class="tile-form">
-            <div class="field-inline">
-              <span>ID</span>
-              <input id="tile-id" type="text" placeholder="e.g. 0" />
-            </div>
-            <div class="field-inline">
-              <span>Fill</span>
-              <input id="tile-fill" type="text" placeholder="#000000" />
-            </div>
-            <div class="field-inline">
-              <span>Sprite</span>
-              <input id="tile-sprite" type="text" placeholder="/assets/Sprite.png" />
-            </div>
-            <button type="submit">Add / Update Tile</button>
-          </form>
-        </section>
-        <section class="panel enemy-panel">
-          <h2>Enemy Templates</h2>
-          <form id="enemy-form" class="enemy-form">
-            <div class="enemy-grid">
-              <label class="field-label">
-                Template ID
-                <input id="enemy-id" type="text" placeholder="wild_sprig" required />
-              </label>
-              <label class="field-label">
-                Name
-                <input id="enemy-name" type="text" placeholder="Wild Sprig" required />
-              </label>
-              <label class="field-label">
-                Basic Type
-                <select id="enemy-basic-type">
-                  <option value="melee">Melee</option>
-                  <option value="magic">Magic</option>
-                </select>
-              </label>
-              <label class="field-label">
-                Level
-                <input id="enemy-level" type="number" min="1" value="1" required />
-              </label>
-              <fieldset class="enemy-attributes">
-                <legend>Attributes</legend>
-                <label>STR <input id="enemy-str" type="number" min="0" value="5" /></label>
-                <label>STA <input id="enemy-sta" type="number" min="0" value="5" /></label>
-                <label>AGI <input id="enemy-agi" type="number" min="0" value="5" /></label>
-                <label>INT <input id="enemy-int" type="number" min="0" value="2" /></label>
-                <label>WIS <input id="enemy-wis" type="number" min="0" value="2" /></label>
-              </fieldset>
-              <fieldset class="enemy-economy">
-                <legend>Rewards</legend>
-                <label>XP % <input id="enemy-xp" type="number" min="0" max="1" step="0.01" value="0.05" /></label>
-                <label>Gold <input id="enemy-gold" type="number" min="0" value="5" /></label>
-                <label>Spawn Chance <input id="enemy-spawn-chance" type="number" min="0" max="1" step="0.01" value="0.5" /></label>
-              </fieldset>
-              <fieldset class="enemy-rotation">
-                <legend>Rotation</legend>
-                <div class="rotation-picker">
-                  <select id="enemy-ability-select"></select>
-                  <button type="button" id="enemy-add-ability">Add Ability</button>
-                </div>
-                <ol id="enemy-rotation-list" class="rotation-list"></ol>
-              </fieldset>
-              <fieldset class="enemy-equipment">
-                <legend>Equipment</legend>
-                <div id="enemy-equipment-slots" class="equipment-slots"></div>
-              </fieldset>
-            </div>
-            <div class="enemy-actions">
-              <button type="submit" id="enemy-save">Save Template</button>
-              <button type="button" id="enemy-reset">Clear</button>
-            </div>
-          </form>
-          <div id="enemy-template-list" class="enemy-template-list"></div>
-        </section>
-      </div>
-      <div class="builder-column builder-column-main">
-        <section class="panel zone-panel">
-          <div class="zone-panel-header">
-            <h2>Zones</h2>
-            <button id="add-zone">Add Zone</button>
-          </div>
-          <div id="zone-list" class="zone-list"></div>
-        </section>
-        <section class="panel zone-editor">
-          <div class="zone-toolbar">
-            <div class="mode-switcher">
-              <span class="mode-label">Edit Mode:</span>
-              <button data-mode="tile" class="mode-button active">Tiles</button>
-              <button data-mode="enemy" class="mode-button">Enemies</button>
-              <button data-mode="transport" class="mode-button">Transports</button>
-              <button data-mode="spawn" class="mode-button">Spawn</button>
-            </div>
-            <div class="transport-controls hidden" id="transport-controls">
-              <label>
-                Target Zone
-                <select id="transport-zone-select"></select>
-              </label>
-              <label>
-                Target X
-                <input id="transport-target-x" type="number" min="0" />
-              </label>
-              <label>
-                Target Y
-                <input id="transport-target-y" type="number" min="0" />
-              </label>
-              <button type="button" id="transport-clear">Clear Target</button>
-            </div>
-            <div class="enemy-mode-info hidden" id="enemy-mode-info">
-              <span>Placement Target:</span>
-              <span id="enemy-placement-target">None Selected</span>
-            </div>
-          </div>
-          <div id="zone-details" class="zone-details"></div>
-          <div id="zone-grid" class="zone-grid-container"></div>
-        </section>
-        <section class="panel output-panel">
-          <h2>Generated world.json</h2>
-          <div class="output-actions">
-            <button id="generate-world">Generate</button>
-            <button id="load-world">Load From JSON</button>
-          </div>
-          <textarea
-            id="world-output"
-            placeholder="Paste existing JSON here or generate to view output..."
-            spellcheck="false"
-          ></textarea>
-        </section>
-      </div>
-    </main>
+
     <div id="builder-loading" class="builder-loading">
       <div class="loading-panel">
-        <p>Loading catalogs...</p>
+        <p>Loading developer catalogs…</p>
       </div>
     </div>
+
+    <main id="builder-wrapper" class="builder-wrapper hidden">
+      <nav class="builder-tabs">
+        <button type="button" class="tab-button active" data-tab="world">World</button>
+        <button type="button" class="tab-button" data-tab="sprites">Sprites</button>
+        <button type="button" class="tab-button" data-tab="enemies">Enemies</button>
+      </nav>
+
+      <section class="builder-tab active" data-tab-panel="world">
+        <div id="builder" class="builder-layout">
+          <div class="builder-column builder-column-settings">
+            <section class="panel">
+              <h2>World Settings</h2>
+              <label class="field-label">
+                World ID
+                <input id="world-id" type="text" placeholder="unique_world_id" />
+              </label>
+              <label class="field-label">
+                World Name
+                <input id="world-name" type="text" placeholder="World Name" />
+              </label>
+              <label class="field-inline">
+                <span>Tile Size</span>
+                <input id="world-tile-size" type="number" min="8" value="32" />
+              </label>
+              <label class="field-inline">
+                <span>Move Cooldown (ms)</span>
+                <input id="world-move-cooldown" type="number" min="0" value="180" />
+              </label>
+              <label class="field-inline">
+                <span>Encounter Enemy Count</span>
+                <input id="world-enemy-count" type="number" min="1" value="6" />
+              </label>
+              <label class="field-inline">
+                <span>Encounter Tiles</span>
+                <input id="world-encounter-tiles" type="text" placeholder="e.g. 2" />
+              </label>
+              <label class="field-inline">
+                <span>Encounter Chance</span>
+                <input
+                  id="world-encounter-chance"
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value="0.22"
+                />
+              </label>
+              <label class="field-inline">
+                <span>Encounter Cooldown (ms)</span>
+                <input id="world-encounter-cooldown" type="number" min="0" value="2000" />
+              </label>
+            </section>
+
+            <section class="panel palette-panel">
+              <div class="panel-header">
+                <h2>Tile Palette</h2>
+                <div class="panel-actions">
+                  <label class="field-inline">
+                    <span>Palette</span>
+                    <select id="palette-select"></select>
+                  </label>
+                  <button type="button" class="panel-link" data-tab-target="sprites">
+                    Edit Palette
+                  </button>
+                </div>
+              </div>
+              <div id="tile-palette" class="tile-palette"></div>
+              <p class="panel-note">Palettes are editable from the Sprites tab.</p>
+            </section>
+
+            <section class="panel enemy-picker-panel">
+              <div class="panel-header">
+                <h2>Enemy Templates</h2>
+                <button type="button" class="panel-link" data-tab-target="enemies">
+                  Manage
+                </button>
+              </div>
+              <div id="enemy-picker-list" class="enemy-template-list enemy-template-list--compact"></div>
+            </section>
+          </div>
+
+          <div class="builder-column builder-column-main">
+            <section class="panel zone-panel">
+              <div class="zone-panel-header">
+                <h2>Zones</h2>
+                <button id="add-zone">Add Zone</button>
+              </div>
+              <div id="zone-list" class="zone-list"></div>
+            </section>
+            <section class="panel zone-editor">
+              <div class="zone-toolbar">
+                <div class="mode-switcher">
+                  <span class="mode-label">Edit Mode:</span>
+                  <button data-mode="tile" class="mode-button active">Tiles</button>
+                  <button data-mode="enemy" class="mode-button">Enemies</button>
+                  <button data-mode="transport" class="mode-button">Transports</button>
+                  <button data-mode="spawn" class="mode-button">Spawn</button>
+                </div>
+                <div class="transport-controls hidden" id="transport-controls">
+                  <label>
+                    Target Zone
+                    <select id="transport-zone-select"></select>
+                  </label>
+                  <label>
+                    Target X
+                    <input id="transport-target-x" type="number" min="0" />
+                  </label>
+                  <label>
+                    Target Y
+                    <input id="transport-target-y" type="number" min="0" />
+                  </label>
+                  <button type="button" id="transport-clear">Clear Target</button>
+                </div>
+                <div class="enemy-mode-info hidden" id="enemy-mode-info">
+                  <span>Placement Target:</span>
+                  <span id="enemy-placement-target">None Selected</span>
+                </div>
+              </div>
+              <div id="zone-details" class="zone-details"></div>
+              <div id="zone-grid" class="zone-grid-container"></div>
+            </section>
+            <section class="panel output-panel">
+              <h2>Generated world.json</h2>
+              <div class="output-actions">
+                <button id="generate-world">Generate</button>
+                <button id="load-world">Load From JSON</button>
+              </div>
+              <textarea
+                id="world-output"
+                placeholder="Paste existing JSON here or generate to view output..."
+                spellcheck="false"
+              ></textarea>
+            </section>
+          </div>
+        </div>
+      </section>
+
+      <section class="builder-tab" data-tab-panel="sprites">
+        <div class="sprite-layout">
+          <section class="panel sprite-meta-panel">
+            <h2>Palette Details</h2>
+            <label class="field-label">
+              Palette Name
+              <input id="palette-name" type="text" placeholder="My Palette" />
+            </label>
+            <label class="field-label">
+              Description
+              <textarea id="palette-description" rows="2" placeholder="Optional notes..."></textarea>
+            </label>
+            <div class="sprite-actions">
+              <button type="button" id="create-palette">New Palette</button>
+              <button type="button" id="save-palette">Save Palette</button>
+              <button type="button" id="delete-palette">Delete Palette</button>
+            </div>
+          </section>
+
+          <section class="panel sprite-palette-panel">
+            <h2>Palette Tiles</h2>
+            <div id="palette-tile-list" class="palette-tile-list"></div>
+          </section>
+
+          <section class="panel sprite-assets-panel">
+            <h2>Sprite Assets</h2>
+            <div id="sprite-asset-list" class="sprite-asset-list"></div>
+          </section>
+
+          <section class="panel sprite-builder-panel">
+            <h2>Sprite Builder</h2>
+            <form id="sprite-form" class="sprite-form">
+              <label class="field-inline">
+                <span>Tile ID</span>
+                <input id="sprite-tile-id" type="text" placeholder="e.g. 5" />
+              </label>
+              <label class="field-inline">
+                <span>Fill</span>
+                <input id="sprite-fill" type="text" placeholder="#ffffff" />
+              </label>
+              <label class="field-label">
+                Sprite Path
+                <input id="sprite-asset-path" type="text" placeholder="/assets/Sprite.png" />
+              </label>
+              <label class="field-inline checkbox">
+                <input id="sprite-walkable" type="checkbox" checked />
+                <span>Walkable</span>
+              </label>
+              <div class="sprite-preview" id="sprite-preview">
+                <p>Select an asset to preview</p>
+              </div>
+              <button type="submit">Add / Update Tile</button>
+            </form>
+          </section>
+        </div>
+      </section>
+
+      <section class="builder-tab" data-tab-panel="enemies">
+        <div class="enemy-layout">
+          <section class="panel enemy-editor-panel">
+            <h2>Enemy Template Editor</h2>
+            <form id="enemy-form" class="enemy-form">
+              <div class="enemy-grid">
+                <label class="field-label">
+                  Template ID
+                  <input id="enemy-id" type="text" placeholder="wild_sprig" required />
+                </label>
+                <label class="field-label">
+                  Name
+                  <input id="enemy-name" type="text" placeholder="Wild Sprig" required />
+                </label>
+                <label class="field-label">
+                  Basic Type
+                  <select id="enemy-basic-type">
+                    <option value="melee">Melee</option>
+                    <option value="magic">Magic</option>
+                  </select>
+                </label>
+                <label class="field-label">
+                  Level
+                  <input id="enemy-level" type="number" min="1" value="1" required />
+                </label>
+                <fieldset class="enemy-attributes">
+                  <legend>Attributes</legend>
+                  <label>STR <input id="enemy-str" type="number" min="0" value="5" /></label>
+                  <label>STA <input id="enemy-sta" type="number" min="0" value="5" /></label>
+                  <label>AGI <input id="enemy-agi" type="number" min="0" value="5" /></label>
+                  <label>INT <input id="enemy-int" type="number" min="0" value="2" /></label>
+                  <label>WIS <input id="enemy-wis" type="number" min="0" value="2" /></label>
+                </fieldset>
+                <fieldset class="enemy-economy">
+                  <legend>Rewards</legend>
+                  <label>XP % <input id="enemy-xp" type="number" min="0" max="1" step="0.01" value="0.05" /></label>
+                  <label>Gold <input id="enemy-gold" type="number" min="0" value="5" /></label>
+                  <label>Spawn Chance <input id="enemy-spawn-chance" type="number" min="0" max="1" step="0.01" value="0.5" /></label>
+                </fieldset>
+                <fieldset class="enemy-rotation">
+                  <legend>Rotation</legend>
+                  <div class="rotation-picker">
+                    <select id="enemy-ability-select"></select>
+                    <button type="button" id="enemy-add-ability">Add Ability</button>
+                  </div>
+                  <ol id="enemy-rotation-list" class="rotation-list"></ol>
+                </fieldset>
+                <fieldset class="enemy-equipment">
+                  <legend>Equipment</legend>
+                  <div id="enemy-equipment-slots" class="equipment-slots"></div>
+                </fieldset>
+              </div>
+              <div class="enemy-actions">
+                <button type="submit" id="enemy-save">Save Template</button>
+                <button type="button" id="enemy-reset">Clear</button>
+              </div>
+            </form>
+          </section>
+
+          <section class="panel enemy-library-panel">
+            <h2>Saved Enemy Templates</h2>
+            <div id="enemy-template-list" class="enemy-template-list"></div>
+          </section>
+        </div>
+      </section>
+    </main>
+
     <script src="/world-builder.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add developer endpoints for listing sprite assets, saving palettes, and persisting reusable enemy templates
- build dedicated sprite and enemy tabs in the world builder with asset previews, palette editing, and template management
- integrate saved palettes and enemy templates back into the world editing workflow for tile painting and encounter placement

## Testing
- npm start *(fails: MongoDB connection not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df7ead61988320b48b61e0b0a31806