### PR TITLE
Add tile brush control to world builder

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -531,6 +531,30 @@ body.world-builder {
   align-items:center;
 }
 
+.tile-controls {
+  display:flex;
+  align-items:center;
+  gap:12px;
+  font-size:12px;
+  text-transform:uppercase;
+}
+
+.brush-control {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  text-transform:uppercase;
+}
+
+.brush-control input {
+  width:64px;
+  border:1px solid #000;
+  padding:4px;
+  font-family:'Courier New', monospace;
+  background:#fff;
+  color:#000;
+}
+
 .transport-controls label {
   display:flex;
   flex-direction:column;

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -118,6 +118,12 @@
                   <button data-mode="transport" class="mode-button">Transports</button>
                   <button data-mode="spawn" class="mode-button">Spawn</button>
                 </div>
+                <div class="tile-controls" id="tile-controls">
+                  <label class="brush-control" for="brush-size">
+                    <span>Brush Size</span>
+                    <input id="brush-size" type="number" min="1" max="25" value="1" />
+                  </label>
+                </div>
                 <div class="transport-controls hidden" id="transport-controls">
                   <label>
                     Target Zone


### PR DESCRIPTION
## Summary
- add a brush size control to the world builder toolbar so tile edits can cover multiple cells at once
- implement brush-aware painting and clearing logic that updates all tiles inside the selected brush footprint
- style and toggle the new control alongside existing edit mode tooling

## Testing
- npm start *(fails: Mongo connection string not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08db082608320b6377f4467d62864