### PR TITLE
Fix tile drawing recursion by deferring cached image callbacks

### DIFF
--- a/ui/world-builder.js
+++ b/ui/world-builder.js
@@ -1657,7 +1657,9 @@ function loadImageAsset(url, onLoad) {
     imageCache.set(url, entry);
   }
   if (entry.loaded) {
-    if (onLoad) onLoad(entry.image);
+    if (onLoad && !entry.error) {
+      Promise.resolve().then(() => onLoad(entry.image));
+    }
   } else if (onLoad && !entry.error) {
     entry.callbacks.push(onLoad);
   }


### PR DESCRIPTION
## Summary
- defer cached image callbacks in the world builder to avoid recursive draw loops when images are already loaded

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e0650d110c832081de5360b9de506b