### PR TITLE
Add deck builder and card catalog seeding

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,0 +1,484 @@
+[
+  {
+    "slug": "sanguine-bargain",
+    "name": "Sanguine Bargain",
+    "school": "BLOOD",
+    "type": "SPELL_ATTACK",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["resource", "draw"],
+    "keywords": ["CHANNEL"],
+    "effects": [
+      { "id": "LOSE_RESOURCE", "resource": "VITALITY", "amount": 2, "target": "SELF" },
+      { "id": "CHANNEL", "amount": 2, "target": "SELF" },
+      { "id": "DRAW", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Lose 2 Vitality. CHANNEL 2. Draw 1 card.",
+    "role": "Pays life to accelerate and filter, enabling explosive turns."
+  },
+  {
+    "slug": "blood-needle",
+    "name": "Blood Needle",
+    "school": "BLOOD",
+    "type": "ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["poke", "life-cost"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 3, "target": "ENEMY" },
+      { "id": "LOSE_RESOURCE", "resource": "VITALITY", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Deal 3 damage. Lose 1 Vitality.",
+    "role": "Efficient ping that bleeds the caster for tempo."
+  },
+  {
+    "slug": "hemomancer-ward",
+    "name": "Hemomancer's Ward",
+    "school": "BLOOD",
+    "type": "REACTION",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["defense"],
+    "keywords": ["LINGER"],
+    "effects": [
+      { "id": "SHIELD", "amount": 6, "target": "SELF" },
+      { "id": "LOSE_RESOURCE", "resource": "VITALITY", "amount": 2, "target": "SELF" }
+    ],
+    "text": "Gain 6 shield. Lose 2 Vitality.",
+    "role": "Converts life to protection in clutch moments."
+  },
+  {
+    "slug": "artery-surge",
+    "name": "Artery Surge",
+    "school": "BLOOD",
+    "type": "SPELL_SKILL",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 3 },
+    "tags": ["buff", "self"],
+    "keywords": ["OVERLOAD"],
+    "effects": [
+      { "id": "BUFF", "stat": "power", "amount": 3, "target": "SELF" },
+      { "id": "GAIN_RESOURCE", "resource": "CHANNEL", "amount": 1, "target": "SELF" },
+      { "id": "LOSE_RESOURCE", "resource": "VITALITY", "amount": 3, "target": "SELF" }
+    ],
+    "text": "Gain +3 Power and 1 Channel. Lose 3 Vitality.",
+    "role": "Turns blood into burst damage potential."
+  },
+  {
+    "slug": "frost-bolt",
+    "name": "Frost Bolt",
+    "school": "FROST",
+    "type": "SPELL_ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["slow"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 4, "target": "ENEMY" },
+      { "id": "APPLY_STATUS", "status": "CHILL", "amount": 1, "target": "ENEMY" }
+    ],
+    "text": "Deal 4 damage. Apply 1 Chill.",
+    "role": "Bread-and-butter control bolt that chills foes."
+  },
+  {
+    "slug": "ice-lance",
+    "name": "Ice Lance",
+    "school": "FROST",
+    "type": "ATTACK",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["burst"],
+    "keywords": ["QUICK"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 7, "target": "ENEMY" },
+      { "id": "DEBUFF", "status": "SLOW", "amount": 2, "target": "ENEMY" }
+    ],
+    "text": "Quick. Deal 7 damage and apply 2 Slow.",
+    "role": "Fast finisher against chilled targets."
+  },
+  {
+    "slug": "glacial-barrier",
+    "name": "Glacial Barrier",
+    "school": "FROST",
+    "type": "REACTION",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["defense"],
+    "keywords": ["LINGER"],
+    "effects": [
+      { "id": "SHIELD", "amount": 8, "target": "SELF" },
+      { "id": "APPLY_STATUS", "status": "CHILL", "amount": 1, "target": "ENEMY" }
+    ],
+    "text": "Gain 8 shield. Apply 1 Chill to attacker.",
+    "role": "Defensive wall that also slows aggressors."
+  },
+  {
+    "slug": "hailstorm",
+    "name": "Hailstorm",
+    "school": "FROST",
+    "type": "SPELL_ATTACK",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 4 },
+    "tags": ["aoe"],
+    "keywords": ["OVERLOAD"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 5, "target": "ALL_ENEMIES" },
+      { "id": "APPLY_STATUS", "status": "CHILL", "amount": 2, "target": "ALL_ENEMIES" }
+    ],
+    "text": "Deal 5 damage to all enemies and apply 2 Chill.",
+    "role": "Board control sweep that sets up slows across the field."
+  },
+  {
+    "slug": "ember-spark",
+    "name": "Ember Spark",
+    "school": "FLAME",
+    "type": "ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["ignite"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 4, "target": "ENEMY" },
+      { "id": "APPLY_STATUS", "status": "BURN", "amount": 1, "target": "ENEMY" }
+    ],
+    "text": "Deal 4 damage and apply 1 Burn.",
+    "role": "Ignites targets to enable burn synergies."
+  },
+  {
+    "slug": "flame-burst",
+    "name": "Flame Burst",
+    "school": "FLAME",
+    "type": "SPELL_ATTACK",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["burst"],
+    "keywords": ["OVERLOAD"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 8, "target": "ENEMY" },
+      { "id": "APPLY_STATUS", "status": "BURN", "amount": 2, "target": "ENEMY" }
+    ],
+    "text": "Deal 8 damage and apply 2 Burn.",
+    "role": "Direct burn that scales with fire synergies."
+  },
+  {
+    "slug": "phoenix-rekindle",
+    "name": "Phoenix Rekindle",
+    "school": "FLAME",
+    "type": "SUPPORT",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 3 },
+    "tags": ["heal", "resilience"],
+    "keywords": ["LINGER"],
+    "effects": [
+      { "id": "GAIN_RESOURCE", "resource": "VITALITY", "amount": 5, "target": "SELF" },
+      { "id": "CLEANSE", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Heal 5 Vitality and cleanse 1 debuff.",
+    "role": "Sustain tool that keeps flame casters alive."
+  },
+  {
+    "slug": "inferno-wheel",
+    "name": "Inferno Wheel",
+    "school": "FLAME",
+    "type": "SPELL_ATTACK",
+    "rarity": "LEGENDARY",
+    "cost": { "resource": "MANA", "amount": 5 },
+    "tags": ["aoe", "finisher"],
+    "keywords": ["OVERLOAD", "EXHAUST"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 10, "target": "ALL_ENEMIES" },
+      { "id": "APPLY_STATUS", "status": "BURN", "amount": 3, "target": "ALL_ENEMIES" }
+    ],
+    "text": "Exhaust. Deal 10 damage and apply 3 Burn to all enemies.",
+    "role": "Massive closer that scorches entire boards."
+  },
+  {
+    "slug": "storm-jolt",
+    "name": "Storm Jolt",
+    "school": "STORM",
+    "type": "ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["charge"],
+    "keywords": ["QUICK"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 4, "target": "ENEMY" },
+      { "id": "DRAW", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Quick. Deal 4 damage. Draw a card.",
+    "role": "Keeps hands full while zapping foes."
+  },
+  {
+    "slug": "lightning-chain",
+    "name": "Lightning Chain",
+    "school": "STORM",
+    "type": "SPELL_ATTACK",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["aoe"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 3, "target": "ALL_ENEMIES" },
+      { "id": "REPEAT_NEXT", "amount": 1, "target": "ENEMY" }
+    ],
+    "text": "Deal 3 damage to all enemies. Repeat on a random enemy.",
+    "role": "Chain lightning that bounces for extra zap."
+  },
+  {
+    "slug": "ion-shield",
+    "name": "Ion Shield",
+    "school": "STORM",
+    "type": "REACTION",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["defense"],
+    "keywords": [],
+    "effects": [
+      { "id": "SHIELD", "amount": 7, "target": "SELF" },
+      { "id": "GAIN_RESOURCE", "resource": "FOCUS", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Gain 7 shield and 1 Focus.",
+    "role": "Protects while charging the mind."
+  },
+  {
+    "slug": "tempest-overload",
+    "name": "Tempest Overload",
+    "school": "STORM",
+    "type": "SPELL_ATTACK",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 4 },
+    "tags": ["finisher"],
+    "keywords": ["OVERLOAD"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 12, "target": "ENEMY" },
+      { "id": "REPEAT_NEXT", "amount": 1, "target": "ENEMY", "condition": "FOCUS_3" }
+    ],
+    "text": "Deal 12 damage. If you have 3+ Focus, repeat this spell.",
+    "role": "High-voltage spike that rewards built-up focus."
+  },
+  {
+    "slug": "stonefist",
+    "name": "Stonefist",
+    "school": "EARTH",
+    "type": "ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["stun"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 5, "target": "ENEMY" },
+      { "id": "DEBUFF", "status": "ROOT", "amount": 1, "target": "ENEMY" }
+    ],
+    "text": "Deal 5 damage and apply Root.",
+    "role": "Heavy punch that stops enemies in place."
+  },
+  {
+    "slug": "granite-wall",
+    "name": "Granite Wall",
+    "school": "EARTH",
+    "type": "REACTION",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["defense"],
+    "keywords": ["LINGER"],
+    "effects": [
+      { "id": "SHIELD", "amount": 10, "target": "SELF" },
+      { "id": "BUFF", "stat": "armor", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Gain 10 shield and +1 Armor this turn.",
+    "role": "Stalwart defense that thickens skin."
+  },
+  {
+    "slug": "tectonic-shift",
+    "name": "Tectonic Shift",
+    "school": "EARTH",
+    "type": "SPELL_ATTACK",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 3 },
+    "tags": ["control"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 6, "target": "ALL_ENEMIES" },
+      { "id": "DEBUFF", "status": "DISPLACE", "amount": 1, "target": "ALL_ENEMIES" }
+    ],
+    "text": "Deal 6 damage to all enemies and Displace them.",
+    "role": "Shakes the battlefield to reposition foes."
+  },
+  {
+    "slug": "verdant-ritual",
+    "name": "Verdant Ritual",
+    "school": "EARTH",
+    "type": "SUPPORT",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["ramp"],
+    "keywords": ["CHANNEL"],
+    "effects": [
+      { "id": "GAIN_RESOURCE", "resource": "MANA", "amount": 1, "target": "SELF" },
+      { "id": "DRAW", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Channel. Gain 1 Mana next turn and draw a card.",
+    "role": "Grows resources while cycling."
+  },
+  {
+    "slug": "void-grasp",
+    "name": "Void Grasp",
+    "school": "VOID",
+    "type": "SPELL_ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["drain"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 4, "target": "ENEMY" },
+      { "id": "GAIN_RESOURCE", "resource": "VITALITY", "amount": 2, "target": "SELF" }
+    ],
+    "text": "Deal 4 damage. Leech 2 Vitality.",
+    "role": "Siphons life to sustain the caster."
+  },
+  {
+    "slug": "abyssal-echo",
+    "name": "Abyssal Echo",
+    "school": "VOID",
+    "type": "SUPPORT",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["copy"],
+    "keywords": [],
+    "effects": [
+      { "id": "COPY", "amount": 1, "target": "SELF" },
+      { "id": "DRAW", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Copy the next spell you cast this turn. Draw a card.",
+    "role": "Doubles up key spells while replacing itself."
+  },
+  {
+    "slug": "entropy-bleed",
+    "name": "Entropy Bleed",
+    "school": "VOID",
+    "type": "SPELL_ATTACK",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 3 },
+    "tags": ["mill"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 7, "target": "ENEMY" },
+      { "id": "MILL", "amount": 2, "target": "ENEMY" }
+    ],
+    "text": "Deal 7 damage. Mill 2 from enemy deck.",
+    "role": "Attacks the library while pressuring life total."
+  },
+  {
+    "slug": "event-horizon",
+    "name": "Event Horizon",
+    "school": "VOID",
+    "type": "REACTION",
+    "rarity": "LEGENDARY",
+    "cost": { "resource": "MANA", "amount": 4 },
+    "tags": ["lockdown"],
+    "keywords": ["EXHAUST"],
+    "effects": [
+      { "id": "SHIELD", "amount": 12, "target": "SELF" },
+      { "id": "DEBUFF", "status": "SILENCE", "amount": 1, "target": "ALL_ENEMIES" }
+    ],
+    "text": "Exhaust. Gain 12 shield and Silence all enemies this turn.",
+    "role": "Shuts down enemy actions for a moment of calm."
+  },
+  {
+    "slug": "radiant-strike",
+    "name": "Radiant Strike",
+    "school": "LIGHT",
+    "type": "ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["cleanse"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 5, "target": "ENEMY" },
+      { "id": "CLEANSE", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Deal 5 damage and cleanse 1 debuff.",
+    "role": "Bright slash that purifies the wielder."
+  },
+  {
+    "slug": "luminous-aegis",
+    "name": "Luminous Aegis",
+    "school": "LIGHT",
+    "type": "REACTION",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["defense"],
+    "keywords": [],
+    "effects": [
+      { "id": "SHIELD", "amount": 9, "target": "SELF" },
+      { "id": "BUFF", "stat": "resist", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Gain 9 shield and +1 Resist this turn.",
+    "role": "Holy barrier that tempers incoming harm."
+  },
+  {
+    "slug": "sanctify",
+    "name": "Sanctify",
+    "school": "LIGHT",
+    "type": "SUPPORT",
+    "rarity": "RARE",
+    "cost": { "resource": "MANA", "amount": 3 },
+    "tags": ["heal"],
+    "keywords": [],
+    "effects": [
+      { "id": "GAIN_RESOURCE", "resource": "VITALITY", "amount": 6, "target": "ALLY" },
+      { "id": "BUFF", "stat": "power", "amount": 1, "target": "ALLY" }
+    ],
+    "text": "Heal an ally for 6 and give them +1 Power this turn.",
+    "role": "Protective blessing that also sharpens blades."
+  },
+  {
+    "slug": "prismatic-vision",
+    "name": "Prismatic Vision",
+    "school": "LIGHT",
+    "type": "SUPPORT",
+    "rarity": "UNCOMMON",
+    "cost": { "resource": "MANA", "amount": 2 },
+    "tags": ["scry"],
+    "keywords": [],
+    "effects": [
+      { "id": "DRAW", "amount": 2, "target": "SELF" },
+      { "id": "DISCARD", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Draw 2 cards, then discard 1.",
+    "role": "Filters the deck to find the perfect answer."
+  },
+  {
+    "slug": "shadow-feint",
+    "name": "Shadow Feint",
+    "school": "VOID",
+    "type": "ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["evasion"],
+    "keywords": ["QUICK"],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 3, "target": "ENEMY" },
+      { "id": "BUFF", "stat": "dodge", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Quick. Deal 3 damage and gain +1 Dodge this turn.",
+    "role": "Slippery poke that raises evasion."
+  },
+  {
+    "slug": "mind-spike",
+    "name": "Mind Spike",
+    "school": "STORM",
+    "type": "SPELL_ATTACK",
+    "rarity": "COMMON",
+    "cost": { "resource": "MANA", "amount": 1 },
+    "tags": ["focus"],
+    "keywords": [],
+    "effects": [
+      { "id": "DEAL_DAMAGE", "amount": 3, "target": "ENEMY" },
+      { "id": "GAIN_RESOURCE", "resource": "FOCUS", "amount": 1, "target": "SELF" }
+    ],
+    "text": "Deal 3 damage. Gain 1 Focus.",
+    "role": "Soft poke that tunes concentration."
+  }
+]

--- a/domain/cardEnums.js
+++ b/domain/cardEnums.js
@@ -1,0 +1,76 @@
+const CardSchool = Object.freeze({
+  BLOOD: 'BLOOD',
+  FROST: 'FROST',
+  FLAME: 'FLAME',
+  STORM: 'STORM',
+  EARTH: 'EARTH',
+  VOID: 'VOID',
+  LIGHT: 'LIGHT',
+});
+
+const CardType = Object.freeze({
+  ATTACK: 'ATTACK',
+  SPELL_ATTACK: 'SPELL_ATTACK',
+  SPELL_SKILL: 'SPELL_SKILL',
+  REACTION: 'REACTION',
+  SUPPORT: 'SUPPORT',
+});
+
+const Rarity = Object.freeze({
+  COMMON: 'COMMON',
+  UNCOMMON: 'UNCOMMON',
+  RARE: 'RARE',
+  LEGENDARY: 'LEGENDARY',
+});
+
+const ResourceType = Object.freeze({
+  MANA: 'MANA',
+  VITALITY: 'VITALITY',
+  CHANNEL: 'CHANNEL',
+  FOCUS: 'FOCUS',
+});
+
+const TargetType = Object.freeze({
+  SELF: 'SELF',
+  ENEMY: 'ENEMY',
+  ALLY: 'ALLY',
+  ALL_ENEMIES: 'ALL_ENEMIES',
+  ALL_ALLIES: 'ALL_ALLIES',
+  ANY: 'ANY',
+});
+
+const EffectType = Object.freeze({
+  DEAL_DAMAGE: 'DEAL_DAMAGE',
+  LOSE_RESOURCE: 'LOSE_RESOURCE',
+  GAIN_RESOURCE: 'GAIN_RESOURCE',
+  APPLY_STATUS: 'APPLY_STATUS',
+  DRAW: 'DRAW',
+  CHANNEL: 'CHANNEL',
+  SHIELD: 'SHIELD',
+  SUMMON: 'SUMMON',
+  DISCARD: 'DISCARD',
+  MILL: 'MILL',
+  COPY: 'COPY',
+  CLEANSE: 'CLEANSE',
+  BUFF: 'BUFF',
+  DEBUFF: 'DEBUFF',
+  REPEAT_NEXT: 'REPEAT_NEXT',
+});
+
+const Keyword = Object.freeze({
+  CHANNEL: 'CHANNEL',
+  EXHAUST: 'EXHAUST',
+  QUICK: 'QUICK',
+  OVERLOAD: 'OVERLOAD',
+  LINGER: 'LINGER',
+});
+
+module.exports = {
+  CardSchool,
+  CardType,
+  Rarity,
+  ResourceType,
+  TargetType,
+  EffectType,
+  Keyword,
+};

--- a/index.js
+++ b/index.js
@@ -68,6 +68,8 @@ const {
   readyWorldMatch,
   getWorldQueueStatus,
 } = require("./systems/worldMatchmakingService");
+const { listCards, seedCardCatalog } = require("./systems/cardService");
+const { listDecks, saveDeck, MAX_DECK_SIZE } = require("./systems/deckService");
 const app = express();
 const connectDB = require("./db");
 const SpritePalette = require("./models/SpritePalette");
@@ -367,6 +369,48 @@ app.post("/login", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(404).json({ error: "login failed" });
+  }
+});
+
+app.get("/cards", async (req, res) => {
+  try {
+    const cards = await listCards();
+    res.json({ cards });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "failed to load cards" });
+  }
+});
+
+app.get("/decks", async (req, res) => {
+  const playerId = parseInt(req.query.playerId, 10);
+  if (!Number.isFinite(playerId)) {
+    return res.status(400).json({ error: "playerId required" });
+  }
+  try {
+    const decks = await listDecks(playerId);
+    res.json({ decks, maxDeckSize: MAX_DECK_SIZE });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message || "failed to load decks" });
+  }
+});
+
+app.post("/decks", async (req, res) => {
+  const { playerId, name, cards } = req.body || {};
+  const pid = parseInt(playerId, 10);
+  if (!Number.isFinite(pid)) {
+    return res.status(400).json({ error: "playerId required" });
+  }
+  if (!name) {
+    return res.status(400).json({ error: "deck name required" });
+  }
+  try {
+    const deck = await saveDeck(pid, name, cards);
+    res.json({ deck, maxDeckSize: MAX_DECK_SIZE });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: err.message || "failed to save deck" });
   }
 });
 
@@ -1275,6 +1319,8 @@ async function start() {
   try {
     await connectDB();
     console.log("Connected to MongoDB");
+    await seedCardCatalog();
+    console.log("Card catalog ready");
     app.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });

--- a/models/Card.js
+++ b/models/Card.js
@@ -1,0 +1,50 @@
+const mongoose = require('mongoose');
+const {
+  CardSchool,
+  CardType,
+  Rarity,
+  ResourceType,
+  TargetType,
+  EffectType,
+  Keyword,
+} = require('../domain/cardEnums');
+
+const effectSchema = new mongoose.Schema(
+  {
+    id: { type: String, enum: Object.values(EffectType), required: true },
+    target: { type: String, enum: Object.values(TargetType), default: TargetType.ENEMY },
+    amount: { type: Number, default: 0 },
+    resource: { type: String, enum: Object.values(ResourceType) },
+    status: { type: String, trim: true },
+    stat: { type: String, trim: true },
+    condition: { type: String, trim: true },
+  },
+  { _id: false }
+);
+
+const costSchema = new mongoose.Schema(
+  {
+    resource: { type: String, enum: Object.values(ResourceType), required: true },
+    amount: { type: Number, min: 0, required: true },
+  },
+  { _id: false }
+);
+
+const cardSchema = new mongoose.Schema(
+  {
+    slug: { type: String, required: true, unique: true, index: true },
+    name: { type: String, required: true },
+    school: { type: String, enum: Object.values(CardSchool), required: true },
+    type: { type: String, enum: Object.values(CardType), required: true },
+    rarity: { type: String, enum: Object.values(Rarity), default: Rarity.COMMON },
+    cost: { type: costSchema, required: true },
+    tags: { type: [String], default: [] },
+    keywords: { type: [String], enum: Object.values(Keyword), default: [] },
+    effects: { type: [effectSchema], default: [] },
+    text: { type: String, default: '' },
+    role: { type: String, default: '' },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Card', cardSchema);

--- a/models/Deck.js
+++ b/models/Deck.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const cardEntrySchema = new mongoose.Schema(
+  {
+    slug: { type: String, required: true },
+    quantity: { type: Number, default: 1, min: 1 },
+  },
+  { _id: false }
+);
+
+const deckSchema = new mongoose.Schema(
+  {
+    deckId: { type: Number, unique: true, index: true, required: true },
+    playerId: { type: Number, index: true, required: true },
+    name: { type: String, required: true },
+    cards: { type: [cardEntrySchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+deckSchema.index({ playerId: 1, name: 1 }, { unique: true, collation: { locale: 'en', strength: 2 } });
+
+module.exports = mongoose.model('Deck', deckSchema);

--- a/systems/cardService.js
+++ b/systems/cardService.js
@@ -1,0 +1,119 @@
+const fs = require('fs').promises;
+const path = require('path');
+const CardModel = require('../models/Card');
+const {
+  CardSchool,
+  CardType,
+  Rarity,
+  ResourceType,
+  TargetType,
+  EffectType,
+  Keyword,
+} = require('../domain/cardEnums');
+
+const CARD_DATA_PATH = path.join(__dirname, '..', 'data', 'cards.json');
+let seedPromise = null;
+
+function ensureEnum(value, allowed, label) {
+  if (!value) {
+    throw new Error(`${label} is required`);
+  }
+  if (!allowed.includes(value)) {
+    throw new Error(`${label} must be one of: ${allowed.join(', ')}`);
+  }
+  return value;
+}
+
+function normalizeEffects(effects = []) {
+  if (!Array.isArray(effects)) return [];
+  return effects.map(effect => {
+    const id = ensureEnum(String(effect.id || '').trim(), Object.values(EffectType), 'effect');
+    const normalized = {
+      id,
+      target: effect.target && Object.values(TargetType).includes(effect.target)
+        ? effect.target
+        : TargetType.ENEMY,
+      amount: Number(effect.amount) || 0,
+    };
+    if (effect.resource && Object.values(ResourceType).includes(effect.resource)) {
+      normalized.resource = effect.resource;
+    }
+    if (typeof effect.status === 'string' && effect.status.trim()) {
+      normalized.status = effect.status.trim();
+    }
+    if (typeof effect.stat === 'string' && effect.stat.trim()) {
+      normalized.stat = effect.stat.trim();
+    }
+    if (typeof effect.condition === 'string' && effect.condition.trim()) {
+      normalized.condition = effect.condition.trim();
+    }
+    return normalized;
+  });
+}
+
+function normalizeCardDefinition(def) {
+  const slug = String(def.slug || '').trim();
+  if (!slug) {
+    throw new Error('card slug required');
+  }
+  const school = ensureEnum(String(def.school || '').trim(), Object.values(CardSchool), 'school');
+  const type = ensureEnum(String(def.type || '').trim(), Object.values(CardType), 'type');
+  const rarity = ensureEnum(String(def.rarity || Rarity.COMMON).trim(), Object.values(Rarity), 'rarity');
+  const cost = def.cost || {};
+  const resource = ensureEnum(String(cost.resource || '').trim(), Object.values(ResourceType), 'cost.resource');
+  const amount = Number(cost.amount);
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error('cost.amount must be non-negative');
+  }
+  const tags = Array.isArray(def.tags) ? def.tags.map(t => String(t)) : [];
+  const keywords = Array.isArray(def.keywords)
+    ? def.keywords.filter(k => Object.values(Keyword).includes(k))
+    : [];
+
+  return {
+    slug,
+    name: String(def.name || slug),
+    school,
+    type,
+    rarity,
+    cost: { resource, amount },
+    tags,
+    keywords,
+    effects: normalizeEffects(def.effects),
+    text: String(def.text || ''),
+    role: String(def.role || ''),
+  };
+}
+
+async function loadCardData() {
+  const raw = await fs.readFile(CARD_DATA_PATH, 'utf8');
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data)) {
+    throw new Error('cards.json must export an array');
+  }
+  return data.map(normalizeCardDefinition);
+}
+
+async function seedCardCatalog() {
+  if (seedPromise) return seedPromise;
+  seedPromise = (async () => {
+    const cards = await loadCardData();
+    const ops = cards.map(card =>
+      CardModel.findOneAndUpdate({ slug: card.slug }, { $set: card }, { upsert: true, new: true })
+    );
+    await Promise.all(ops);
+    return cards.length;
+  })();
+  return seedPromise;
+}
+
+async function listCards() {
+  await seedCardCatalog();
+  return CardModel.find().sort({ name: 1 }).lean();
+}
+
+module.exports = {
+  seedCardCatalog,
+  listCards,
+  enums: { CardSchool, CardType, Rarity, ResourceType, TargetType, EffectType, Keyword },
+};

--- a/systems/deckService.js
+++ b/systems/deckService.js
@@ -1,0 +1,77 @@
+const DeckModel = require('../models/Deck');
+const CardModel = require('../models/Card');
+const { seedCardCatalog } = require('./cardService');
+
+const MAX_DECK_SIZE = 30;
+
+async function getNextDeckId() {
+  const latest = await DeckModel.findOne().sort({ deckId: -1 }).select('deckId').lean();
+  if (!latest || typeof latest.deckId !== 'number') {
+    return 1;
+  }
+  return latest.deckId + 1;
+}
+
+async function ensureCardCatalog() {
+  await seedCardCatalog();
+}
+
+async function listDecks(playerId) {
+  const pid = parseInt(playerId, 10);
+  if (!Number.isFinite(pid)) {
+    throw new Error('playerId required');
+  }
+  return DeckModel.find({ playerId: pid }).sort({ updatedAt: -1 }).lean();
+}
+
+function normalizeDeckCards(cards) {
+  if (!Array.isArray(cards)) return [];
+  const counts = new Map();
+  cards.forEach(slug => {
+    const key = String(slug || '').trim();
+    if (!key) return;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  });
+  return Array.from(counts.entries()).map(([slug, quantity]) => ({ slug, quantity }));
+}
+
+async function saveDeck(playerId, name, cardSlugs) {
+  const pid = parseInt(playerId, 10);
+  if (!Number.isFinite(pid)) {
+    throw new Error('playerId required');
+  }
+  const deckName = String(name || '').trim();
+  if (!deckName) {
+    throw new Error('deck name required');
+  }
+  await ensureCardCatalog();
+  const normalizedCards = normalizeDeckCards(cardSlugs);
+  const totalCards = normalizedCards.reduce((sum, c) => sum + c.quantity, 0);
+  if (totalCards > MAX_DECK_SIZE) {
+    throw new Error(`deck cannot exceed ${MAX_DECK_SIZE} cards`);
+  }
+  const catalog = await CardModel.find({ slug: { $in: normalizedCards.map(c => c.slug) } })
+    .select('slug')
+    .lean();
+  const catalogSlugs = new Set(catalog.map(c => c.slug));
+  normalizedCards.forEach(entry => {
+    if (!catalogSlugs.has(entry.slug)) {
+      throw new Error(`unknown card slug: ${entry.slug}`);
+    }
+  });
+
+  const existing = await DeckModel.findOne({ playerId: pid, name: deckName }).collation({
+    locale: 'en',
+    strength: 2,
+  });
+  if (existing) {
+    existing.cards = normalizedCards;
+    await existing.save();
+    return existing.toObject();
+  }
+  const deckId = await getNextDeckId();
+  const deck = await DeckModel.create({ deckId, playerId: pid, name: deckName, cards: normalizedCards });
+  return deck.toObject();
+}
+
+module.exports = { listDecks, saveDeck, MAX_DECK_SIZE };

--- a/ui/index.html
+++ b/ui/index.html
@@ -16,10 +16,63 @@
     <div class="character-select-header">
       <h2>Select Your Champion</h2>
       <p>Scroll through your roster and choose who answers the call.</p>
+      <button id="back-to-menu" type="button" class="ghost">Main Menu</button>
     </div>
     <div id="character-list" class="character-card-list"></div>
     <div class="character-select-actions">
       <button id="create-character">Create Character</button>
+    </div>
+  </div>
+  <div id="main-menu" class="hidden main-menu">
+    <div class="menu-card">
+      <h1>ARMORY TERMINAL</h1>
+      <p>Choose where to start.</p>
+      <div class="menu-grid">
+        <button id="menu-characters" class="menu-button">Characters</button>
+        <button id="menu-decks" class="menu-button">Decks</button>
+        <button id="menu-enter-world" class="menu-button">Enter World</button>
+      </div>
+    </div>
+  </div>
+  <div id="deck-builder" class="hidden deck-builder">
+    <div class="deck-builder-header">
+      <div>
+        <h2>Deck Builder</h2>
+        <p>Build your first deck with cards from the Armory archives.</p>
+      </div>
+      <button id="deck-close" type="button" class="ghost">Back to Menu</button>
+    </div>
+    <div class="deck-builder-toolbar">
+      <label class="deck-field">
+        <span>Deck Name</span>
+        <input id="deck-name" type="text" value="First Strike" maxlength="40" />
+      </label>
+      <div class="deck-count">Cards: <span id="deck-count">0</span>/<span id="deck-limit">30</span></div>
+      <button id="deck-save" type="button">Save Deck</button>
+      <div id="deck-message" class="deck-message hidden"></div>
+    </div>
+    <div class="deck-builder-layout">
+      <div class="deck-library">
+        <div class="library-header">
+          <input id="card-search" type="search" placeholder="Search cards" />
+          <div id="card-filter-summary" class="card-filter-summary"></div>
+        </div>
+        <div id="card-grid" class="card-grid"></div>
+      </div>
+      <div class="deck-panel">
+        <div class="deck-panel-header">
+          <h3>Your Deck</h3>
+          <div id="deck-subtitle" class="deck-subtitle">Drag or tap to add cards.</div>
+        </div>
+        <div id="deck-card-list" class="deck-card-list"></div>
+        <div class="saved-decks">
+          <div class="saved-decks-header">
+            <h4>Saved Decks</h4>
+            <div class="deck-note">Load and tweak without losing progress.</div>
+          </div>
+          <div id="saved-decks-list" class="saved-decks-list"></div>
+        </div>
+      </div>
     </div>
   </div>
   <div id="name-dialog" class="hidden">

--- a/ui/main.js
+++ b/ui/main.js
@@ -8,6 +8,12 @@ let rotationInitialized = false;
 let rotationDamageType = 'melee';
 let rotationViewMode = 'planner';
 let rotationTabsInitialized = false;
+let cardCatalog = [];
+let cardCatalogIndex = new Map();
+let cardCatalogLoaded = false;
+let savedDecks = [];
+let deckCardCounts = new Map();
+let deckLimit = 30;
 
 const rotationDamageTypeSelect = document.getElementById('rotation-damage-type');
 
@@ -4989,6 +4995,24 @@ const nameDialog = document.getElementById('name-dialog');
 const newCharName = document.getElementById('new-char-name');
 const nameOk = document.getElementById('name-ok');
 const nameCancel = document.getElementById('name-cancel');
+const mainMenuDiv = document.getElementById('main-menu');
+const deckBuilderDiv = document.getElementById('deck-builder');
+const deckNameInput = document.getElementById('deck-name');
+const deckCountEl = document.getElementById('deck-count');
+const deckLimitEl = document.getElementById('deck-limit');
+const deckMessageEl = document.getElementById('deck-message');
+const deckCardListEl = document.getElementById('deck-card-list');
+const savedDecksListEl = document.getElementById('saved-decks-list');
+const cardGridEl = document.getElementById('card-grid');
+const cardSearchInput = document.getElementById('card-search');
+const deckSubtitleEl = document.getElementById('deck-subtitle');
+const cardFilterSummary = document.getElementById('card-filter-summary');
+const deckCloseBtn = document.getElementById('deck-close');
+const deckSaveBtn = document.getElementById('deck-save');
+const menuCharactersBtn = document.getElementById('menu-characters');
+const menuDecksBtn = document.getElementById('menu-decks');
+const menuEnterWorldBtn = document.getElementById('menu-enter-world');
+const backToMenuBtn = document.getElementById('back-to-menu');
 
 async function postJSON(url, data) {
   const res = await fetch(url, {
@@ -5005,6 +5029,277 @@ async function postJSON(url, data) {
     throw new Error(message);
   }
   return res.json();
+}
+
+function showMainMenu() {
+  if (mainMenuDiv) mainMenuDiv.classList.remove('hidden');
+  if (deckBuilderDiv) deckBuilderDiv.classList.add('hidden');
+  if (charSelectDiv) charSelectDiv.classList.add('hidden');
+  if (gameDiv) gameDiv.classList.add('hidden');
+}
+
+function showCharacterSelect() {
+  if (mainMenuDiv) mainMenuDiv.classList.add('hidden');
+  if (deckBuilderDiv) deckBuilderDiv.classList.add('hidden');
+  if (charSelectDiv) charSelectDiv.classList.remove('hidden');
+}
+
+function setDeckMessage(message, isError = false) {
+  if (!deckMessageEl) return;
+  if (!message) {
+    deckMessageEl.classList.add('hidden');
+    deckMessageEl.textContent = '';
+    return;
+  }
+  deckMessageEl.textContent = message;
+  deckMessageEl.classList.toggle('hidden', false);
+  deckMessageEl.style.color = isError ? '#ff7b7b' : '#b3f7ff';
+}
+
+function totalDeckCards() {
+  let total = 0;
+  deckCardCounts.forEach(qty => {
+    total += qty;
+  });
+  return total;
+}
+
+function updateDeckCountDisplay() {
+  if (deckCountEl) deckCountEl.textContent = totalDeckCards();
+  if (deckLimitEl) deckLimitEl.textContent = deckLimit;
+  if (deckSubtitleEl) {
+    const total = totalDeckCards();
+    deckSubtitleEl.textContent = total ? `${total} / ${deckLimit} cards` : 'Tap a card to add it to your deck.';
+  }
+}
+
+async function fetchCardCatalog(force = false) {
+  if (cardCatalogLoaded && !force) return cardCatalog;
+  const res = await fetch('/cards');
+  if (!res.ok) {
+    throw new Error('Unable to load cards');
+  }
+  const data = await res.json();
+  cardCatalog = data.cards || [];
+  cardCatalogIndex = new Map(cardCatalog.map(card => [card.slug, card]));
+  cardCatalogLoaded = true;
+  return cardCatalog;
+}
+
+function renderDeckList() {
+  if (!deckCardListEl) return;
+  deckCardListEl.innerHTML = '';
+  const entries = Array.from(deckCardCounts.entries());
+  entries.sort((a, b) => {
+    const cardA = cardCatalogIndex.get(a[0]);
+    const cardB = cardCatalogIndex.get(b[0]);
+    const nameA = (cardA?.name || a[0]).toLowerCase();
+    const nameB = (cardB?.name || b[0]).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+  entries.forEach(([slug, quantity]) => {
+    const card = cardCatalogIndex.get(slug);
+    const row = document.createElement('div');
+    row.className = 'deck-entry';
+    const label = document.createElement('span');
+    label.textContent = `${quantity}x ${card ? card.name : slug}`;
+    row.appendChild(label);
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = '-';
+    removeBtn.addEventListener('click', () => {
+      removeCardFromDeck(slug);
+    });
+    row.appendChild(removeBtn);
+    deckCardListEl.appendChild(row);
+  });
+  updateDeckCountDisplay();
+}
+
+function renderSavedDecks() {
+  if (!savedDecksListEl) return;
+  savedDecksListEl.innerHTML = '';
+  savedDecks.forEach(deck => {
+    const btn = document.createElement('button');
+    btn.className = 'saved-deck';
+    const totalCards = (deck.cards || []).reduce((sum, c) => sum + (c.quantity || 0), 0);
+    btn.innerHTML = `<strong>${deck.name}</strong><br/><small>${totalCards} cards</small>`;
+    btn.addEventListener('click', () => {
+      setDeckFromSaved(deck);
+    });
+    savedDecksListEl.appendChild(btn);
+  });
+}
+
+function formatEffect(effect) {
+  const parts = [];
+  if (effect.id) {
+    parts.push(effect.id.replace(/_/g, ' ').toLowerCase());
+  }
+  if (effect.amount) {
+    parts.push(effect.amount);
+  }
+  if (effect.resource) {
+    parts.push(effect.resource.toLowerCase());
+  }
+  if (effect.status) {
+    parts.push(effect.status.toLowerCase());
+  }
+  if (effect.condition) {
+    parts.push(`(${effect.condition.toLowerCase()})`);
+  }
+  return parts.join(' ');
+}
+
+function renderCardGrid() {
+  if (!cardGridEl) return;
+  const search = (cardSearchInput?.value || '').trim().toLowerCase();
+  const filtered = cardCatalog.filter(card => {
+    if (!search) return true;
+    return (
+      card.name.toLowerCase().includes(search) ||
+      card.school.toLowerCase().includes(search) ||
+      card.tags.some(t => t.toLowerCase().includes(search))
+    );
+  });
+  cardGridEl.innerHTML = '';
+  filtered.forEach(card => {
+    const tile = document.createElement('div');
+    tile.className = 'card-tile';
+    const title = document.createElement('h4');
+    title.textContent = card.name;
+    tile.appendChild(title);
+    const meta = document.createElement('div');
+    meta.className = 'card-meta';
+    meta.textContent = `${card.school} • ${card.type} • Cost ${card.cost.amount} ${card.cost.resource}`;
+    tile.appendChild(meta);
+    const text = document.createElement('div');
+    text.className = 'card-effects';
+    text.textContent = card.text || card.role;
+    tile.appendChild(text);
+    if (card.effects?.length) {
+      const effects = document.createElement('div');
+      effects.className = 'card-effects';
+      effects.textContent = card.effects.map(formatEffect).join(' • ');
+      tile.appendChild(effects);
+    }
+    const actions = document.createElement('div');
+    actions.className = 'card-actions';
+    const addBtn = document.createElement('button');
+    addBtn.textContent = 'Add';
+    addBtn.addEventListener('click', () => addCardToDeck(card.slug));
+    actions.appendChild(addBtn);
+    tile.appendChild(actions);
+    cardGridEl.appendChild(tile);
+  });
+  if (cardFilterSummary) {
+    cardFilterSummary.textContent = `${filtered.length} / ${cardCatalog.length} cards`;
+  }
+}
+
+function addCardToDeck(slug) {
+  const total = totalDeckCards();
+  if (total >= deckLimit) {
+    setDeckMessage(`Deck is limited to ${deckLimit} cards.`, true);
+    return;
+  }
+  deckCardCounts.set(slug, (deckCardCounts.get(slug) || 0) + 1);
+  setDeckMessage('');
+  renderDeckList();
+}
+
+function removeCardFromDeck(slug) {
+  if (!deckCardCounts.has(slug)) return;
+  const current = deckCardCounts.get(slug);
+  if (current <= 1) {
+    deckCardCounts.delete(slug);
+  } else {
+    deckCardCounts.set(slug, current - 1);
+  }
+  renderDeckList();
+}
+
+function setDeckFromSaved(deck) {
+  const entries = Array.isArray(deck.cards) ? deck.cards : [];
+  deckCardCounts = new Map(entries.map(entry => [entry.slug, entry.quantity]));
+  if (deckNameInput) deckNameInput.value = deck.name;
+  renderDeckList();
+  setDeckMessage('Loaded deck.');
+}
+
+function getFlatDeckList() {
+  const list = [];
+  deckCardCounts.forEach((qty, slug) => {
+    for (let i = 0; i < qty; i++) {
+      list.push(slug);
+    }
+  });
+  return list;
+}
+
+async function loadDecks() {
+  if (!currentPlayer) return;
+  const res = await fetch(`/decks?playerId=${currentPlayer.playerId}`);
+  if (!res.ok) {
+    throw new Error('Unable to load decks');
+  }
+  const data = await res.json();
+  savedDecks = data.decks || [];
+  deckLimit = data.maxDeckSize || deckLimit;
+  renderSavedDecks();
+  if (deckLimitEl) deckLimitEl.textContent = deckLimit;
+  if (savedDecks.length && deckCardCounts.size === 0) {
+    setDeckFromSaved(savedDecks[0]);
+  }
+  updateDeckCountDisplay();
+}
+
+async function openDeckBuilder() {
+  if (!currentPlayer) return;
+  try {
+    await fetchCardCatalog();
+    await loadDecks();
+    renderCardGrid();
+    renderDeckList();
+    if (deckNameInput && !deckNameInput.value) {
+      deckNameInput.value = `${currentPlayer.name}'s Deck`;
+    }
+    if (mainMenuDiv) mainMenuDiv.classList.add('hidden');
+    if (charSelectDiv) charSelectDiv.classList.add('hidden');
+    if (gameDiv) gameDiv.classList.add('hidden');
+    if (deckBuilderDiv) deckBuilderDiv.classList.remove('hidden');
+    setDeckMessage('Add cards to reach your target size.');
+  } catch (err) {
+    setDeckMessage(err.message || 'Unable to open deck builder', true);
+  }
+}
+
+async function saveDeck() {
+  if (!currentPlayer) return;
+  const name = (deckNameInput?.value || '').trim();
+  if (!name) {
+    setDeckMessage('Name your deck before saving.', true);
+    return;
+  }
+  if (!deckCardCounts.size) {
+    setDeckMessage('Add cards to your deck first.', true);
+    return;
+  }
+  const cards = getFlatDeckList();
+  try {
+    const result = await postJSON('/decks', { playerId: currentPlayer.playerId, name, cards });
+    if (result?.deck) {
+      const existingIndex = savedDecks.findIndex(d => d.deckId === result.deck.deckId);
+      if (existingIndex >= 0) {
+        savedDecks[existingIndex] = result.deck;
+      } else {
+        savedDecks.unshift(result.deck);
+      }
+      renderSavedDecks();
+    }
+    setDeckMessage('Deck saved.');
+  } catch (err) {
+    setDeckMessage(err.message || 'Failed to save deck', true);
+  }
 }
 
 async function loadAbilityCatalog(force = false) {
@@ -8090,8 +8385,8 @@ document.getElementById('login-btn').addEventListener('click', async () => {
     characters = data.characters;
     renderCharacters();
     authDiv.classList.add('hidden');
-    charSelectDiv.classList.remove('hidden');
     authError.classList.add('hidden');
+    showMainMenu();
   } catch (err) {
     authError.textContent = err.message;
     authError.classList.remove('hidden');
@@ -8108,13 +8403,51 @@ document.getElementById('register-btn').addEventListener('click', async () => {
     characters = data.characters;
     renderCharacters();
     authDiv.classList.add('hidden');
-    charSelectDiv.classList.remove('hidden');
     authError.classList.add('hidden');
+    showMainMenu();
   } catch (err) {
     authError.textContent = err.message;
     authError.classList.remove('hidden');
   }
 });
+
+if (menuCharactersBtn) {
+  menuCharactersBtn.addEventListener('click', () => {
+    renderCharacters();
+    showCharacterSelect();
+  });
+}
+
+if (menuDecksBtn) {
+  menuDecksBtn.addEventListener('click', () => {
+    openDeckBuilder();
+  });
+}
+
+if (menuEnterWorldBtn) {
+  menuEnterWorldBtn.addEventListener('click', () => {
+    renderCharacters();
+    showCharacterSelect();
+  });
+}
+
+if (backToMenuBtn) {
+  backToMenuBtn.addEventListener('click', () => {
+    showMainMenu();
+  });
+}
+
+if (deckCloseBtn) {
+  deckCloseBtn.addEventListener('click', () => showMainMenu());
+}
+
+if (deckSaveBtn) {
+  deckSaveBtn.addEventListener('click', () => saveDeck());
+}
+
+if (cardSearchInput) {
+  cardSearchInput.addEventListener('input', () => renderCardGrid());
+}
 
 document.getElementById('create-character').addEventListener('click', () => {
   newCharName.value = '';

--- a/ui/style.css
+++ b/ui/style.css
@@ -3608,3 +3608,276 @@ body.world-canvas-focused #world {
   flex-direction: column;
 }
 
+
+/* Deck builder + main menu */
+#main-menu {
+  min-height: 100vh;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.05), transparent 35%), #050505;
+  color: #f5f7ff;
+  padding: 2rem;
+}
+
+#main-menu:not(.hidden) {
+  display: flex;
+}
+
+.menu-card {
+  background: #0c0c0f;
+  border: 3px solid #ffffff;
+  box-shadow: 0 0 0 4px #0c0c0f, 0 0 0 7px #ffffff;
+  padding: 2rem;
+  max-width: 720px;
+  width: 100%;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.menu-card h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.4rem;
+}
+
+.menu-card p {
+  margin: 0 0 1.5rem;
+  color: #cfd4ff;
+}
+
+.ghost {
+  background: transparent;
+  color: #fff;
+  border: 2px solid #fff;
+  padding: 0.5rem 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.menu-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.menu-button {
+  background: #000;
+  color: #fff;
+  padding: 1rem;
+  border: 2px solid #fff;
+  box-shadow: inset 0 0 0 2px #0c0c0f;
+  cursor: pointer;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.menu-button:hover,
+.menu-button:focus {
+  background: #1c1c1f;
+  outline: none;
+}
+
+.deck-builder {
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #050505;
+  color: #e9ecf5;
+}
+
+.deck-builder:not(.hidden) {
+  display: flex;
+}
+
+.deck-builder-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 2px solid #fff;
+  padding-bottom: 0.75rem;
+}
+
+.deck-builder h2 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.deck-builder p {
+  margin: 0.25rem 0 0;
+  color: #b7bad4;
+}
+
+.deck-builder-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  background: #0c0c0f;
+  padding: 1rem;
+  border: 2px solid #fff;
+}
+
+.deck-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #cfd4ff;
+}
+
+.deck-field input {
+  background: #050505;
+  border: 2px solid #fff;
+  color: #fff;
+  padding: 0.5rem 0.75rem;
+  min-width: 220px;
+}
+
+.deck-count {
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+#deck-save {
+  background: #000;
+  color: #fff;
+  border: 2px solid #fff;
+  padding: 0.75rem 1.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.deck-message {
+  color: #ffb347;
+  font-weight: 700;
+}
+
+.deck-builder-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+  min-height: 420px;
+}
+
+.deck-library,
+.deck-panel {
+  background: #0c0c0f;
+  border: 2px solid #fff;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.library-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+#card-search {
+  flex: 1;
+  background: #050505;
+  color: #fff;
+  border: 2px solid #fff;
+  padding: 0.5rem 0.75rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.card-tile {
+  background: #111;
+  border: 2px solid #fff;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 160px;
+}
+
+.card-tile h4 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.card-meta {
+  font-size: 0.85rem;
+  color: #cfd4ff;
+}
+
+.card-effects {
+  font-size: 0.85rem;
+  color: #e9ecf5;
+}
+
+.card-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.card-actions button,
+.deck-entry button {
+  background: #000;
+  color: #fff;
+  border: 2px solid #fff;
+  padding: 0.35rem 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.deck-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.deck-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: #050505;
+  border: 2px solid #fff;
+}
+
+.deck-entry span {
+  font-weight: 700;
+}
+
+.saved-decks-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.saved-deck {
+  border: 2px solid #fff;
+  padding: 0.5rem 0.75rem;
+  background: #111;
+  cursor: pointer;
+}
+
+.saved-deck:hover,
+.saved-deck:focus {
+  background: #1d1d24;
+  outline: none;
+}
+
+@media (max-width: 900px) {
+  .deck-builder-layout {
+    grid-template-columns: 1fr;
+  }
+  .deck-builder-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add enum-backed card and deck schemas plus seed pipeline to load the 30-card catalog into MongoDB
- expose cards and deck CRUD endpoints and seed the catalog at server startup
- introduce a main menu and deck-building UI flow with a dark, blocky theme so players can build decks after login

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ae342f94832081535f9e56370bac)