### PR TITLE
Improve world shop canvas layout and scrolling

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -2975,6 +2975,7 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   width: 100%;
   height: 100%;
   pointer-events: auto;
+  touch-action: none;
 }
 
 #world-shop-canvas.hidden {


### PR DESCRIPTION
## Summary
- simplify world mode shop cards to display only item names and rarities while keeping purchase controls
- add touch-friendly canvas scrolling with inertial drag handling and a visible scroll indicator
- replace the sort dropdown with inline selectable sort options to keep controls within the canvas bounds

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e1bf56d6e08320bd681651d7bf4ab2