### PR TITLE
Fix world builder canvas input compatibility

### DIFF
--- a/ui/world-builder.js
+++ b/ui/world-builder.js
@@ -581,6 +581,8 @@ const state = {
 
 const imageCache = new Map();
 
+const pointerEventsSupported = typeof window !== 'undefined' && 'PointerEvent' in window;
+
 const zoneCanvasState = {
   baseCanvas: null,
   overlayCanvas: null,
@@ -595,6 +597,42 @@ const zoneCanvasState = {
   lastCell: null,
   previewRect: null,
 };
+
+function normalizeCanvasPointerEvent(event) {
+  if (!event) return null;
+
+  if (typeof event.pointerId !== 'undefined') {
+    return event;
+  }
+
+  const touch = event.changedTouches && event.changedTouches[0];
+  if (touch) {
+    return {
+      pointerId: `touch-${touch.identifier}`,
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+      button: 0,
+      buttons: event.type === 'touchend' || event.type === 'touchcancel' ? 0 : 1,
+      preventDefault: () => event.preventDefault(),
+      originalEvent: event,
+    };
+  }
+
+  return {
+    pointerId: 'mouse',
+    clientX: event.clientX,
+    clientY: event.clientY,
+    button: typeof event.button === 'number' ? event.button : 0,
+    buttons:
+      typeof event.buttons === 'number'
+        ? event.buttons
+        : event.type === 'mousedown'
+        ? 1
+        : 0,
+    preventDefault: () => event.preventDefault(),
+    originalEvent: event,
+  };
+}
 
 function setActiveTab(tabId) {
   if (!tabId) {
@@ -1830,14 +1868,16 @@ function resetZoneCanvasPointerState() {
 function getTileCoordsFromEvent(event) {
   const zone = getSelectedZone();
   if (!zone || !zoneCanvasState.overlayCanvas) return null;
+  const normalized = normalizeCanvasPointerEvent(event);
+  if (!normalized) return null;
   const rect = zoneCanvasState.overlayCanvas.getBoundingClientRect();
   if (!rect.width || !rect.height) return null;
   const width = zone.width * zoneCanvasState.cellSize;
   const height = zone.height * zoneCanvasState.cellSize;
   const scaleX = width / rect.width;
   const scaleY = height / rect.height;
-  const canvasX = (event.clientX - rect.left) * scaleX;
-  const canvasY = (event.clientY - rect.top) * scaleY;
+  const canvasX = (normalized.clientX - rect.left) * scaleX;
+  const canvasY = (normalized.clientY - rect.top) * scaleY;
   const x = Math.floor(canvasX / zoneCanvasState.cellSize);
   const y = Math.floor(canvasY / zoneCanvasState.cellSize);
   if (x < 0 || y < 0 || x >= zone.width || y >= zone.height) {
@@ -1849,10 +1889,12 @@ function getTileCoordsFromEvent(event) {
 function handleZonePointerDown(event) {
   const zone = getSelectedZone();
   if (!zone) return;
+  const normalized = normalizeCanvasPointerEvent(event);
+  if (!normalized) return;
   const coords = getTileCoordsFromEvent(event);
   if (!coords) return;
 
-  if (event.button === 2) {
+  if (normalized.button === 2) {
     event.preventDefault();
     const changed = applySecondaryAction(zone, coords.x, coords.y);
     if (changed) {
@@ -1872,13 +1914,15 @@ function handleZonePointerDown(event) {
     return;
   }
 
-  zoneCanvasState.pointerId = event.pointerId;
+  zoneCanvasState.pointerId = normalized.pointerId;
   zoneCanvasState.startCell = coords;
   zoneCanvasState.lastCell = coords;
 
   if (state.editMode === 'tile') {
     if (state.tileTool === 'brush') {
-      zoneCanvasState.overlayCanvas.setPointerCapture(event.pointerId);
+      if (pointerEventsSupported && zoneCanvasState.overlayCanvas.setPointerCapture && typeof event.pointerId !== 'undefined') {
+        zoneCanvasState.overlayCanvas.setPointerCapture(event.pointerId);
+      }
       zoneCanvasState.dragging = true;
       if (applyTileBrush(zone, coords.x, coords.y, state.selectedTileId)) {
         refreshZoneTiles();
@@ -1889,7 +1933,9 @@ function handleZonePointerDown(event) {
       }
       resetZoneCanvasPointerState();
     } else if (state.tileTool === 'rectangle') {
-      zoneCanvasState.overlayCanvas.setPointerCapture(event.pointerId);
+      if (pointerEventsSupported && zoneCanvasState.overlayCanvas.setPointerCapture && typeof event.pointerId !== 'undefined') {
+        zoneCanvasState.overlayCanvas.setPointerCapture(event.pointerId);
+      }
       zoneCanvasState.dragging = true;
       zoneCanvasState.previewRect = { start: coords, end: coords };
       refreshZoneOverlay();
@@ -1907,8 +1953,13 @@ function handleZonePointerDown(event) {
 }
 
 function handleZonePointerMove(event) {
-  if (!zoneCanvasState.dragging || zoneCanvasState.pointerId !== event.pointerId) {
+  const normalized = normalizeCanvasPointerEvent(event);
+  if (!normalized) return;
+  if (!zoneCanvasState.dragging || zoneCanvasState.pointerId !== normalized.pointerId) {
     return;
+  }
+  if (event.cancelable) {
+    event.preventDefault();
   }
   const zone = getSelectedZone();
   if (!zone || zoneCanvasState.zoneId !== zone.id) {
@@ -1934,10 +1985,16 @@ function handleZonePointerMove(event) {
 }
 
 function handleZonePointerUp(event) {
-  if (zoneCanvasState.pointerId !== event.pointerId) {
+  const normalized = normalizeCanvasPointerEvent(event);
+  if (!normalized) return;
+  if (zoneCanvasState.pointerId !== normalized.pointerId) {
     return;
   }
-  if (zoneCanvasState.overlayCanvas?.hasPointerCapture(event.pointerId)) {
+  if (
+    pointerEventsSupported &&
+    typeof event.pointerId !== 'undefined' &&
+    zoneCanvasState.overlayCanvas?.hasPointerCapture?.(event.pointerId)
+  ) {
     zoneCanvasState.overlayCanvas.releasePointerCapture(event.pointerId);
   }
   const zone = getSelectedZone();
@@ -1953,10 +2010,16 @@ function handleZonePointerUp(event) {
 }
 
 function handleZonePointerCancel(event) {
-  if (zoneCanvasState.pointerId !== event.pointerId) {
+  const normalized = normalizeCanvasPointerEvent(event);
+  if (!normalized) return;
+  if (zoneCanvasState.pointerId !== normalized.pointerId) {
     return;
   }
-  if (zoneCanvasState.overlayCanvas?.hasPointerCapture(event.pointerId)) {
+  if (
+    pointerEventsSupported &&
+    typeof event.pointerId !== 'undefined' &&
+    zoneCanvasState.overlayCanvas?.hasPointerCapture?.(event.pointerId)
+  ) {
     zoneCanvasState.overlayCanvas.releasePointerCapture(event.pointerId);
   }
   zoneCanvasState.previewRect = null;
@@ -2015,11 +2078,24 @@ function renderZoneGrid() {
   zoneCanvasState.previewRect = null;
   resetZoneCanvasPointerState();
 
-  overlayCanvas.addEventListener('pointerdown', handleZonePointerDown);
-  overlayCanvas.addEventListener('pointermove', handleZonePointerMove);
-  overlayCanvas.addEventListener('pointerup', handleZonePointerUp);
-  overlayCanvas.addEventListener('pointercancel', handleZonePointerCancel);
-  overlayCanvas.addEventListener('pointerleave', handleZonePointerCancel);
+  overlayCanvas.style.touchAction = 'none';
+
+  if (pointerEventsSupported) {
+    overlayCanvas.addEventListener('pointerdown', handleZonePointerDown);
+    overlayCanvas.addEventListener('pointermove', handleZonePointerMove);
+    overlayCanvas.addEventListener('pointerup', handleZonePointerUp);
+    overlayCanvas.addEventListener('pointercancel', handleZonePointerCancel);
+    overlayCanvas.addEventListener('pointerleave', handleZonePointerCancel);
+  } else {
+    overlayCanvas.addEventListener('mousedown', handleZonePointerDown);
+    overlayCanvas.addEventListener('mousemove', handleZonePointerMove);
+    overlayCanvas.addEventListener('mouseup', handleZonePointerUp);
+    overlayCanvas.addEventListener('mouseleave', handleZonePointerCancel);
+    overlayCanvas.addEventListener('touchstart', handleZonePointerDown, { passive: false });
+    overlayCanvas.addEventListener('touchmove', handleZonePointerMove, { passive: false });
+    overlayCanvas.addEventListener('touchend', handleZonePointerUp);
+    overlayCanvas.addEventListener('touchcancel', handleZonePointerCancel);
+  }
   overlayCanvas.addEventListener('contextmenu', event => event.preventDefault());
 
   drawZoneTiles(zone);


### PR DESCRIPTION
## Summary
- normalize canvas input events so the world builder can interpret mouse and touch input when Pointer Events are unavailable
- add mouse and touch listeners as a fallback and disable touch scrolling on the overlay canvas
- prevent default scrolling while dragging to keep drawing responsive

## Testing
- npm start *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.fwdtteo.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68e0776a99348320b701e908bb13bdcc