### PR TITLE
Remove enemy sprite border in world mode

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -1240,9 +1240,6 @@ function renderWorldScene() {
         drawLeft = Math.round(screenX - size / 2);
         drawTop = Math.round(screenY - size / 2);
         worldCtx.drawImage(sprite, drawLeft, drawTop, size, size);
-        worldCtx.strokeStyle = '#000000';
-        worldCtx.lineWidth = Math.max(1, Math.floor(size / 12));
-        worldCtx.strokeRect(drawLeft + 0.5, drawTop + 0.5, size, size);
       } else {
         worldCtx.fillStyle = '#ffffff';
         worldCtx.fillRect(drawLeft, drawTop, size, size);


### PR DESCRIPTION
## Summary
- stop stroking a border when drawing enemy sprites in world mode to avoid the black outline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e012212cac8320a3f34dc0e04d7cf0