### PR TITLE
Remove zone tile button borders in world builder

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -678,10 +678,22 @@ body.world-builder {
   background-size:cover;
   background-position:center;
   image-rendering:pixelated;
+  border:0;
+  padding:0;
+  margin:0;
+  box-sizing:border-box;
 }
 
 .zone-cell:hover {
   box-shadow:inset 0 0 0 2px rgba(0, 0, 0, 0.4);
+}
+
+.zone-cell:focus {
+  outline:none;
+}
+
+.zone-cell:focus-visible {
+  box-shadow:inset 0 0 0 2px rgba(0, 0, 0, 0.6);
 }
 
 .zone-cell-enemy {


### PR DESCRIPTION
## Summary
- remove default button borders and spacing from zone tiles so they render flush without gaps
- add a custom focus-visible style to keep an accessible focus indicator without a persistent outline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e09182a8548320b4a7346e58f10da8