### PR TITLE
Enable multi-tile palette selection in world builder

### DIFF
--- a/ui/world-builder.css
+++ b/ui/world-builder.css
@@ -146,6 +146,10 @@ body.world-builder {
 
 .tile-palette {
   margin-bottom:12px;
+  overflow:auto;
+  max-width:100%;
+  min-width:0;
+  box-sizing:border-box;
 }
 
 .panel-header {
@@ -198,6 +202,18 @@ body.world-builder {
   inset:0;
   border:2px solid transparent;
   pointer-events:none;
+}
+
+.tile-token.tile-token-selected::after {
+  border-color:#000;
+}
+
+.tile-token.tile-token-anchor::after {
+  border-width:3px;
+}
+
+.brush-control--disabled {
+  opacity:0.6;
 }
 
 .tile-token.active::after {


### PR DESCRIPTION
## Summary
- allow selecting rectangular regions in the tile palette and persist the selection pattern
- apply multi-tile placement logic while managing brush size availability
- adjust palette styling to keep large palettes contained and highlight active selections

## Testing
- Not run (requires external MongoDB services)


------
https://chatgpt.com/codex/tasks/task_e_68e484fd64188320b5ce6554dc0abcfe