### PR TITLE
Add NPC interaction controls and mobile action buttons

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -88,13 +88,33 @@
               <canvas id="world-canvas" width="640" height="480" aria-label="World view" tabindex="0"></canvas>
             </div>
             <div id="world-message" class="world-message message hidden"></div>
-            <div class="world-dpad-wrapper">
-              <div class="world-dpad" id="world-dpad" role="group" aria-label="Movement controls">
-                <button type="button" class="world-dpad-btn world-dpad-up" data-direction="up" aria-label="Move up">▲</button>
-                <button type="button" class="world-dpad-btn world-dpad-left" data-direction="left" aria-label="Move left">◀</button>
-                <div class="world-dpad-center" aria-hidden="true"></div>
-                <button type="button" class="world-dpad-btn world-dpad-right" data-direction="right" aria-label="Move right">▶</button>
-                <button type="button" class="world-dpad-btn world-dpad-down" data-direction="down" aria-label="Move down">▼</button>
+            <div class="world-mobile-controls">
+              <div class="world-dpad-wrapper">
+                <div class="world-dpad" id="world-dpad" role="group" aria-label="Movement controls">
+                  <button type="button" class="world-dpad-btn world-dpad-up" data-direction="up" aria-label="Move up">▲</button>
+                  <button type="button" class="world-dpad-btn world-dpad-left" data-direction="left" aria-label="Move left">◀</button>
+                  <div class="world-dpad-center" aria-hidden="true"></div>
+                  <button type="button" class="world-dpad-btn world-dpad-right" data-direction="right" aria-label="Move right">▶</button>
+                  <button type="button" class="world-dpad-btn world-dpad-down" data-direction="down" aria-label="Move down">▼</button>
+                </div>
+              </div>
+              <div class="world-action-wrapper" id="world-actions" role="group" aria-label="Action controls">
+                <button
+                  type="button"
+                  class="world-action-btn world-action-a"
+                  data-action="interact"
+                  aria-label="Interact (E)"
+                >
+                  A
+                </button>
+                <button
+                  type="button"
+                  class="world-action-btn world-action-b"
+                  data-action="cancel"
+                  aria-label="Cancel / Close"
+                >
+                  B
+                </button>
               </div>
             </div>
           </div>
@@ -105,7 +125,11 @@
             </div>
             <div class="world-sidebar-section world-controls">
               <h3>Controls</h3>
-              <p>Use <strong>WASD</strong> or arrow keys to move, or tap the on-screen D-pad below. Encounters may occur in tall grass.</p>
+              <p>
+                Use <strong>WASD</strong> or arrow keys to move, or tap the on-screen controls below. Press
+                <strong>E</strong> (or the on-screen <strong>A</strong> button) to talk to nearby NPCs. Press
+                <strong>Esc</strong> or the <strong>B</strong> button to close dialog.
+              </p>
             </div>
           </aside>
         </div>

--- a/ui/main.js
+++ b/ui/main.js
@@ -162,6 +162,7 @@ let worldPlayerListEl = null;
 let worldTitleEl = null;
 const WORLD_VISIBLE_TILES = 16;
 let worldDpadEl = null;
+let worldActionsEl = null;
 let worldLobbyStatusEl = null;
 let worldWorldSelectEl = null;
 let worldPartySizeSelectEl = null;
@@ -176,6 +177,7 @@ let worldDpadActiveDirection = null;
 let worldDpadRepeatTimer = null;
 let worldDpadPointerId = null;
 let worldDpadLastPointerTs = 0;
+let worldActionLastPointerTs = 0;
 let worldResizeListenerAttached = false;
 let worldDpadBlurListenerAttached = false;
 const worldSpriteCache = new Map();
@@ -589,6 +591,7 @@ function resetWorldState() {
   worldMovementLocked = false;
   worldDialogState = null;
   worldInteractPending = false;
+  worldActionLastPointerTs = 0;
   worldLastMoveAt = 0;
   clearWorldDpadHold();
   updateWorldStatus(currentCharacter ? 'Disconnected' : 'Select a character');
@@ -762,17 +765,33 @@ function ensureWorldTouchControls() {
       worldDpadEl.dataset.worldDpadBound = 'true';
     }
   }
-  if (!worldDpadEl) return;
-  const buttons = worldDpadEl.querySelectorAll('button[data-direction]');
-  buttons.forEach(button => {
-    if (button.dataset.worldDpadBound === 'true') return;
-    button.dataset.worldDpadBound = 'true';
-    button.addEventListener('pointerdown', handleWorldDpadPointerDown);
-    button.addEventListener('pointerup', handleWorldDpadPointerUp);
-    button.addEventListener('pointerleave', handleWorldDpadPointerUp);
-    button.addEventListener('pointercancel', handleWorldDpadPointerUp);
-    button.addEventListener('click', handleWorldDpadClick);
-  });
+  if (worldDpadEl) {
+    const buttons = worldDpadEl.querySelectorAll('button[data-direction]');
+    buttons.forEach(button => {
+      if (button.dataset.worldDpadBound === 'true') return;
+      button.dataset.worldDpadBound = 'true';
+      button.addEventListener('pointerdown', handleWorldDpadPointerDown);
+      button.addEventListener('pointerup', handleWorldDpadPointerUp);
+      button.addEventListener('pointerleave', handleWorldDpadPointerUp);
+      button.addEventListener('pointercancel', handleWorldDpadPointerUp);
+      button.addEventListener('click', handleWorldDpadClick);
+    });
+  }
+  if (worldActionsEl && !document.body.contains(worldActionsEl)) {
+    worldActionsEl = null;
+  }
+  if (!worldActionsEl) {
+    worldActionsEl = document.getElementById('world-actions');
+  }
+  if (worldActionsEl) {
+    const actionButtons = worldActionsEl.querySelectorAll('button[data-action]');
+    actionButtons.forEach(button => {
+      if (button.dataset.worldActionBound === 'true') return;
+      button.dataset.worldActionBound = 'true';
+      button.addEventListener('pointerdown', handleWorldActionPointerDown);
+      button.addEventListener('click', handleWorldActionClick);
+    });
+  }
 }
 
 function startWorldDpadHold(direction) {
@@ -861,6 +880,38 @@ function handleWorldDpadClick(event) {
   }
   event.preventDefault();
   queueWorldMove(direction);
+}
+
+function handleWorldActionPointerDown(event) {
+  if (!isTabActive('world')) return;
+  const button = event.currentTarget;
+  const action = button && button.getAttribute('data-action');
+  if (!action) return;
+  worldActionLastPointerTs = Date.now();
+  event.preventDefault();
+  activateWorldAction(action);
+}
+
+function handleWorldActionClick(event) {
+  const button = event.currentTarget;
+  const action = button && button.getAttribute('data-action');
+  if (!action) return;
+  const now = Date.now();
+  if (now - worldActionLastPointerTs < 250) {
+    event.preventDefault();
+    return;
+  }
+  event.preventDefault();
+  activateWorldAction(action);
+}
+
+function activateWorldAction(action) {
+  if (!action) return;
+  if (action === 'interact') {
+    triggerWorldInteract();
+  } else if (action === 'cancel') {
+    handleWorldCancelAction();
+  }
 }
 
 function setWorldQueueUIState(mode = 'idle') {
@@ -1549,8 +1600,12 @@ function drawWorldDialog() {
 }
 
 function closeWorldDialog() {
+  const hadDialog = !!worldDialogState;
   worldDialogState = null;
   worldMovementLocked = false;
+  if (hadDialog) {
+    renderWorldScene();
+  }
 }
 
 function advanceWorldDialog() {
@@ -1562,7 +1617,16 @@ function advanceWorldDialog() {
     closeWorldDialog();
   } else {
     worldDialogState.index = nextIndex;
+    renderWorldScene();
   }
+}
+
+function handleWorldCancelAction() {
+  if (worldDialogState) {
+    closeWorldDialog();
+    return true;
+  }
+  return false;
 }
 
 function startWorldRenderLoop() {
@@ -1785,10 +1849,9 @@ function handleWorldKeydown(event) {
     return;
   }
   const key = (event.key || event.code || '').toLowerCase();
-  if (key === 'escape') {
-    if (worldDialogState) {
+  if (key === 'escape' || key === 'x' || key === 'b') {
+    if (handleWorldCancelAction()) {
       event.preventDefault();
-      closeWorldDialog();
     }
     return;
   }
@@ -1831,6 +1894,7 @@ async function triggerWorldInteract() {
         index: 0,
       };
       worldMovementLocked = true;
+      renderWorldScene();
     } else if (payload && payload.result === 'none') {
       // No interaction available; do nothing.
     }

--- a/ui/style.css
+++ b/ui/style.css
@@ -3246,9 +3246,19 @@ body.world-canvas-focused .world-focus-exit {
   letter-spacing: 1px;
 }
 
+.world-mobile-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin: 12px auto 0;
+  width: 100%;
+}
+
 .world-dpad-wrapper {
   display: flex;
   justify-content: center;
+  width: 100%;
 }
 
 .world-dpad {
@@ -3261,7 +3271,7 @@ body.world-canvas-focused .world-focus-exit {
     '. down .';
   gap: 8px;
   width: min(280px, 100%);
-  margin: 12px auto;
+  margin: 0 auto;
   touch-action: none;
 }
 
@@ -3312,6 +3322,45 @@ body.world-canvas-focused .world-focus-exit {
   border-radius: 12px;
   background: #000;
   box-shadow: inset 0 0 0 4px #fff;
+}
+
+.world-action-wrapper {
+  display: flex;
+  justify-content: center;
+  gap: clamp(12px, 4vw, 28px);
+  width: min(360px, 100%);
+}
+
+.world-action-btn {
+  width: clamp(64px, 18vw, 88px);
+  height: clamp(64px, 18vw, 88px);
+  border-radius: 50%;
+  border: 3px solid #000;
+  background: #fff;
+  color: #000;
+  font-size: clamp(1.35rem, 4.5vw, 2rem);
+  font-weight: 700;
+  box-shadow: 4px 4px 0 #000;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: transform 0.1s ease;
+}
+
+.world-action-btn:focus-visible {
+  outline: 3px solid #000;
+  outline-offset: 3px;
+}
+
+.world-action-btn:active {
+  transform: translate(1px, 1px);
+}
+
+.world-action-a {
+  background: #42ff8b;
+}
+
+.world-action-b {
+  background: #ff6aa6;
 }
 
 @media (max-width: 960px) {
@@ -3392,7 +3441,7 @@ body.world-canvas-focused .world-focus-exit {
     max-width: none;
   }
 
-  body.world-tab-active .world-dpad-wrapper {
+  body.world-tab-active .world-mobile-controls {
     margin-top: auto;
   }
 
@@ -3460,7 +3509,7 @@ body.world-canvas-focused .world-focus-exit {
     aspect-ratio: unset;
   }
 
-  body.world-tab-active.world-canvas-focused .world-dpad-wrapper {
+  body.world-tab-active.world-canvas-focused .world-mobile-controls {
     position: sticky;
     bottom: 0;
     background: #fff;
@@ -3468,6 +3517,7 @@ body.world-canvas-focused .world-focus-exit {
     border-top: 2px solid #000;
     box-shadow: 0 -6px 0 #000;
     margin-top: auto;
+    gap: 20px;
   }
 
   body.world-tab-active.world-canvas-focused .world-dpad {


### PR DESCRIPTION
## Summary
- add on-screen A/B controls for the world view and wire the A button to NPC interaction
- ensure dialog opens, advances, and closes reliably from both keyboard and touch inputs
- refresh the world UI copy and styles to support the new mobile-friendly control layout

## Testing
- npm start *(fails: requires MongoDB connection in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17d8a68c8832093efe5fd6acab2cc