### PR TITLE
Refactor world builder tiles to require sprites

### DIFF
--- a/data/worlds.json
+++ b/data/worlds.json
@@ -3,25 +3,18 @@
     "id": "masai_marsh",
     "name": "Masai Marsh",
     "tileSize": 32,
-    "palette": {
-      "0": "#000000",
-      "1": "#ffffff",
-      "2": "#dcdcdc"
-    },
+    "palette": {},
     "tileConfig": {
       "0": {
         "sprite": "/assets/Sprite-0005.png",
-        "fill": "#000000",
         "walkable": true
       },
       "1": {
         "sprite": "/assets/Sprite-0003.png",
-        "fill": "#ffffff",
         "walkable": true
       },
       "2": {
         "sprite": "/assets/Sprite-0004.png",
-        "fill": "#dcdcdc",
         "walkable": true
       }
     },

--- a/index.js
+++ b/index.js
@@ -131,9 +131,8 @@ function sanitizePaletteTiles(tiles) {
     if (!tileId || !sprite) {
       return;
     }
-    const fill = typeof tile.fill === "string" && tile.fill.trim() ? tile.fill.trim() : "#ffffff";
-    const walkable = Boolean(tile.walkable);
-    byId.set(tileId, { tileId, sprite, fill, walkable });
+    const walkable = tile.walkable !== false;
+    byId.set(tileId, { tileId, sprite, walkable });
   });
   return Array.from(byId.values());
 }

--- a/models/SpritePalette.js
+++ b/models/SpritePalette.js
@@ -4,7 +4,6 @@ const PaletteTileSchema = new mongoose.Schema(
   {
     tileId: { type: String, required: true },
     sprite: { type: String, required: true },
-    fill: { type: String, default: '#ffffff' },
     walkable: { type: Boolean, default: true },
   },
   { _id: false }

--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -75,24 +75,15 @@ function normalizeTileConfig(raw) {
     if (!value || typeof value !== 'object') {
       return;
     }
-    const sprite = typeof value.sprite === 'string' && value.sprite.trim() ? value.sprite.trim() : null;
-    let fill = null;
-    if (typeof value.fill === 'string') {
-      const rawFill = value.fill.trim().toLowerCase();
-      if (/^#(?:0{3}|f{3}|0{6}|f{6})$/.test(rawFill)) {
-        fill = rawFill.length === 4 ? (rawFill === '#000' ? '#000000' : '#ffffff') : rawFill;
-      }
-    }
-    if (!sprite && !fill) {
+    const sprite =
+      typeof value.sprite === 'string' && value.sprite.trim() ? value.sprite.trim() : null;
+    if (!sprite) {
       return;
     }
-    tileConfig[String(key)] = {};
-    if (sprite) {
-      tileConfig[String(key)].sprite = sprite;
-    }
-    if (fill) {
-      tileConfig[String(key)].fill = fill;
-    }
+    tileConfig[String(key)] = {
+      sprite,
+      walkable: value.walkable !== false,
+    };
   });
   return tileConfig;
 }

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -205,10 +205,6 @@
                 <span>Tile ID</span>
                 <input id="sprite-tile-id" type="text" placeholder="e.g. 5" />
               </label>
-              <label class="field-inline">
-                <span>Fill</span>
-                <input id="sprite-fill" type="text" placeholder="#ffffff" />
-              </label>
               <label class="field-label">
                 Sprite Path
                 <input id="sprite-asset-path" type="text" placeholder="/assets/Sprite.png" />


### PR DESCRIPTION
## Summary
- remove tile fill configuration from the world builder UI so tiles always render with their sprite
- update palette storage, world export, and server normalization to work with sprite-only tiles
- refresh sample world data to drop obsolete fill values

## Testing
- npm start *(fails: MongoDB cluster DNS is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e07ba8445883209a5c6475de2ada18