### PR TITLE
Include NPC service in move-triggered interactions

### DIFF
--- a/systems/worldService.js
+++ b/systems/worldService.js
@@ -1595,6 +1595,7 @@ async function movePlayer(worldId, instanceId, characterId, direction) {
               ? triggeredNpcInteraction.lines.slice()
               : [],
             sprite: triggeredNpcInteraction.npc.sprite || null,
+            service: triggeredNpcInteraction.npc.service || null,
           },
         }
       : null,


### PR DESCRIPTION
## Summary
- ensure move-triggered NPC interaction payloads carry service details so client can open assigned services

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1aeb6d20483208ec924c2970f1b1f