### PR TITLE
Add click-based transport selection and two-way links

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -219,6 +219,7 @@ body.world-builder {
 #load-world,
 #enemy-add-ability,
 #transport-clear,
+.transport-pick-button,
 .enemy-template button {
   border:1px solid #000;
   background:#fff;
@@ -636,12 +637,38 @@ body.world-builder {
   color:#000;
 }
 
-.transport-controls label {
+.transport-controls {
   display:flex;
   flex-direction:column;
-  gap:4px;
+  gap:8px;
   font-size:12px;
   text-transform:uppercase;
+}
+
+.transport-stage {
+  letter-spacing:1px;
+}
+
+.transport-pickers {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+
+.transport-pick-button.active {
+  background:#000;
+  color:#fff;
+}
+
+.transport-pick-button:disabled {
+  opacity:0.45;
+  cursor:default;
+  box-shadow:2px 2px 0 rgba(0, 0, 0, 0.3);
+}
+
+.transport-two-way {
+  align-items:center;
+  gap:6px;
 }
 
 .enemy-mode-info {
@@ -775,6 +802,18 @@ body.world-builder {
 
 .zone-cell:focus-visible {
   box-shadow:inset 0 0 0 2px rgba(0, 0, 0, 0.6);
+}
+
+.zone-cell.transport-source {
+  box-shadow:inset 0 0 0 3px rgba(66, 153, 225, 0.9);
+}
+
+.zone-cell.transport-destination {
+  box-shadow:inset 0 0 0 3px rgba(72, 187, 120, 0.9);
+}
+
+.zone-cell.transport-source.transport-destination {
+  box-shadow:inset 0 0 0 3px rgba(0, 0, 0, 0.85);
 }
 
 .zone-cell-enemy {

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -136,19 +136,30 @@
                   </label>
                 </div>
                 <div class="transport-controls hidden" id="transport-controls">
-                  <label>
-                    Target Zone
-                    <select id="transport-zone-select"></select>
+                  <div class="transport-stage" id="transport-stage-indicator">
+                    Select a source tile.
+                  </div>
+                  <div class="transport-pickers">
+                    <button
+                      type="button"
+                      class="transport-pick-button"
+                      id="transport-source-button"
+                    >
+                      Select source tile
+                    </button>
+                    <button
+                      type="button"
+                      class="transport-pick-button"
+                      id="transport-destination-button"
+                    >
+                      Select destination tile
+                    </button>
+                  </div>
+                  <label class="field-inline checkbox transport-two-way">
+                    <input type="checkbox" id="transport-two-way" />
+                    <span>Create two-way link</span>
                   </label>
-                  <label>
-                    Target X
-                    <input id="transport-target-x" type="number" min="0" />
-                  </label>
-                  <label>
-                    Target Y
-                    <input id="transport-target-y" type="number" min="0" />
-                  </label>
-                  <button type="button" id="transport-clear">Clear Target</button>
+                  <button type="button" id="transport-clear">Clear Selection</button>
                 </div>
                 <div class="enemy-mode-info hidden" id="enemy-mode-info">
                   <span>Placement Target:</span>


### PR DESCRIPTION
## Summary
- add transport mode controls for selecting source and destination tiles directly from the grid
- highlight selected tiles, support optional two-way links, and keep selections in sync when transports change
- update world builder UI styling to reflect the new workflow

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e2c09110fc8320bf63b6202d99874c