### PR TITLE
Add NPC shop services to builder and world mode

### DIFF
--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -211,6 +211,31 @@ function normalizeNpcDialog(rawDialog) {
   };
 }
 
+function normalizeNpcService(rawService) {
+  if (!rawService) {
+    return null;
+  }
+  if (typeof rawService === 'string') {
+    const type = rawService.trim().toLowerCase();
+    if (type === 'shop') {
+      return { type: 'shop', shopId: null };
+    }
+    return null;
+  }
+  if (typeof rawService === 'object') {
+    const type = typeof rawService.type === 'string' ? rawService.type.trim().toLowerCase() : '';
+    if (!type) {
+      return null;
+    }
+    if (type === 'shop') {
+      const shopId =
+        typeof rawService.shopId === 'string' && rawService.shopId.trim() ? rawService.shopId.trim() : null;
+      return { type: 'shop', shopId };
+    }
+  }
+  return null;
+}
+
 function sanitizeNpcId(value) {
   const base = typeof value === 'string' ? value : '';
   const sanitized = base.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
@@ -372,6 +397,7 @@ function normalizeNpcs(entry, zones, defaultZoneId) {
     const facingRaw = typeof npcEntry.facing === 'string' ? npcEntry.facing.toLowerCase() : '';
     const facing = VALID_FACING.has(facingRaw) ? facingRaw : 'down';
     const dialog = normalizeNpcDialog(npcEntry.dialog);
+    const service = normalizeNpcService(npcEntry.service);
     const npc = {
       id,
       name,
@@ -381,6 +407,7 @@ function normalizeNpcs(entry, zones, defaultZoneId) {
       y,
       facing,
       dialog,
+      service,
     };
     npcs.push(npc);
     npcMap.set(id, npc);
@@ -519,6 +546,7 @@ function normalizeWorld(entry) {
       y: npc.y,
       facing: npc.facing,
       sprite: npc.sprite || null,
+      service: npc.service || null,
     }));
   });
   const tiles = defaultZone ? defaultZone.tiles : [];
@@ -630,6 +658,7 @@ function sanitizeWorld(world) {
         y: npc.y,
         facing: npc.facing,
         sprite: npc.sprite || null,
+        service: npc.service || null,
       }))
     : [];
   return {
@@ -685,6 +714,7 @@ function serializeNpcsForClient(state) {
     facing: npc.facing || 'down',
     zoneId: npc.zoneId || null,
     sprite: npc.sprite || null,
+    service: npc.service || null,
   }));
 }
 
@@ -1334,6 +1364,7 @@ async function createWorldInstance(worldId, participantIds = []) {
       state.npcs.set(npc.id, {
         ...npc,
         dialog: normalizeNpcDialog(npc.dialog),
+        service: normalizeNpcService(npc.service),
         dialogState: { nextIndex: 0 },
       });
     });
@@ -1750,6 +1781,7 @@ async function interactWithWorld(worldId, instanceId, characterId) {
       name: npc.name,
       dialog: dialogLines.slice(),
       sprite: npc.sprite || null,
+      service: npc.service || null,
     },
   };
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -85,7 +85,16 @@
               </div>
             </div>
             <div class="world-screen">
-              <canvas id="world-canvas" width="640" height="480" aria-label="World view" tabindex="0"></canvas>
+              <div class="world-canvas-stack">
+                <canvas id="world-canvas" width="640" height="480" aria-label="World view" tabindex="0"></canvas>
+                <canvas
+                  id="world-shop-canvas"
+                  class="world-shop-canvas hidden"
+                  width="640"
+                  height="480"
+                  aria-hidden="true"
+                ></canvas>
+              </div>
             </div>
             <div id="world-message" class="world-message message hidden"></div>
             <div class="world-dpad-wrapper">

--- a/ui/style.css
+++ b/ui/style.css
@@ -2957,6 +2957,30 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   width: 100%;
 }
 
+.world-canvas-stack {
+  position: relative;
+  width: min(100%, 960px);
+}
+
+.world-canvas-stack canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+#world-shop-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;
+}
+
+#world-shop-canvas.hidden {
+  pointer-events: none;
+}
+
 .world-header {
   display: flex;
   justify-content: space-between;

--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -872,6 +872,16 @@ body.world-builder {
   font-size:12px;
 }
 
+.npc-item .npc-service-label {
+  font-size:11px;
+  letter-spacing:1px;
+  color:#555;
+}
+
+.npc-item.active .npc-service-label {
+  color:#ddd;
+}
+
 .npc-item .npc-position {
   font-size:11px;
   letter-spacing:1px;

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -349,6 +349,14 @@
               <div class="npc-sprite-preview" id="npc-sprite-preview">
                 <span>No sprite selected</span>
               </div>
+              <label class="field-label">
+                Service
+                <select id="npc-service">
+                  <option value="">None</option>
+                  <option value="shop">Shop</option>
+                </select>
+                <span class="field-hint">Assign optional interactions like shops for this NPC.</span>
+              </label>
               <div class="npc-dialog-section">
                 <div class="npc-dialog-header">
                   <span>Dialogue Entries</span>


### PR DESCRIPTION
## Summary
- add NPC service selection, serialization, and labels to the world builder UI
- normalize NPC services on the server and include them in world interactions
- render a canvas-based shop overlay in world mode with filters, tooltips, and purchasing tied to NPC services

## Testing
- `node -p "require('./systems/worldService') ? 'ok' : 'fail'"`

------
https://chatgpt.com/codex/tasks/task_e_68e18fb0061883208c903e2e8fc6c383