### PR TITLE
Remove gaps between world builder tiles

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -638,13 +638,12 @@ body.world-builder {
 
 .zone-grid {
   display:grid;
-  gap:2px;
+  gap:0;
 }
 
 .zone-cell {
   width:32px;
   height:32px;
-  border:1px solid #000;
   background:#fff;
   font-size:10px;
   display:flex;
@@ -654,6 +653,11 @@ body.world-builder {
   cursor:pointer;
   background-size:cover;
   background-position:center;
+  image-rendering:pixelated;
+}
+
+.zone-cell:hover {
+  box-shadow:inset 0 0 0 2px rgba(0, 0, 0, 0.4);
 }
 
 .zone-cell-enemy {


### PR DESCRIPTION
## Summary
- remove the CSS grid gap between zone cells so tiles touch without white seams
- drop the default border on each zone cell and add pixelated rendering for sharper sprites
- add a hover-only inset outline so editors can still see the active cell while painting

## Testing
- not run (Mongo connection required for `npm start` fails in container)


------
https://chatgpt.com/codex/tasks/task_e_68e088fd8c6c8320894ace2767b22088