### PR TITLE
Fix sprite tile rendering to not require fill colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,8 @@ function sanitizePaletteTiles(tiles) {
     if (!tileId || !sprite) {
       return;
     }
-    const fill = typeof tile.fill === "string" && tile.fill.trim() ? tile.fill.trim() : "#ffffff";
+    const rawFill = typeof tile.fill === "string" ? tile.fill.trim() : "";
+    const fill = rawFill || (sprite ? "" : "#ffffff");
     const walkable = Boolean(tile.walkable);
     byId.set(tileId, { tileId, sprite, fill, walkable });
   });


### PR DESCRIPTION
## Summary
- skip applying default fills when sprite tiles have no valid color so sprites render correctly on the canvas
- normalize palette fill handling and UI rendering to treat invalid colors as optional when sprites are present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e04837cf608320a1ff10cca6bb9ec3