### PR TITLE
Add NPC support with dialogue and builder tooling

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ const {
   subscribe: subscribeToWorld,
   runEncounter: runWorldEncounter,
   createWorldInstance,
+  interact: interactWithWorld,
 } = require("./systems/worldService");
 const {
   queueForWorld,
@@ -437,6 +438,25 @@ app.post("/worlds/:worldId/move", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(400).json({ error: err.message || "failed to move" });
+  }
+});
+
+app.post("/worlds/:worldId/interact", async (req, res) => {
+  const worldId = req.params.worldId;
+  const { characterId, instanceId } = req.body || {};
+  if (!characterId || !instanceId) {
+    return res.status(400).json({ error: "characterId and instanceId required" });
+  }
+  try {
+    const numericId = Number(characterId);
+    if (!Number.isInteger(numericId)) {
+      return res.status(400).json({ error: "characterId must be an integer" });
+    }
+    const payload = await interactWithWorld(worldId, instanceId, numericId);
+    res.json(payload || { result: "none" });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to interact" });
   }
 });
 

--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -753,6 +753,108 @@ body.world-builder {
   gap:16px;
 }
 
+.npc-layout {
+  display:grid;
+  grid-template-columns:320px 1fr;
+  gap:16px;
+}
+
+.npc-list {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  max-height:420px;
+  overflow:auto;
+}
+
+.npc-item {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  border:1px solid #000;
+  padding:8px;
+  background:#fdfdfd;
+  text-transform:uppercase;
+  gap:8px;
+  cursor:pointer;
+}
+
+.npc-item.active {
+  background:#000;
+  color:#fff;
+}
+
+.npc-item .npc-meta {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:12px;
+}
+
+.npc-item .npc-position {
+  font-size:11px;
+  letter-spacing:1px;
+}
+
+.npc-sprite-preview {
+  border:1px solid #000;
+  min-height:100px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:#fdfdfd;
+  margin:8px 0;
+}
+
+.npc-sprite-preview img {
+  width:96px;
+  height:96px;
+  image-rendering:pixelated;
+}
+
+.npc-form-actions {
+  display:flex;
+  gap:8px;
+  margin-top:12px;
+}
+
+.npc-form-actions .danger {
+  background:#000;
+  color:#fff;
+}
+
+.npc-mode-info {
+  display:flex;
+  gap:6px;
+  align-items:center;
+  font-size:12px;
+  text-transform:uppercase;
+}
+
+.zone-cell.has-npc::after {
+  content:'NPC';
+  position:absolute;
+  bottom:2px;
+  right:2px;
+  font-size:10px;
+  background:#000;
+  color:#fff;
+  padding:1px 3px;
+}
+
+.zone-cell-npc {
+  position:absolute;
+  inset:3px;
+  border:1px solid #000;
+  background:rgba(255, 255, 255, 0.8);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  pointer-events:none;
+  font-size:12px;
+  text-transform:uppercase;
+}
+
 .sprite-actions {
   display:flex;
   gap:8px;

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -25,6 +25,7 @@
         <button type="button" class="tab-button active" data-tab="world">World</button>
         <button type="button" class="tab-button" data-tab="sprites">Sprites</button>
         <button type="button" class="tab-button" data-tab="enemies">Enemies</button>
+        <button type="button" class="tab-button" data-tab="npcs">NPCs</button>
       </nav>
 
       <section class="builder-tab active" data-tab-panel="world">
@@ -115,6 +116,7 @@
                   <span class="mode-label">Edit Mode:</span>
                   <button data-mode="tile" class="mode-button active">Tiles</button>
                   <button data-mode="enemy" class="mode-button">Enemies</button>
+                  <button data-mode="npc" class="mode-button">NPCs</button>
                   <button data-mode="transport" class="mode-button">Transports</button>
                   <button data-mode="spawn" class="mode-button">Spawn</button>
                 </div>
@@ -142,6 +144,10 @@
                 <div class="enemy-mode-info hidden" id="enemy-mode-info">
                   <span>Placement Target:</span>
                   <span id="enemy-placement-target">None Selected</span>
+                </div>
+                <div class="npc-mode-info hidden" id="npc-mode-info">
+                  <span>NPC Target:</span>
+                  <span id="npc-placement-target">None Selected</span>
                 </div>
               </div>
               <div id="zone-details" class="zone-details"></div>
@@ -291,6 +297,63 @@
           <section class="panel enemy-library-panel">
             <h2>Saved Enemy Templates</h2>
             <div id="enemy-template-list" class="enemy-template-list"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="builder-tab" data-tab-panel="npcs">
+        <div class="npc-layout">
+          <section class="panel npc-list-panel">
+            <div class="panel-header">
+              <h2>NPCs</h2>
+              <button type="button" id="npc-create">New NPC</button>
+            </div>
+            <div id="npc-list" class="npc-list"></div>
+          </section>
+
+          <section class="panel npc-editor-panel">
+            <h2>NPC Details</h2>
+            <form id="npc-form" class="npc-form">
+              <label class="field-label">
+                NPC ID
+                <input id="npc-id" type="text" placeholder="village_elder" />
+              </label>
+              <label class="field-label">
+                Name
+                <input id="npc-name" type="text" placeholder="Village Elder" />
+              </label>
+              <label class="field-label">
+                Facing
+                <select id="npc-facing">
+                  <option value="down">Down</option>
+                  <option value="up">Up</option>
+                  <option value="left">Left</option>
+                  <option value="right">Right</option>
+                </select>
+              </label>
+              <label class="field-label">
+                Sprite
+                <select id="npc-sprite-select">
+                  <option value="">None (Default)</option>
+                </select>
+              </label>
+              <div class="npc-sprite-preview" id="npc-sprite-preview">
+                <span>No sprite selected</span>
+              </div>
+              <label class="field-label">
+                Dialogue Lines
+                <textarea
+                  id="npc-dialog"
+                  rows="5"
+                  placeholder="Enter one line per message..."
+                ></textarea>
+              </label>
+              <p class="panel-note">Place NPCs from the World tab using the NPC edit mode.</p>
+              <div class="npc-form-actions">
+                <button type="submit" id="npc-save">Save NPC</button>
+                <button type="button" id="npc-delete" class="danger">Delete NPC</button>
+              </div>
+            </form>
           </section>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add NPC normalization, serialization, and interaction handling to the world service
- expose a world interaction endpoint for NPC conversations
- render NPCs and in-canvas dialog overlays on the world client
- expand the world builder with NPC management UI, placement mode, and styling updates

## Testing
- no automated tests were run (not available)
- attempted to start the Node server but MongoDB was unavailable
- captured a screenshot of the updated world builder NPC tab

------
https://chatgpt.com/codex/tasks/task_e_68e09f1bef788320beefb82d840b3320