### PR TITLE
Add toggleable fullscreen layout for world mode on mobile

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -49,7 +49,8 @@
               <div id="world-title">Exploration</div>
               <div id="world-status" class="world-status">Connecting...</div>
               <button id="world-exit-focus" type="button" class="world-focus-exit" aria-label="Exit focused world view">
-                Exit Focus
+                <span aria-hidden="true">×</span>
+                <span class="visually-hidden">Exit Focus</span>
               </button>
             </div>
             <div class="world-party-bar world-lobby">

--- a/ui/style.css
+++ b/ui/style.css
@@ -3013,12 +3013,17 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   border: 2px solid #000;
   background: #000;
   color: #fff;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  padding: 6px 14px;
-  font-weight: bold;
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  padding: 0;
   box-shadow: 4px 4px 0 #000;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
+  font-size: 28px;
+  line-height: 1;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }
 
 .world-focus-exit:focus-visible {
@@ -3033,8 +3038,15 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
 
 body.world-canvas-focused .world-focus-exit {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1200;
+}
+
+body.world-canvas-focused .world-focus-exit span[aria-hidden="true"] {
+  font-size: 28px;
+  line-height: 1;
 }
 
 #world-canvas {
@@ -3487,40 +3499,35 @@ body.world-canvas-focused .world-focus-exit {
     min-height: 100vh;
     min-height: 100svh;
     padding-bottom: env(safe-area-inset-bottom);
-    gap: 12px;
-  }
-
-  body.world-tab-active.world-canvas-focused .world-header,
-  body.world-tab-active.world-canvas-focused .world-party-bar,
-  body.world-tab-active.world-canvas-focused .world-message {
-    margin: 0 16px;
-  }
-
-  body.world-tab-active.world-canvas-focused .world-header {
-    border-width: 2px 0;
-    box-shadow: none;
-    border-left: none;
-    border-right: none;
-    border-radius: 0;
-  }
-
-  body.world-tab-active.world-canvas-focused .world-party-bar,
-  body.world-tab-active.world-canvas-focused .world-message {
-    box-shadow: none;
+    gap: 0;
   }
 
   body.world-tab-active.world-canvas-focused .world-screen {
     flex: 1 1 auto;
     display: flex;
-    align-items: stretch;
+    align-items: center;
     justify-content: center;
-    padding: 0 16px;
+    padding: 0;
     min-height: 0;
+  }
+
+  body.world-tab-active.world-canvas-focused .world-canvas-stack {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  body.world-tab-active.world-canvas-focused .world-canvas-stack canvas {
+    width: 100%;
+    height: auto;
+    max-height: 100%;
   }
 
   body.world-tab-active.world-canvas-focused #world-canvas {
     width: 100%;
-    height: 100%;
+    height: auto;
     max-width: 100%;
     max-height: 100%;
     aspect-ratio: unset;
@@ -3544,4 +3551,58 @@ body.world-canvas-focused .world-focus-exit {
   body.world-tab-active.world-canvas-focused .world-sidebar {
     display: none;
   }
+
+  body.world-tab-active.world-canvas-focused #world-title,
+  body.world-tab-active.world-canvas-focused #world-status {
+    display: none;
+  }
+
+  body.world-tab-active.world-canvas-focused .world-header {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    justify-content: flex-end;
+  }
+
+  body.world-tab-active.world-canvas-focused .world-party-bar,
+  body.world-tab-active.world-canvas-focused .world-message {
+    display: none;
+  }
 }
+body.world-canvas-focused {
+  background: #000;
+  overflow: hidden;
+}
+
+body.world-canvas-focused #game {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  max-width: none;
+  width: 100%;
+}
+
+body.world-canvas-focused #tabs {
+  display: none;
+}
+
+body.world-canvas-focused #content {
+  flex: 1 1 auto;
+  display: flex;
+  padding: 0;
+  border: none;
+}
+
+body.world-canvas-focused #content > .tab-pane:not(#world) {
+  display: none !important;
+}
+
+body.world-canvas-focused #world {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+


### PR DESCRIPTION
## Summary
- add a mobile fullscreen layout for world mode that hides site navigation when focused
- restyle the world focus exit button into a floating X control for closing fullscreen mode

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e428f983a483208e78b04bf0cbc75b