### PR TITLE
Add sprite support for world enemies

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,8 @@ function sanitizeEnemyTemplatePayload(payload) {
         .filter(value => value !== null && value !== "")
     : [];
   const equipment = payload.equipment && typeof payload.equipment === "object" ? payload.equipment : {};
+  const spriteRaw = typeof payload.sprite === "string" ? payload.sprite.trim() : "";
+  const sprite = spriteRaw ? spriteRaw : null;
   const attributes = payload.attributes && typeof payload.attributes === "object" ? payload.attributes : {};
   return {
     templateId: id,
@@ -178,6 +180,7 @@ function sanitizeEnemyTemplatePayload(payload) {
     xpPct: Number(payload.xpPct ?? payload.xp ?? 0) || 0,
     gold: Number.parseInt(payload.gold ?? 0, 10) || 0,
     spawnChance: Number(payload.spawnChance ?? 0) || 0,
+    sprite,
   };
 }
 

--- a/models/EnemyTemplate.js
+++ b/models/EnemyTemplate.js
@@ -15,6 +15,7 @@ const EnemyTemplateSchema = new mongoose.Schema(
   {
     templateId: { type: String, required: true, trim: true, unique: true },
     name: { type: String, required: true, trim: true },
+    sprite: { type: String, trim: true, default: null },
     basicType: { type: String, default: 'melee', trim: true },
     level: { type: Number, default: 1 },
     attributes: { type: AttributeSchema, default: () => ({}) },

--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -117,6 +117,10 @@ function normalizeTemplates(rawTemplates) {
         ? Number(template.spawnChance)
         : parseFloat(template.spawnChance);
       const spawnChance = Number.isFinite(spawnChanceRaw) ? Math.max(0, spawnChanceRaw) : 1;
+      const sprite =
+        typeof template.sprite === 'string' && template.sprite.trim()
+          ? template.sprite.trim()
+          : null;
       return {
         id: template.id || uuid(),
         name: typeof template.name === 'string' && template.name ? template.name : 'Wild Foe',
@@ -128,6 +132,7 @@ function normalizeTemplates(rawTemplates) {
         xpPct: Number.isFinite(template.xpPct) ? Math.max(0.01, template.xpPct) : 0.06,
         gold: Number.isFinite(template.gold) ? Math.max(1, Math.round(template.gold)) : 7,
         spawnChance,
+        sprite,
       };
     })
     .filter(Boolean);
@@ -470,6 +475,7 @@ function serializeEnemiesForClient(state) {
     y: enemy.y,
     facing: enemy.facing,
     zoneId: enemy.zoneId || null,
+    sprite: enemy.sprite || null,
   }));
 }
 
@@ -763,6 +769,7 @@ function spawnMissingEnemies(state) {
           zoneId: zone.id,
           facing: 'down',
           updatedAt: now,
+          sprite: template.sprite || null,
         };
         enemyMap.set(enemy.id, enemy);
         enemyPositions.push({ x: enemy.x, y: enemy.y });

--- a/ui/main.js
+++ b/ui/main.js
@@ -1222,21 +1222,38 @@ function renderWorldScene() {
     const screenX = offsetX + renderWidth / 2 + (entry.x + 0.5 - cameraX) * tileSize;
     const screenY = offsetY + renderHeight / 2 + (entry.y + 0.5 - cameraY) * tileSize;
     if (screenX < -tileSize || screenX > width + tileSize || screenY < -tileSize || screenY > height + tileSize) return;
-    const size = Math.max(12, Math.floor(tileSize * 0.65));
-    const drawLeft = Math.round(screenX - size / 2);
-    const drawTop = Math.round(screenY - size / 2);
+    const baseSize = Math.max(12, Math.floor(tileSize * 0.65));
+    let size = baseSize;
+    let drawLeft = Math.round(screenX - size / 2);
+    let drawTop = Math.round(screenY - size / 2);
     worldCtx.save();
     worldCtx.lineWidth = Math.max(1, Math.floor(size / 8));
     if (options.isEnemy) {
-      worldCtx.fillStyle = '#ffffff';
-      worldCtx.fillRect(drawLeft, drawTop, size, size);
-      worldCtx.strokeStyle = '#000000';
-      worldCtx.strokeRect(drawLeft + 0.5, drawTop + 0.5, size, size);
-      const innerSize = Math.max(4, Math.floor(size / 2));
-      const innerLeft = Math.round(drawLeft + (size - innerSize) / 2);
-      const innerTop = Math.round(drawTop + (size - innerSize) / 2);
-      worldCtx.fillStyle = '#000000';
-      worldCtx.fillRect(innerLeft, innerTop, innerSize, innerSize);
+      const sprite = entry.sprite ? getWorldSprite(entry.sprite) : null;
+      if (
+        sprite &&
+        sprite.complete &&
+        sprite.naturalWidth > 0 &&
+        sprite.naturalHeight > 0
+      ) {
+        size = Math.max(tileSize, baseSize);
+        drawLeft = Math.round(screenX - size / 2);
+        drawTop = Math.round(screenY - size / 2);
+        worldCtx.drawImage(sprite, drawLeft, drawTop, size, size);
+        worldCtx.strokeStyle = '#000000';
+        worldCtx.lineWidth = Math.max(1, Math.floor(size / 12));
+        worldCtx.strokeRect(drawLeft + 0.5, drawTop + 0.5, size, size);
+      } else {
+        worldCtx.fillStyle = '#ffffff';
+        worldCtx.fillRect(drawLeft, drawTop, size, size);
+        worldCtx.strokeStyle = '#000000';
+        worldCtx.strokeRect(drawLeft + 0.5, drawTop + 0.5, size, size);
+        const innerSize = Math.max(4, Math.floor(size / 2));
+        const innerLeft = Math.round(drawLeft + (size - innerSize) / 2);
+        const innerTop = Math.round(drawTop + (size - innerSize) / 2);
+        worldCtx.fillStyle = '#000000';
+        worldCtx.fillRect(innerLeft, innerTop, innerSize, innerSize);
+      }
     } else {
       const fill = options.isYou ? '#ffffff' : '#000000';
       const border = options.isYou ? '#000000' : '#ffffff';
@@ -1309,6 +1326,10 @@ function handleWorldStateUpdate(data) {
           y: Number.isFinite(enemy.y) ? enemy.y : 0,
           facing: enemy.facing || 'down',
           zoneId,
+          sprite:
+            typeof enemy.sprite === 'string' && enemy.sprite.trim()
+              ? enemy.sprite.trim()
+              : null,
         });
       });
     }

--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -245,6 +245,38 @@ body.world-builder {
   gap:12px;
 }
 
+.enemy-sprite-field {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.enemy-sprite-field select {
+  border:1px solid #000;
+  background:#fff;
+  padding:4px;
+  font-family:'Courier New', monospace;
+}
+
+.enemy-sprite-preview {
+  border:1px solid #000;
+  background:#fff;
+  min-height:60px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:4px;
+  font-size:12px;
+  gap:4px;
+}
+
+.enemy-sprite-preview img {
+  width:56px;
+  height:56px;
+  object-fit:contain;
+  image-rendering:pixelated;
+}
+
 .enemy-attributes,
 .enemy-economy,
 .enemy-rotation,
@@ -340,6 +372,45 @@ body.world-builder {
 .enemy-template.active {
   background:#000;
   color:#fff;
+}
+
+.enemy-template-info {
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+  font-size:12px;
+}
+
+.enemy-template-info strong {
+  font-size:14px;
+}
+
+.enemy-template-preview {
+  width:56px;
+  height:56px;
+  border:1px solid #000;
+  background:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  image-rendering:pixelated;
+}
+
+.enemy-template-preview img {
+  width:100%;
+  height:100%;
+  object-fit:contain;
+  image-rendering:pixelated;
+}
+
+.enemy-template-preview span {
+  font-size:18px;
+  color:#000;
+}
+
+.enemy-template.active .enemy-template-preview {
+  border-color:#fff;
+  background:#fff;
 }
 
 .enemy-template .actions {
@@ -448,6 +519,37 @@ body.world-builder {
   gap:8px;
 }
 
+.zone-enemy-row {
+  align-items:center;
+}
+
+.zone-enemy-info {
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+
+.zone-enemy-text {
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+  font-size:12px;
+}
+
+.zone-enemy-text strong {
+  font-size:13px;
+}
+
+.zone-enemy-id {
+  font-size:11px;
+  opacity:0.85;
+}
+
+.zone-enemy-coords {
+  font-size:11px;
+  opacity:0.7;
+}
+
 .zone-subsection button {
   border:1px solid #000;
   background:#fff;
@@ -482,6 +584,20 @@ body.world-builder {
   cursor:pointer;
   background-size:cover;
   background-position:center;
+}
+
+.zone-cell-enemy {
+  position:absolute;
+  inset:4px;
+  background-repeat:no-repeat;
+  background-position:center;
+  background-size:contain;
+  image-rendering:pixelated;
+  pointer-events:none;
+}
+
+.zone-cell.has-enemy-sprite::after {
+  display:none;
 }
 
 .zone-cell.has-enemy::after {

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -228,6 +228,15 @@
                   Name
                   <input id="enemy-name" type="text" placeholder="Wild Sprig" required />
                 </label>
+                <label class="field-label enemy-sprite-field">
+                  Sprite
+                  <select id="enemy-sprite-select">
+                    <option value="">None (Default)</option>
+                  </select>
+                </label>
+                <div class="enemy-sprite-preview" id="enemy-sprite-preview">
+                  <span>No sprite selected</span>
+                </div>
                 <label class="field-label">
                   Basic Type
                   <select id="enemy-basic-type">


### PR DESCRIPTION
## Summary
- add sprite support to enemy templates in the API and persistence schema
- enhance the world builder to select, preview, and export enemy sprites alongside new UI cues
- render enemy sprites inside the game world canvas while keeping retro styling cues

## Testing
- node --check index.js
- node --check systems/worldService.js
- node --check ui/world-builder.js
- node --check ui/main.js

------
https://chatgpt.com/codex/tasks/task_e_68df8d94ae84832096ccd30ef7c01aae