### PR TITLE
Enable NPC collision dialog and add mobile interact control

### DIFF
--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -1340,6 +1340,7 @@ async function movePlayer(worldId, instanceId, characterId, direction) {
   }
   let moved = false;
   let encounterEnemy = null;
+  let triggeredNpcInteraction = null;
   const zoneBeforeMove = player.zoneId || world.defaultZoneId || null;
   const nextX = player.x + delta.dx;
   const nextY = player.y + delta.dy;
@@ -1353,6 +1354,8 @@ async function movePlayer(worldId, instanceId, characterId, direction) {
       moved = true;
     } else if (blocking.type === 'enemy') {
       encounterEnemy = blocking.entity;
+    } else if (blocking.type === 'npc') {
+      triggeredNpcInteraction = blocking.entity;
     }
   }
   player.facing = delta.facing;
@@ -1448,6 +1451,19 @@ async function movePlayer(worldId, instanceId, characterId, direction) {
     },
     moved: moved || transportTriggered,
     encounter,
+    interaction: triggeredNpcInteraction
+      ? {
+          result: 'npc',
+          npc: {
+            id: triggeredNpcInteraction.id,
+            name: triggeredNpcInteraction.name,
+            dialog: Array.isArray(triggeredNpcInteraction.dialog)
+              ? triggeredNpcInteraction.dialog.slice()
+              : [],
+            sprite: triggeredNpcInteraction.sprite || null,
+          },
+        }
+      : null,
   };
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -89,12 +89,22 @@
             </div>
             <div id="world-message" class="world-message message hidden"></div>
             <div class="world-dpad-wrapper">
-              <div class="world-dpad" id="world-dpad" role="group" aria-label="Movement controls">
-                <button type="button" class="world-dpad-btn world-dpad-up" data-direction="up" aria-label="Move up">▲</button>
-                <button type="button" class="world-dpad-btn world-dpad-left" data-direction="left" aria-label="Move left">◀</button>
-                <div class="world-dpad-center" aria-hidden="true"></div>
-                <button type="button" class="world-dpad-btn world-dpad-right" data-direction="right" aria-label="Move right">▶</button>
-                <button type="button" class="world-dpad-btn world-dpad-down" data-direction="down" aria-label="Move down">▼</button>
+              <div class="world-dpad-controls">
+                <div class="world-dpad" id="world-dpad" role="group" aria-label="Movement controls">
+                  <button type="button" class="world-dpad-btn world-dpad-up" data-direction="up" aria-label="Move up">▲</button>
+                  <button type="button" class="world-dpad-btn world-dpad-left" data-direction="left" aria-label="Move left">◀</button>
+                  <div class="world-dpad-center" aria-hidden="true"></div>
+                  <button type="button" class="world-dpad-btn world-dpad-right" data-direction="right" aria-label="Move right">▶</button>
+                  <button type="button" class="world-dpad-btn world-dpad-down" data-direction="down" aria-label="Move down">▼</button>
+                </div>
+                <button
+                  type="button"
+                  class="world-action-btn"
+                  id="world-action-btn"
+                  aria-label="Interact"
+                >
+                  A
+                </button>
               </div>
             </div>
           </div>
@@ -105,7 +115,11 @@
             </div>
             <div class="world-sidebar-section world-controls">
               <h3>Controls</h3>
-              <p>Use <strong>WASD</strong> or arrow keys to move, or tap the on-screen D-pad below. Encounters may occur in tall grass.</p>
+              <p>
+                Use <strong>WASD</strong> or arrow keys to move, or tap the on-screen D-pad below.
+                Press <strong>E</strong> (or the on-screen <strong>A</strong> button) to interact with NPCs. Encounters may occur in tall
+                grass.
+              </p>
             </div>
           </aside>
         </div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -3251,6 +3251,14 @@ body.world-canvas-focused .world-focus-exit {
   justify-content: center;
 }
 
+.world-dpad-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  width: min(360px, 100%);
+}
+
 .world-dpad {
   display: grid;
   grid-template-columns: repeat(3, minmax(48px, 1fr));
@@ -3314,6 +3322,34 @@ body.world-canvas-focused .world-focus-exit {
   box-shadow: inset 0 0 0 4px #fff;
 }
 
+.world-action-btn {
+  border: 2px solid #000;
+  background: #fff;
+  color: #000;
+  font-size: 1.5rem;
+  font-weight: 700;
+  border-radius: 50%;
+  width: clamp(56px, 18vw, 92px);
+  height: clamp(56px, 18vw, 92px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 3px 3px 0 #000;
+  cursor: pointer;
+  touch-action: manipulation;
+  text-transform: uppercase;
+  transition: transform 0.1s ease;
+}
+
+.world-action-btn:focus-visible {
+  outline: 3px solid #000;
+  outline-offset: 2px;
+}
+
+.world-action-btn:active {
+  transform: translate(1px, 1px);
+}
+
 @media (max-width: 960px) {
   .world-container {
     flex-direction: column;
@@ -3333,6 +3369,11 @@ body.world-canvas-focused .world-focus-exit {
 
   .world-dpad {
     width: 100%;
+  }
+
+  .world-dpad-controls {
+    width: 100%;
+    gap: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- trigger NPC dialog when a player moves into them so conversations open automatically
- centralize NPC dialog handling on the client so both collisions and manual interactions reuse the same flow
- add an on-screen A button with styling and updated instructions to support mobile interaction

## Testing
- Not run (MongoDB-dependent server)


------
https://chatgpt.com/codex/tasks/task_e_68e1843629d083209e195f82a2e13a7d