### PR TITLE
Ensure world canvas renders pixel art crisply

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -2966,6 +2966,8 @@ button { background:#fff; color:#000; border:1px solid #000; padding:8px; cursor
   display: block;
   width: 100%;
   height: auto;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
 }
 
 #world-shop-canvas {


### PR DESCRIPTION
## Summary
- apply pixel-art friendly image rendering to the world canvas element to prevent smoothing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e448763a3c8320afe4896a8c032b1b