### PR TITLE
Fix sprite rendering in world builder

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -172,11 +172,30 @@ body.world-builder {
   cursor:pointer;
   text-transform:uppercase;
   position:relative;
+  background-size:cover;
+  background-position:center;
 }
 
 .tile-token.active {
   outline:2px dashed #000;
   outline-offset:3px;
+}
+
+.tile-token.has-sprite {
+  color:#fff;
+  text-shadow:0 1px 1px #000;
+}
+
+.tile-token.has-sprite span {
+  background:rgba(0, 0, 0, 0.6);
+  padding:2px 4px;
+  border-radius:2px;
+}
+
+.tile-token.has-sprite strong {
+  background:rgba(0, 0, 0, 0.6);
+  padding:2px 4px;
+  border-radius:2px;
 }
 
 .tile-token span {
@@ -461,6 +480,8 @@ body.world-builder {
   justify-content:center;
   position:relative;
   cursor:pointer;
+  background-size:cover;
+  background-position:center;
 }
 
 .zone-cell.has-enemy::after {

--- a/ui/world-builder.js
+++ b/ui/world-builder.js
@@ -266,10 +266,20 @@ function renderTilePalette() {
     const token = document.createElement('button');
     token.type = 'button';
     token.className = 'tile-token';
+    const hasSprite = Boolean(config.sprite);
+    if (hasSprite) {
+      token.classList.add('has-sprite');
+      token.style.backgroundImage = `url(${config.sprite})`;
+      token.style.backgroundSize = 'cover';
+      token.style.backgroundPosition = 'center';
+      token.style.backgroundColor = config.fill || '#ffffff';
+    } else {
+      token.style.background = config.fill || '#ffffff';
+      token.style.backgroundImage = '';
+    }
     if (state.selectedTileId === id) {
       token.classList.add('active');
     }
-    token.style.background = config.fill || '#ffffff';
     token.innerHTML = `<strong>${id}</strong><span>${config.fill || ''}</span>`;
     token.title = config.walkable ? 'Walkable' : 'Blocked';
     token.addEventListener('click', () => {
@@ -1029,8 +1039,18 @@ function renderZoneGrid() {
       cell.dataset.y = y;
       const tileId = zone.tiles[y][x];
       const tileConfig = state.tileConfig[tileId] || {};
-      cell.style.background = tileConfig.fill || '#ffffff';
-      cell.textContent = tileId;
+      cell.dataset.tileId = tileId;
+      if (tileConfig.sprite) {
+        cell.style.backgroundImage = `url(${tileConfig.sprite})`;
+        cell.style.backgroundSize = 'cover';
+        cell.style.backgroundPosition = 'center';
+        cell.style.backgroundColor = tileConfig.fill || '#ffffff';
+        cell.textContent = '';
+      } else {
+        cell.style.backgroundImage = '';
+        cell.style.backgroundColor = tileConfig.fill || '#ffffff';
+        cell.textContent = tileId;
+      }
       if (tileConfig.walkable === false) {
         cell.classList.add('not-walkable');
       } else {


### PR DESCRIPTION
## Summary
- render palette tiles with their associated sprite artwork when available
- display zone grid cells with sprite backgrounds so worlds mirror the sprite tab
- adjust styling so sprite-backed tiles stay readable in the retro theme

## Testing
- npm start *(fails: querySrv ENOTFOUND for MongoDB service in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df89e5b8548320bbb10d9a62c6eaf9