### PR TITLE
Refine world builder sprite palette UI

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -132,9 +132,14 @@ body.world-builder {
 }
 
 .tile-palette {
-  display:flex;
-  flex-wrap:wrap;
-  gap:8px;
+  --tile-size: 48px;
+  display:grid;
+  grid-auto-columns:var(--tile-size);
+  grid-auto-rows:var(--tile-size);
+  grid-auto-flow:dense;
+  gap:0;
+  justify-content:flex-start;
+  align-content:flex-start;
   margin-bottom:12px;
 }
 
@@ -169,45 +174,59 @@ body.world-builder {
 }
 
 .tile-token {
-  width:60px;
-  height:60px;
-  border:2px solid #000;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  flex-direction:column;
+  width:var(--tile-size);
+  height:var(--tile-size);
+  border:none;
+  padding:0;
+  margin:0;
   cursor:pointer;
-  text-transform:uppercase;
   position:relative;
   background-size:cover;
   background-position:center;
+  background-repeat:no-repeat;
+  image-rendering:pixelated;
 }
 
-.tile-token.active {
-  outline:2px dashed #000;
-  outline-offset:3px;
+.tile-token::after {
+  content:'';
+  position:absolute;
+  inset:0;
+  border:2px solid transparent;
+  pointer-events:none;
 }
 
-.tile-token.has-sprite {
+.tile-token.active::after {
+  border-color:#000;
+}
+
+.tile-token-label {
+  position:absolute;
+  left:0;
+  right:0;
+  bottom:0;
+  background:rgba(0, 0, 0, 0.65);
   color:#fff;
-  text-shadow:0 1px 1px #000;
-}
-
-.tile-token.has-sprite span {
-  background:rgba(0, 0, 0, 0.6);
-  padding:2px 4px;
-  border-radius:2px;
-}
-
-.tile-token.has-sprite strong {
-  background:rgba(0, 0, 0, 0.6);
-  padding:2px 4px;
-  border-radius:2px;
-}
-
-.tile-token span {
-  font-size:12px;
+  font-size:10px;
   letter-spacing:1px;
+  text-transform:uppercase;
+  padding:2px 4px;
+}
+
+.tile-token.tile-token-blocked::before {
+  content:'✖';
+  position:absolute;
+  top:2px;
+  right:2px;
+  width:16px;
+  height:16px;
+  border-radius:50%;
+  background:rgba(180, 0, 0, 0.85);
+  color:#fff;
+  font-size:10px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  pointer-events:none;
 }
 
 .enemy-actions button,
@@ -1056,56 +1075,52 @@ body.world-builder {
   flex-wrap:wrap;
 }
 
-.palette-tile-list {
-  display:flex;
-  flex-direction:column;
-  gap:8px;
-}
-
-.palette-tile {
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  border:1px solid #000;
-  padding:8px;
-  background:#fdfdfd;
-  gap:12px;
-}
-
-.palette-tile button {
-  align-self:flex-start;
-}
-
-.palette-tile .actions {
-  display:flex;
-  gap:6px;
-  flex-wrap:wrap;
-}
-
-.palette-tile-info {
-  display:flex;
-  align-items:center;
-  gap:8px;
-  font-size:12px;
-  text-transform:uppercase;
-}
-
-.palette-tile-swatch {
-  width:36px;
-  height:36px;
-  border:1px solid #000;
+.palette-grid {
+  --tile-size: 48px;
+  display:grid;
+  grid-auto-columns:var(--tile-size);
+  grid-auto-rows:var(--tile-size);
+  grid-auto-flow:dense;
+  gap:0;
+  justify-content:flex-start;
+  align-content:flex-start;
+  min-height:var(--tile-size);
   background:#fff;
+}
+
+.palette-grid-empty {
   display:flex;
   align-items:center;
   justify-content:center;
-  overflow:hidden;
+  padding:24px;
+  background:#fdfdfd;
+  border:1px dashed #000;
+  text-transform:uppercase;
+  font-size:12px;
+  letter-spacing:1px;
 }
 
-.palette-tile-swatch img {
-  width:100%;
-  height:100%;
-  object-fit:cover;
+.selected-asset-preview {
+  border:1px solid #000;
+  background:#fff;
+  min-height:120px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  margin-bottom:12px;
+}
+
+.selected-asset-preview img {
+  width:96px;
+  height:96px;
+  object-fit:contain;
   image-rendering:pixelated;
+}
+
+.sprite-selection-actions {
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
 }
 
 .sprite-asset-list {

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -209,8 +209,9 @@
           </section>
 
           <section class="panel sprite-palette-panel">
-            <h2>Palette Tiles</h2>
-            <div id="palette-tile-list" class="palette-tile-list"></div>
+            <h2>Palette Grid</h2>
+            <div id="palette-grid" class="palette-grid"></div>
+            <p class="panel-note">Click a tile to edit its settings.</p>
           </section>
 
           <section class="panel sprite-assets-panel">
@@ -218,30 +219,20 @@
             <div id="sprite-asset-list" class="sprite-asset-list"></div>
           </section>
 
-          <section class="panel sprite-builder-panel">
-            <h2>Sprite Builder</h2>
-            <form id="sprite-form" class="sprite-form">
-              <label class="field-inline">
-                <span>Tile ID</span>
-                <input id="sprite-tile-id" type="text" placeholder="e.g. 5" />
-              </label>
-              <label class="field-inline">
-                <span>Fill</span>
-                <input id="sprite-fill" type="text" placeholder="#ffffff" />
-              </label>
-              <label class="field-label">
-                Sprite Path
-                <input id="sprite-asset-path" type="text" placeholder="/assets/Sprite.png" />
-              </label>
-              <label class="field-inline checkbox">
-                <input id="sprite-walkable" type="checkbox" checked />
-                <span>Walkable</span>
-              </label>
-              <div class="sprite-preview" id="sprite-preview">
-                <p>Select an asset to preview</p>
-              </div>
-              <button type="submit">Add / Update Tile</button>
-            </form>
+          <section class="panel sprite-selection-panel">
+            <h2>Sprite Selection</h2>
+            <div id="selected-asset-preview" class="selected-asset-preview">
+              <p>Select a sprite asset to add it to the palette.</p>
+            </div>
+            <label class="field-inline checkbox">
+              <input id="selected-asset-walkable" type="checkbox" checked />
+              <span>Walkable</span>
+            </label>
+            <div class="sprite-selection-actions">
+              <button type="button" id="add-palette-tile">Add to Palette</button>
+              <button type="button" id="update-palette-tile" disabled>Update Selected Tile</button>
+              <button type="button" id="remove-palette-tile" disabled>Remove Selected Tile</button>
+            </div>
           </section>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the Sprites tab palette editor with a grid-based builder that supports selecting assets, auto-generated IDs, and walkability toggles
- render the tile palette in the world tab as a gapless grid that mirrors the in-game sprite layout
- update palette state management to keep selections, world painting, and palette persistence aligned with the new workflow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e452e328b08320ab9ad86c818d64b3