### PR TITLE
Refactor world builder palette into a grid

### DIFF
--- a/models/SpritePalette.js
+++ b/models/SpritePalette.js
@@ -6,6 +6,8 @@ const PaletteTileSchema = new mongoose.Schema(
     sprite: { type: String, required: true },
     fill: { type: String, default: '#ffffff' },
     walkable: { type: Boolean, default: true },
+    row: { type: Number, min: 0, default: 0 },
+    column: { type: Number, min: 0, default: 0 },
   },
   { _id: false }
 );
@@ -14,6 +16,8 @@ const SpritePaletteSchema = new mongoose.Schema(
   {
     name: { type: String, required: true, trim: true },
     description: { type: String, trim: true },
+    rows: { type: Number, min: 1, max: 50, default: 3 },
+    columns: { type: Number, min: 1, max: 50, default: 3 },
     tiles: {
       type: [PaletteTileSchema],
       default: [],

--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -131,15 +131,20 @@ body.world-builder {
   color:#333;
 }
 
-.tile-palette {
+.tile-palette,
+.palette-grid {
   --tile-size: 48px;
+  --palette-columns: 1;
+  --palette-rows: 1;
   display:grid;
-  grid-auto-columns:var(--tile-size);
-  grid-auto-rows:var(--tile-size);
-  grid-auto-flow:dense;
+  grid-template-columns:repeat(var(--palette-columns), var(--tile-size));
+  grid-template-rows:repeat(var(--palette-rows), var(--tile-size));
   gap:0;
   justify-content:flex-start;
   align-content:flex-start;
+}
+
+.tile-palette {
   margin-bottom:12px;
 }
 
@@ -197,6 +202,29 @@ body.world-builder {
 
 .tile-token.active::after {
   border-color:#000;
+}
+
+.tile-token.tile-token-empty {
+  background:#f3f3f3;
+  background-image:none;
+  color:#777;
+}
+
+.tile-token.tile-token-empty::before {
+  content:'+';
+  position:absolute;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:22px;
+  font-weight:bold;
+  pointer-events:none;
+  color:#b0b0b0;
+}
+
+.tile-token.tile-token-empty .tile-token-label {
+  display:none;
 }
 
 .tile-token-label {
@@ -1076,14 +1104,6 @@ body.world-builder {
 }
 
 .palette-grid {
-  --tile-size: 48px;
-  display:grid;
-  grid-auto-columns:var(--tile-size);
-  grid-auto-rows:var(--tile-size);
-  grid-auto-flow:dense;
-  gap:0;
-  justify-content:flex-start;
-  align-content:flex-start;
   min-height:var(--tile-size);
   background:#fff;
 }

--- a/ui/world-builder.html
+++ b/ui/world-builder.html
@@ -201,6 +201,14 @@
               Description
               <textarea id="palette-description" rows="2" placeholder="Optional notes..."></textarea>
             </label>
+            <label class="field-inline">
+              <span>Rows</span>
+              <input id="palette-rows" type="number" min="1" max="20" value="3" />
+            </label>
+            <label class="field-inline">
+              <span>Columns</span>
+              <input id="palette-columns" type="number" min="1" max="20" value="3" />
+            </label>
             <div class="sprite-actions">
               <button type="button" id="create-palette">New Palette</button>
               <button type="button" id="save-palette">Save Palette</button>


### PR DESCRIPTION
## Summary
- add row and column controls to the sprite palette editor and render palettes as a grid on both sprites and world tabs
- update client logic to track palette cell selection, manage add/update/remove flows, and export/import palette layout metadata
- persist palette dimensions and tile coordinates on the backend schema and API, and adjust styling for grid presentation

## Testing
- node --check ui/world-builder.js
- node --check index.js
- node --check models/SpritePalette.js

------
https://chatgpt.com/codex/tasks/task_e_68e46458c2608320bb77b065bf27ed26