### PR TITLE
Refine world builder painting tools

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -207,6 +207,7 @@ body.world-builder {
 .sprite-actions button,
 .palette-tile button,
 .mode-button,
+.tile-tool-button,
 #add-zone,
 #generate-world,
 #load-world,
@@ -222,9 +223,26 @@ body.world-builder {
   box-shadow:2px 2px 0 #000;
 }
 
-.mode-button.active {
+.mode-button.active,
+.tile-tool-button.active {
   background:#000;
   color:#fff;
+}
+
+.tile-tool-controls {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  flex-wrap:wrap;
+}
+
+.tile-tool-controls .mode-label {
+  font-size:12px;
+  letter-spacing:1px;
+}
+
+.tile-tool-button {
+  min-width:84px;
 }
 
 .enemy-form {
@@ -637,73 +655,30 @@ body.world-builder {
 }
 
 .zone-grid {
-  display:grid;
-  gap:2px;
-}
-
-.zone-cell {
-  width:32px;
-  height:32px;
-  border:1px solid #000;
-  background:#fff;
-  font-size:10px;
-  display:flex;
-  align-items:center;
-  justify-content:center;
   position:relative;
-  cursor:pointer;
-  background-size:cover;
-  background-position:center;
+  display:inline-block;
+  background:#fff;
+  box-shadow:inset 0 0 0 1px #000;
 }
 
-.zone-cell-enemy {
-  position:absolute;
-  inset:4px;
-  background-repeat:no-repeat;
-  background-position:center;
-  background-size:contain;
+.zone-grid canvas {
+  display:block;
+}
+
+.zone-grid-canvas {
   image-rendering:pixelated;
   pointer-events:none;
 }
 
-.zone-cell.has-enemy-sprite::after {
-  display:none;
+.zone-grid-overlay {
+  position:absolute;
+  inset:0;
+  image-rendering:pixelated;
+  cursor:crosshair;
 }
 
-.zone-cell.has-enemy::after {
-  content:"E";
-  position:absolute;
-  bottom:2px;
-  right:2px;
-  font-weight:bold;
-  font-size:11px;
-}
-
-.zone-cell.has-transport::after {
-  content:"⇄";
-  position:absolute;
-  top:2px;
-  right:2px;
-  font-weight:bold;
-  font-size:11px;
-}
-
-.zone-cell.is-spawn::after {
-  content:"S";
-  position:absolute;
-  top:2px;
-  left:2px;
-  font-weight:bold;
-  font-size:11px;
-}
-
-.zone-cell.not-walkable::before {
-  content:"✕";
-  position:absolute;
-  top:2px;
-  left:2px;
-  font-weight:bold;
-  font-size:11px;
+.zone-grid-overlay.is-non-tile {
+  cursor:pointer;
 }
 
 .sprite-layout,

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -118,6 +118,18 @@
                   <button data-mode="transport" class="mode-button">Transports</button>
                   <button data-mode="spawn" class="mode-button">Spawn</button>
                 </div>
+                <div class="tile-tool-controls" id="tile-tool-controls">
+                  <span class="mode-label">Tile Tool:</span>
+                  <button type="button" class="tile-tool-button active" data-tool="brush">
+                    Brush
+                  </button>
+                  <button type="button" class="tile-tool-button" data-tool="fill">
+                    Fill
+                  </button>
+                  <button type="button" class="tile-tool-button" data-tool="rectangle">
+                    Rectangle
+                  </button>
+                </div>
                 <div class="transport-controls hidden" id="transport-controls">
                   <label>
                     Target Zone


### PR DESCRIPTION
## Summary
- replace the world builder tile grid of individual HTML buttons with a layered canvas renderer
- add brush, fill, and rectangle tile tools with drag painting support and improved overlays for enemies, transports, and spawn points
- refresh the toolbar and styling to accommodate the new canvas-based workflow

## Testing
- npm start *(fails: MongoDB connection string required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0440c27408320887d5bad0f3adc06