### PR TITLE
Ensure zone enemy placements spawn specified templates

### DIFF
--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -864,6 +864,94 @@ function spawnMissingEnemies(state) {
     if (!zone || !Array.isArray(zone.walkableTiles) || !zone.walkableTiles.length) {
       return;
     }
+    const enemyPlacements = Array.isArray(zone.enemyPlacements) ? zone.enemyPlacements : [];
+    if (enemyPlacements.length) {
+      const existingByKey = new Map();
+      const enemiesToRemove = [];
+      enemyMap.forEach(enemy => {
+        if (enemy.zoneId === zone.id) {
+          const key = positionKey(zone.id, enemy.x, enemy.y);
+          existingByKey.set(key, enemy);
+        }
+      });
+
+      const placementKeys = new Set();
+      enemyPlacements.forEach(rawPlacement => {
+        if (!rawPlacement) return;
+        const x = Number.isFinite(rawPlacement.x)
+          ? Math.max(0, Math.round(rawPlacement.x))
+          : Math.max(0, parseInt(rawPlacement.x, 10) || 0);
+        const y = Number.isFinite(rawPlacement.y)
+          ? Math.max(0, Math.round(rawPlacement.y))
+          : Math.max(0, parseInt(rawPlacement.y, 10) || 0);
+        const key = positionKey(zone.id, x, y);
+        placementKeys.add(key);
+        if (!isWalkableTile(world, zone.id, x, y)) {
+          enemiesToRemove.push(existingByKey.get(key));
+          existingByKey.delete(key);
+          return;
+        }
+        const templateId = rawPlacement.templateId ? String(rawPlacement.templateId) : '';
+        if (!templateId) {
+          enemiesToRemove.push(existingByKey.get(key));
+          existingByKey.delete(key);
+          return;
+        }
+        const template = getEncounterTemplateById(world, templateId);
+        if (!template) {
+          enemiesToRemove.push(existingByKey.get(key));
+          existingByKey.delete(key);
+          return;
+        }
+        const spawnChanceRaw = Number(template.spawnChance);
+        const spawnChance = Number.isFinite(spawnChanceRaw)
+          ? Math.max(0, Math.min(1, spawnChanceRaw))
+          : 1;
+        const existing = existingByKey.get(key);
+        if (spawnChance <= 0) {
+          if (existing) {
+            enemiesToRemove.push(existing);
+            existingByKey.delete(key);
+          }
+          return;
+        }
+        if (existing && existing.templateId === template.id) {
+          return;
+        }
+        if (existing) {
+          enemiesToRemove.push(existing);
+          existingByKey.delete(key);
+        }
+        if (Math.random() > spawnChance) {
+          return;
+        }
+        const enemy = {
+          id: uuid(),
+          templateId: template.id,
+          name: template.name,
+          x,
+          y,
+          zoneId: zone.id,
+          facing: 'down',
+          updatedAt: now,
+          sprite: template.sprite || null,
+        };
+        enemyMap.set(enemy.id, enemy);
+        existingByKey.set(key, enemy);
+      });
+
+      existingByKey.forEach((enemy, key) => {
+        if (!placementKeys.has(key)) {
+          enemiesToRemove.push(enemy);
+        }
+      });
+
+      enemiesToRemove.filter(Boolean).forEach(enemy => {
+        enemyMap.delete(enemy.id);
+      });
+      return;
+    }
+
     const zoneWalkable = shuffleArray(zone.walkableTiles.slice());
     const occupied = new Set();
     const enemyPositions = [];


### PR DESCRIPTION
## Summary
- ensure zones with configured enemy placements spawn only the selected templates
- normalize placement handling by removing mismatched enemies and honoring spawn chance as a true probability
- fall back to existing random spawning behaviour when no placements are defined

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e17b842bf083208a7aa2af9fb24372