### PR TITLE
Fix tile palette selection updating

### DIFF
--- a/ui/world-builder.js
+++ b/ui/world-builder.js
@@ -820,7 +820,7 @@ function renderTilePalette() {
       label.textContent = tileId;
       button.appendChild(label);
       button.addEventListener('click', () => {
-        setSelectedPaletteTile(tileId, { skipTilePalette: true });
+        setSelectedPaletteTile(tileId);
         renderZoneEditor();
       });
       tilePaletteEl.appendChild(button);


### PR DESCRIPTION
## Summary
- re-render the tile palette when selecting a tile so the active state follows the current selection
- keep the zone editor refresh in place to immediately reflect the new brush selection

## Testing
- npm start *(fails: requires MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68e46ec6a6588320ae0f2eb34d18dcf5